### PR TITLE
Cleanup manual

### DIFF
--- a/docs/api/plugins/manual.rst
+++ b/docs/api/plugins/manual.rst
@@ -3,3 +3,9 @@
 
 .. automodule:: letsencrypt.plugins.manual
    :members:
+
+:mod:`letsencrypt.plugins.manual.authenticator`
+-----------------------------------------------
+
+.. automodule:: letsencrypt.plugins.manual.authenticator
+   :members:

--- a/letsencrypt/plugins/manual/__init__.py
+++ b/letsencrypt/plugins/manual/__init__.py
@@ -1,1 +1,1 @@
-"""Let's Encrypt client.plugins.manual"""
+"""Let's Encrypt Manual Authenticator plugin."""

--- a/letsencrypt/plugins/manual/__init__.py
+++ b/letsencrypt/plugins/manual/__init__.py
@@ -1,0 +1,1 @@
+"""Let's Encrypt client.plugins.manual"""

--- a/letsencrypt/plugins/manual/authenticator.py
+++ b/letsencrypt/plugins/manual/authenticator.py
@@ -79,7 +79,7 @@ s.serve_forever()" """
         return """\
 This plugin requires user's manual intervention in setting up a HTTP
 server for solving SimpleHTTP challenges and thus does not need to be
-run as a privilidged process. Alternatively, the manual authenticator
+run as a privileged process. Alternatively, the manual authenticator
 shows instructions on how to use Python's built-in HTTP server and the
 openssl binary for temporary key/certificate generation, if HTTPS is
 needed.""".replace("\n", " ")

--- a/letsencrypt/plugins/manual/authenticator.py
+++ b/letsencrypt/plugins/manual/authenticator.py
@@ -79,9 +79,10 @@ s.serve_forever()" """
         return """\
 This plugin requires user's manual intervention in setting up a HTTP
 server for solving SimpleHTTP challenges and thus does not need to be
-run as a privilidged process. Alternatively shows instructions on how
-to use Python's built-in HTTP server and, in case of HTTPS, openssl
-binary for temporary key/certificate generation.""".replace("\n", " ")
+run as a privilidged process. Alternatively, the manual authenticator
+shows instructions on how to use Python's built-in HTTP server and the
+openssl binary for temporary key/certificate generation, if HTTPS is
+needed.""".replace("\n", " ")
 
     def get_chall_pref(self, domain):
         # pylint: disable=missing-docstring,no-self-use,unused-argument

--- a/letsencrypt/plugins/manual/authenticator.py
+++ b/letsencrypt/plugins/manual/authenticator.py
@@ -81,7 +81,7 @@ This plugin requires user's manual intervention in setting up a HTTP
 server for solving SimpleHTTP challenges and thus does not need to be
 run as a privilidged process. Alternatively shows instructions on how
 to use Python's built-in HTTP server and, in case of HTTPS, openssl
-binary for temporary key/certificate generation.""".replace("\n", "")
+binary for temporary key/certificate generation.""".replace("\n", " ")
 
     def get_chall_pref(self, domain):
         # pylint: disable=missing-docstring,no-self-use,unused-argument

--- a/letsencrypt/plugins/manual/tests/__init__.py
+++ b/letsencrypt/plugins/manual/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Let's Encrypt Manual Tests"""

--- a/letsencrypt/plugins/manual/tests/authenticator_test.py
+++ b/letsencrypt/plugins/manual/tests/authenticator_test.py
@@ -1,4 +1,4 @@
-"""Tests for letsencrypt.plugins.manual."""
+"""Tests for letsencrypt.plugins.manual.authenticator."""
 import unittest
 
 import mock
@@ -11,10 +11,10 @@ from letsencrypt.tests import acme_util
 
 
 class ManualAuthenticatorTest(unittest.TestCase):
-    """Tests for letsencrypt.plugins.manual.ManualAuthenticator."""
+    """Tests for letsencrypt.plugins.manual.authenticator.ManualAuthenticator."""
 
     def setUp(self):
-        from letsencrypt.plugins.manual import ManualAuthenticator
+        from letsencrypt.plugins.manual.authenticator import ManualAuthenticator
         self.config = mock.MagicMock(no_simple_http_tls=True)
         self.auth = ManualAuthenticator(config=self.config, name="manual")
         self.achalls = [achallenges.SimpleHTTP(
@@ -30,9 +30,9 @@ class ManualAuthenticatorTest(unittest.TestCase):
     def test_perform_empty(self):
         self.assertEqual([], self.auth.perform([]))
 
-    @mock.patch("letsencrypt.plugins.manual.sys.stdout")
-    @mock.patch("letsencrypt.plugins.manual.os.urandom")
-    @mock.patch("letsencrypt.plugins.manual.requests.get")
+    @mock.patch("letsencrypt.plugins.manual.authenticator.sys.stdout")
+    @mock.patch("letsencrypt.plugins.manual.authenticator.os.urandom")
+    @mock.patch("letsencrypt.plugins.manual.authenticator.requests.get")
     @mock.patch("__builtin__.raw_input")
     def test_perform(self, mock_raw_input, mock_get, mock_urandom, mock_stdout):
         mock_urandom.return_value = "foo"
@@ -54,6 +54,7 @@ class ManualAuthenticatorTest(unittest.TestCase):
 
         mock_get.side_effect = requests.exceptions.ConnectionError
         self.assertEqual([None], self.auth.perform(self.achalls))
+
 
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -180,7 +180,8 @@ setup(
             'jws = letsencrypt.acme.jose.jws:CLI.run',
         ],
         'letsencrypt.plugins': [
-            'manual = letsencrypt.plugins.manual:ManualAuthenticator',
+            'manual = letsencrypt.plugins.manual.authenticator'
+            ':ManualAuthenticator',
             'standalone = letsencrypt.plugins.standalone.authenticator'
             ':StandaloneAuthenticator',
 


### PR DESCRIPTION
While investigating the plugin prepare functionality. I noticed that the string formatting for more_info was missing spaces between words.  I then thought it best to move the manual authenticator into its own plugins directory.  I thought this would reduce confusion, add another easily found plugin example, and would allow it to be easily extended in the future.

I might imagine a manual installer implementation that allows you to choose your installation and gives steps on how to install the certificate into it manually.