### PR TITLE
Add SSLLab URLs at the end of installation

### DIFF
--- a/letsencrypt/display/ops.py
+++ b/letsencrypt/display/ops.py
@@ -205,11 +205,12 @@ def success_installation(domains):
 
     """
     util(interfaces.IDisplay).notification(
-        "Congratulations! You have successfully enabled {0}! You should test your configuration:{1}"
-        "{2}".format(
+        "Congratulations! You have successfully enabled {0}!{1}{1}"
+        "You should test your configuration at:{1}{2}".format(
             _gen_https_names(domains),
             os.linesep,
             os.linesep.join(_gen_ssl_lab_urls(domains))),
+        height=(10 + len(domains)),
         pause=False)
 
 
@@ -219,7 +220,7 @@ def _gen_ssl_lab_urls(domains):
     :param list domains: Each domain is a 'str'
 
     """
-    return ["https://www.ssllabs.com/ssltest/analyze.html?d=%s", dom for dom in domains]
+    return ["https://www.ssllabs.com/ssltest/analyze.html?d=%s" % dom for dom in domains]
 
 
 def _gen_https_names(domains):

--- a/letsencrypt/display/ops.py
+++ b/letsencrypt/display/ops.py
@@ -205,8 +205,21 @@ def success_installation(domains):
 
     """
     util(interfaces.IDisplay).notification(
-        "Congratulations! You have successfully enabled "
-        "%s!" % _gen_https_names(domains), pause=False)
+        "Congratulations! You have successfully enabled {0}! You should test your configuration:{1}"
+        "{2}".format(
+            _gen_https_names(domains),
+            os.linesep,
+            os.linesep.join(_gen_ssl_lab_urls(domains))),
+        pause=False)
+
+
+def _gen_ssl_lab_urls(domains):
+    """Returns a list of urls.
+    
+    :param list domains: Each domain is a 'str'
+
+    """
+    return ["https://www.ssllabs.com/ssltest/analyze.html?d=%s", dom for dom in domains]
 
 
 def _gen_https_names(domains):

--- a/letsencrypt/display/ops.py
+++ b/letsencrypt/display/ops.py
@@ -216,7 +216,7 @@ def success_installation(domains):
 
 def _gen_ssl_lab_urls(domains):
     """Returns a list of urls.
-    
+
     :param list domains: Each domain is a 'str'
 
     """

--- a/letsencrypt/tests/display/ops_test.py
+++ b/letsencrypt/tests/display/ops_test.py
@@ -195,9 +195,6 @@ class GenSSLLabURLs(unittest.TestCase):
     def test_zero(self):
         self.assertEqual(self._call([]), [])
 
-    def test_one(self):
-        self.assertTrue("eff.org" in self._call(["eff.org"])[0])
-
     def test_two(self):
         urls = self._call(["eff.org", "umich.edu"])
         self.assertTrue("eff.org" in urls[0])
@@ -328,7 +325,7 @@ class SuccessInstallationTest(unittest.TestCase):
         names = ["example.com", "abc.com"]
 
         self._call(names)
-
+        
         self.assertEqual(mock_util().notification.call_count, 1)
         arg = mock_util().notification.call_args_list[0][0][0]
 

--- a/letsencrypt/tests/display/ops_test.py
+++ b/letsencrypt/tests/display/ops_test.py
@@ -182,6 +182,27 @@ class ChooseAccountTest(unittest.TestCase):
         self.assertTrue(self._call([self.acc1, self.acc2]) is None)
 
 
+class GenSSLLabURLs(unittest.TestCase):
+    """Loose test of _gen_ssl_lab_urls. URL can change easily in the future"""
+    def setUp(self):
+        zope.component.provideUtility(display_util.FileDisplay(sys.stdout))
+
+    @classmethod
+    def _call(cls, domains):
+        from letsencrypt.display.ops import _gen_ssl_lab_urls
+        return _gen_ssl_lab_urls(domains)
+
+    def test_zero(self):
+        self.assertEqual(self._call([]), [])
+
+    def test_one(self):
+        self.assertTrue("eff.org" in self._call(["eff.org"])[0])
+
+    def test_two(self):
+        urls = self._call(["eff.org", "umich.edu"])
+        self.assertTrue("eff.org" in urls[0])
+        self.assertTrue("umich.edu" in urls[1])
+
 class GenHttpsNamesTest(unittest.TestCase):
     """Test _gen_https_names."""
     def setUp(self):

--- a/letsencrypt/tests/display/ops_test.py
+++ b/letsencrypt/tests/display/ops_test.py
@@ -183,7 +183,7 @@ class ChooseAccountTest(unittest.TestCase):
 
 
 class GenSSLLabURLs(unittest.TestCase):
-    """Loose test of _gen_ssl_lab_urls. URL can change easily in the future"""
+    """Loose test of _gen_ssl_lab_urls. URL can change easily in the future."""
     def setUp(self):
         zope.component.provideUtility(display_util.FileDisplay(sys.stdout))
 
@@ -325,7 +325,7 @@ class SuccessInstallationTest(unittest.TestCase):
         names = ["example.com", "abc.com"]
 
         self._call(names)
-        
+
         self.assertEqual(mock_util().notification.call_count, 1)
         arg = mock_util().notification.call_args_list[0][0][0]
 


### PR DESCRIPTION
We would like to integrate ssllabs testing after deployment of the certificate.  After discussing this with @ivanr we have decided to simply add a link at the end of installation in preparation for launch, which this PR addresses. 

We can fully integrate with the API's once the core foundation is solid.