### PR TITLE
Reduce the matching of REWRITE_HTTPS_ARGS and add query string

### DIFF
--- a/letsencrypt/client/CONFIG.py
+++ b/letsencrypt/client/CONFIG.py
@@ -56,4 +56,4 @@ CHALLENGE_PREFERENCES = ["dvsni", "recoveryToken"]
 EXCLUSIVE_CHALLENGES = [set(["dvsni", "simpleHttps"])]
 
 # Rewrite rule arguments used for redirections to https vhost
-REWRITE_HTTPS_ARGS = ["^.*$", "https://%{SERVER_NAME}%{REQUEST_URI}", "[L,R=permanent]"]
+REWRITE_HTTPS_ARGS = ["^", "https://%{SERVER_NAME}%{REQUEST_URI}", "[L,QSA,R=permanent]"]


### PR DESCRIPTION
If the backreference of the match is not used, it's enough to match '^' instead of '^.*$'. It's slightly faster.

^ -> Match, if it starts
^.*$` -> Match, if everything matches

In addition it might be useful to append the query string with the flag: QSA