### PR TITLE
Fix broken cli test when Apache is installed

### DIFF
--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -4,6 +4,7 @@ import unittest
 
 import mock
 
+from letsencrypt import errors
 
 class CLITest(unittest.TestCase):
     """Tests for different commands."""
@@ -41,7 +42,11 @@ class CLITest(unittest.TestCase):
         for args in itertools.chain(
                 *(itertools.combinations(flags, r)
                   for r in xrange(len(flags)))):
-            self._call(['plugins',] + list(args))
+            try:
+                self._call(['plugins',] + list(args))
+            except errors.ConfiguratorError as err:
+                if "--prepare" not in args:
+                    raise err
 
 
 if __name__ == '__main__':

--- a/letsencrypt_apache/configurator.py
+++ b/letsencrypt_apache/configurator.py
@@ -133,6 +133,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
 
     def prepare(self):
         """Prepare the authenticator/installer."""
+        self.config_test()
         self.parser = parser.ApacheParser(
             self.aug, self.conf('server-root'), self.mod_ssl_conf)
         # Check for errors in parsing files with Augeas
@@ -925,7 +926,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
             stdout, stderr = proc.communicate()
         except (OSError, ValueError):
             logging.fatal("Unable to run /usr/sbin/apache2ctl configtest")
-            sys.exit(1)
+            raise errors.ConfiguratorError("Unable to run apache2ctl")
 
         if proc.returncode != 0:
             # Enter recovery routine...
@@ -1059,7 +1060,7 @@ def enable_mod(mod_name, apache_init_script, apache_enmod):
         apache_restart(apache_init_script)
     except (OSError, subprocess.CalledProcessError):
         logging.exception("Error enabling mod_%s", mod_name)
-        sys.exit(1)
+        raise errors.ConfiguratorError("Unable to initiate a2enmod")
 
 
 def mod_loaded(module, apache_ctl):
@@ -1125,8 +1126,9 @@ def apache_restart(apache_init_script):
 
     except (OSError, ValueError):
         logging.fatal(
-            "Apache Restart Failed - Please Check the Configuration")
-        sys.exit(1)
+            "Unable to initiate process to restart Apache")
+        raise errors.ConfiguratorError(
+            "Unable to initiate process to restart Apache")
 
     return True
 


### PR DESCRIPTION
Minimum changes to resolve broken cli test when --prepare is called.  The prepare function by definition is supposed to throw errors when problems occur.  I believe the cli plugin test function should catch these specific errors and allow the test to continue.