### PR TITLE
Tracebacks and Forks

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -676,11 +676,7 @@ def main(cli_args=sys.argv[1:]):
     except errors.Error as error:
         handle_exception_common()
         return error
-    except KeyboardInterrupt:
-        handle_exception_common()
-        # Ensures a new line is printed
-        return ""
-    except: # pylint: disable=bare-except
+    except Exception: # pylint: disable=broad-except
         handle_exception_common()
         return ("An unexpected error occured. Please see the logfiles in {0} "
                 "for more details.".format(args.logs_dir))

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -67,11 +67,6 @@ class CLITest(unittest.TestCase):
             errors.Error, self._call, ['--debug'] + cmd_arg, attrs)
         self._call(cmd_arg, attrs)
 
-        attrs['view_config_changes.side_effect'] = [KeyboardInterrupt]
-        self.assertRaises(
-            KeyboardInterrupt, self._call, ['--debug'] + cmd_arg, attrs)
-        self._call(cmd_arg, attrs)
-
         attrs['view_config_changes.side_effect'] = [ValueError]
         self.assertRaises(
             ValueError, self._call, ['--debug'] + cmd_arg, attrs)


### PR DESCRIPTION
This fixes the issue of catching things like the call to sys.exit from the Standalone Authenticator fork which was causing strange output.