### PR TITLE
Include ssl-cert in the debian bootstrap

### DIFF
--- a/bootstrap/_deb_common.sh
+++ b/bootstrap/_deb_common.sh
@@ -61,3 +61,4 @@ apt-get install -y --no-install-recommends \
   libffi-dev \
   ca-certificates \
   dpkg-dev \
+  ssl-cert \


### PR DESCRIPTION
Discovered this while testing out letsencrypt on a raspbian install
(debian for the raspberry pi). Everything worked but the nginx
configurator requires the default snakeoil certs[0]. These are generated
in the postinst script of the ssl-cert package, added here to the
bootstrap script.

[0] - https://github.com/letsencrypt/letsencrypt/blob/7665e8c8c16b9f4ce46c55c0b72b04b6c34a569f/letsencrypt_nginx/configurator.py#L279