### PR TITLE
Log and hide tracebacks by default

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -682,7 +682,7 @@ def main(cli_args=sys.argv[1:]):
         return ""
     except: # pylint: disable=bare-except
         handle_exception_common()
-        return ("\nAn unexpected error occured. Please see the logfiles in {0} "
+        return ("An unexpected error occured. Please see the logfiles in {0} "
                 "for more details.".format(args.logs_dir))
 
 

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -676,10 +676,14 @@ def main(cli_args=sys.argv[1:]):
     except errors.Error as error:
         handle_exception_common()
         return error
-    except: # pylint: disable=bare-except
+    except KeyboardInterrupt:
         handle_exception_common()
         # Ensures a new line is printed
         return ""
+    except: # pylint: disable=bare-except
+        handle_exception_common()
+        return ("\nAn unexpected error occured. Please see the logfiles in {0} "
+                "for more details.".format(args.logs_dir))
 
 
 if __name__ == "__main__":

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -72,6 +72,10 @@ class CLITest(unittest.TestCase):
             self._call(['--debug'] + cmd_arg, attrs)
         self._call(cmd_arg, attrs)
 
+        attrs['view_config_changes.side_effect'] = [ValueError]
+        with self.assertRaises(ValueError):
+            self._call(['--debug'] + cmd_arg, attrs)
+        self._call(cmd_arg, attrs)
 
 if __name__ == '__main__':
     unittest.main()  # pragma: no cover

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -63,18 +63,18 @@ class CLITest(unittest.TestCase):
         cmd_arg = ['config_changes']
         error = [errors.Error('problem')]
         attrs = {'view_config_changes.side_effect' : error}
-        with self.assertRaises(errors.Error):
-            self._call(['--debug'] + cmd_arg, attrs)
+        self.assertRaises(
+            errors.Error, self._call, ['--debug'] + cmd_arg, attrs)
         self._call(cmd_arg, attrs)
 
         attrs['view_config_changes.side_effect'] = [KeyboardInterrupt]
-        with self.assertRaises(KeyboardInterrupt):
-            self._call(['--debug'] + cmd_arg, attrs)
+        self.assertRaises(
+            KeyboardInterrupt, self._call, ['--debug'] + cmd_arg, attrs)
         self._call(cmd_arg, attrs)
 
         attrs['view_config_changes.side_effect'] = [ValueError]
-        with self.assertRaises(ValueError):
-            self._call(['--debug'] + cmd_arg, attrs)
+        self.assertRaises(
+            ValueError, self._call, ['--debug'] + cmd_arg, attrs)
         self._call(cmd_arg, attrs)
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR implements #544. The new behavior is that all tracebacks are written to a logfile. In addition, they are not printed to the user by default. To have tracebacks be shown to the user, `--debug` can be specified on the command line.

If `--debug` is not included on the command line and the error is one of the client exception types, the contents of the error message is printed to the user. Otherwise, the error is suppressed, instructing the user to view the logfile if they want more information.