### PR TITLE
Try to renew certs before trying to deploy them

### DIFF
--- a/letsencrypt/renewer.py
+++ b/letsencrypt/renewer.py
@@ -166,11 +166,6 @@ def main(config=None, args=sys.argv[1:]):
             # user about the existence of an invalid or corrupt renewal
             # config rather than simply ignoring it.
             continue
-        if cert.should_autodeploy():
-            cert.update_all_links_to(cert.latest_common_version())
-            # TODO: restart web server (invoke IInstaller.restart() method)
-            notify.notify("Autodeployed a cert!!!", "root", "It worked!")
-            # TODO: explain what happened
         if cert.should_autorenew():
             # Note: not cert.current_version() because the basis for
             # the renewal is the latest version, even if it hasn't been
@@ -178,4 +173,9 @@ def main(config=None, args=sys.argv[1:]):
             old_version = cert.latest_common_version()
             renew(cert, old_version)
             notify.notify("Autorenewed a cert!!!", "root", "It worked!")
+            # TODO: explain what happened
+        if cert.should_autodeploy():
+            cert.update_all_links_to(cert.latest_common_version())
+            # TODO: restart web server (invoke IInstaller.restart() method)
+            notify.notify("Autodeployed a cert!!!", "root", "It worked!")
             # TODO: explain what happened

--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -43,5 +43,5 @@ for x in cert chain fullchain privkey;
 do
     latest="$(ls -1t $dir/ | grep -e "^${x}" | head -n1)"
     live="$(readlink -f "$root/conf/live/le.wtf/${x}.pem")"
-    #[ "${dir}/${latest}" = "$live" ]  # renewer fails this test
+    [ "${dir}/${latest}" = "$live" ]
 done


### PR DESCRIPTION
This is a simple change in the order of operations in the renewer to address a possibly counterintuitive behavior that @kuba observed that also made it harder to do renewer integration testing.

Before, the renewer would try to deploy a lineage update (if it was time to do so and there was a pending update to be deployed), then try to renew that lineage (if it was time to do so). One thing this meant was that normally both operations wouldn't occur with respect to a single lineage in a single renewer run.

Now, it tries to renew and then tries to deploy, so both operations can occur in a single run if it's close enough in time to the cert's expiry (although if I recall the implementation properly, "close enough" is counted differently for deployment and renewal -- it's relative to the expiry of the newest existing cert for deployment, and relative to the expiry of the currently-deployed cert for renewal).

I thought that there was an important reason for the old order, but have been unable to remember why it would be beneficial. My intuition is that it had something to do with #423, but I can't convince myself of why. Hopefully this change doesn't somehow reintroduce #423.

Cc @jdkasten.