### PR TITLE
Fixed traceback when not run as root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 dist/
 /venv/
 /.tox/
+letsencrypt.log
 
 # coverage
 .coverage

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -661,10 +661,11 @@ def _handle_exception(exc_type, exc_value, trace, args):
 
     if issubclass(exc_type, Exception) and (args is None or not args.debug):
         if args is None:
+            logfile = "letsencrypt.log"
             try:
-                with open("letsencrypt.log", "w") as logfile:
+                with open(logfile, "w") as logfd:
                     traceback.print_exception(
-                        exc_type, exc_value, trace, file=logfile)
+                        exc_type, exc_value, trace, file=logfd)
             except: # pylint: disable=bare-except
                 sys.exit("".join(
                     traceback.format_exception(exc_type, exc_value, trace)))
@@ -674,7 +675,7 @@ def _handle_exception(exc_type, exc_value, trace, args):
         elif args is None:
             sys.exit(
                 "An unexpected error occurred. Please see the logfile '{0}' "
-                "for more details.".format(os.path.abspath("letsencrypt.log")))
+                "for more details.".format(logfile))
         else:
             sys.exit(
                 "An unexpected error occurred. Please see the logfiles in {0} "


### PR DESCRIPTION
Looks like the way cli.py was automerged in #558 caused a traceback to be shown when Let's Encrypt is not run as root and the default configuration directories are used. This PR fixes that.