### PR TITLE
Renewer integration tests, quickfixes

### DIFF
--- a/letsencrypt/renewer.py
+++ b/letsencrypt/renewer.py
@@ -12,6 +12,7 @@ import os
 import sys
 
 import configobj
+import zope.component
 
 from letsencrypt import configuration
 from letsencrypt import cli
@@ -20,6 +21,7 @@ from letsencrypt import crypto_util
 from letsencrypt import notify
 from letsencrypt import storage
 
+from letsencrypt.display import util as display_util
 from letsencrypt.plugins import disco as plugins_disco
 
 
@@ -64,6 +66,7 @@ def renew(cert, old_version):
     # XXX: this loses type data (for example, the fact that key_size
     #      was an int, not a str)
     config.rsa_key_size = int(config.rsa_key_size)
+    config.dvsni_port = int(config.dvsni_port)
     try:
         authenticator = plugins[renewalparams["authenticator"]]
     except KeyError:
@@ -119,6 +122,8 @@ def main(config=None, args=sys.argv[1:]):
     #       invocations if /etc/letsencrypt/renewal.conf defaults have
     #       turned it off. (The boolean parameter should probably be
     #       called renewer_enabled.)
+
+    zope.component.provideUtility(display_util.FileDisplay(sys.stdout))
 
     cli_config = configuration.RenewerConfiguration(
         _create_parser().parse_args(args))

--- a/letsencrypt/renewer.py
+++ b/letsencrypt/renewer.py
@@ -140,6 +140,8 @@ def main(config=None, args=sys.argv[1:]):
         rc_config = configobj.ConfigObj(cli_config.renewer_config_file)
         rc_config.merge(configobj.ConfigObj(
             os.path.join(cli_config.renewal_configs_dir, i)))
+        # TODO: this is a dirty hack!
+        rc_config.filename = os.path.join(cli_config.renewal_configs_dir, i)
         try:
             # TODO: Before trying to initialize the RenewableCert object,
             #       we could check here whether the combination of the config

--- a/letsencrypt/tests/renewer_test.py
+++ b/letsencrypt/tests/renewer_test.py
@@ -574,6 +574,7 @@ class RenewableCertTests(unittest.TestCase):
         self.test_rc.configfile["renewalparams"]["rsa_key_size"] = "2048"
         self.test_rc.configfile["renewalparams"]["server"] = "acme.example.com"
         self.test_rc.configfile["renewalparams"]["authenticator"] = "fake"
+        self.test_rc.configfile["renewalparams"]["dvsni_port"] = "4430"
         mock_auth = mock.MagicMock()
         mock_pd.PluginsRegistry.find_all.return_value = {"apache": mock_auth}
         # Fails because "fake" != "apache"

--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -5,14 +5,14 @@
 
 root="$(mktemp -d)"
 echo "\nRoot integration tests directory: $root"
+store_flags="--config-dir $root/conf --work-dir $root/work"
 
 # first three flags required, rest is handy defaults
 letsencrypt \
   --server http://localhost:4000/acme/new-reg \
   --no-verify-ssl \
   --dvsni-port 5001 \
-  --config-dir "$root/conf" \
-  --work-dir "$root/work" \
+  $store_flags \
   --text \
   --agree-eula \
   --email "" \
@@ -20,3 +20,18 @@ letsencrypt \
   --authenticator standalone \
   -vvvvvvv \
   auth
+
+# the following assumes that Boulder issues certificates for less than
+# 10 years, otherwise renewal will not take place
+cat <<EOF > "$root/conf/renewer.conf"
+renew_before_expiry = 10 years
+deploy_before_expiry = 10 years
+EOF
+letsencrypt-renewer $store_flags
+dir="$root/conf/archive/le.wtf"
+for x in cert chain fullchain privkey;
+do
+    latest="$(ls -1t $dir/ | grep -e "^${x}" | head -n1)"
+    live="$(readlink -f "$root/conf/live/le.wtf/${x}.pem")"
+    #[ "${dir}/${latest}" = "$live" ]  # renewer fails this test
+done


### PR DESCRIPTION
Fixes `IOError: [Errno 2] No such file or directory: '/tmp/le/config/archive/renewer/privkey2.pem'`

With this patch I was able to successfully renew my certificates, @schoen! :)

Unfortunately, renewer didn't update `live` directory symlinks... :(