### PR TITLE
Sync with acme-spec#158 (updated error codes)

### DIFF
--- a/acme/messages.py
+++ b/acme/messages.py
@@ -14,11 +14,15 @@ class Error(jose.JSONObjectWithFields, Exception):
     """
     ERROR_TYPE_NAMESPACE = 'urn:acme:error:'
     ERROR_TYPE_DESCRIPTIONS = {
-        'malformed': 'The request message was malformed',
-        'unauthorized': 'The client lacks sufficient authorization',
-        'serverInternal': 'The server experienced an internal error',
         'badCSR': 'The CSR is unacceptable (e.g., due to a short key)',
         'badNonce': 'The client sent an unacceptable anti-replay nonce',
+        'connection': 'The server could not connect to the client for DV',
+        'dnssec': 'The server could not validate a DNSSEC signed domain',
+        'malformed': 'The request message was malformed',
+        'serverInternal': 'The server experienced an internal error',
+        'tls': 'The server experienced a TLS error during DV',
+        'unauthorized': 'The client lacks sufficient authorization',
+        'unknownHost': 'The server could not resolve a domain name',
     }
 
     typ = jose.Field('type')
@@ -220,8 +224,11 @@ class ChallengeBody(ResourceBody):
     """
     __slots__ = ('chall',)
     uri = jose.Field('uri')
-    status = jose.Field('status', decoder=Status.from_json)
+    status = jose.Field('status', decoder=Status.from_json,
+                        omitempty=True, default=STATUS_PENDING)
     validated = fields.RFC3339Field('validated', omitempty=True)
+    error = jose.Field('error', decoder=Error.from_json,
+                       omitempty=True, default=None)
 
     def to_partial_json(self):
         jobj = super(ChallengeBody, self).to_partial_json()

--- a/acme/messages_test.py
+++ b/acme/messages_test.py
@@ -198,19 +198,29 @@ class ChallengeBodyTest(unittest.TestCase):
         self.chall = challenges.DNS(token='foo')
 
         from acme.messages import ChallengeBody
-        from acme.messages import STATUS_VALID
-        self.status = STATUS_VALID
+        from acme.messages import Error
+        from acme.messages import STATUS_INVALID
+        self.status = STATUS_INVALID
+        error = Error(typ='serverInternal',
+                      detail='Unable to communicate with DNS server')
         self.challb = ChallengeBody(
-            uri='http://challb', chall=self.chall, status=self.status)
+            uri='http://challb', chall=self.chall, status=self.status,
+            error=error)
 
         self.jobj_to = {
             'uri': 'http://challb',
             'status': self.status,
             'type': 'dns',
             'token': 'foo',
+            'error': error,
         }
         self.jobj_from = self.jobj_to.copy()
-        self.jobj_from['status'] = 'valid'
+        self.jobj_from['status'] = 'invalid'
+        self.jobj_from['error'] = {
+            'type': 'urn:acme:error:serverInternal',
+            'detail': 'Unable to communicate with DNS server',
+        }
+
 
     def test_to_partial_json(self):
         self.assertEqual(self.jobj_to, self.challb.to_partial_json())

--- a/letsencrypt/errors.py
+++ b/letsencrypt/errors.py
@@ -14,6 +14,24 @@ class AuthorizationError(LetsEncryptClientError):
     """Authorization error."""
 
 
+class FailedChallenges(AuthorizationError):
+    """Failed challenges error.
+
+    :ivar set failed_achalls: Failed `.AnnotatedChallenge` instances.
+
+    """
+    def __init__(self, failed_achalls):
+        assert failed_achalls
+        self.failed_achalls = failed_achalls
+        super(FailedChallenges, self).__init__()
+
+    def __str__(self):
+        return "Failed authorization procedure. {0}".format(
+            ", ".join(
+                "{0} ({1}): {2}".format(achall.domain, achall.typ, achall.error)
+                for achall in self.failed_achalls if achall.error is not None))
+
+
 class LetsEncryptContAuthError(AuthorizationError):
     """Let's Encrypt Continuity Authenticator error."""
 

--- a/letsencrypt/tests/errors_test.py
+++ b/letsencrypt/tests/errors_test.py
@@ -1,0 +1,26 @@
+"""Tests for letsencrypt.errors."""
+import unittest
+
+from acme import messages
+
+from letsencrypt import achallenges
+from letsencrypt.tests import acme_util
+
+
+class FaiiledChallengesTest(unittest.TestCase):
+    """Tests for letsencrypt.errors.FailedChallenges."""
+
+    def setUp(self):
+        from letsencrypt.errors import FailedChallenges
+        self.error = FailedChallenges(set([achallenges.DNS(
+            domain="example.com", challb=messages.ChallengeBody(
+                chall=acme_util.DNS, uri=None,
+                error=messages.Error(typ="tls", detail="detail")))]))
+
+    def test_str(self):
+        self.assertTrue(str(self.error).startswith(
+            "Failed authorization procedure. example.com (dns): tls"))
+
+
+if __name__ == "__main__":
+    unittest.main()  # pragma: no cover


### PR DESCRIPTION
Gives more helpful debug traceback in case of failed authorization (tested against demo server):
```
letsencrypt.errors.FailedChallenges: Failed authorization procedure. letsencrypt.org (dvsni): unauthorized :: The client lacks sufficient authorization :: Correct zName not found for DVSNI challe
ng
```

Related:
- acme-spec: https://github.com/letsencrypt/acme-spec/pull/158
- boulder: https://github.com/letsencrypt/boulder/pull/369

cc: @bradmw