### PR TITLE
Do not include /etc/nginx/mime.types in nginx integration testing.

### DIFF
--- a/tests/integration/nginx.conf.sh
+++ b/tests/integration/nginx.conf.sh
@@ -37,7 +37,7 @@ http {
   keepalive_timeout 65;
   types_hash_max_size 2048;
 
-  include /etc/nginx/mime.types;
+  #include /etc/nginx/mime.types;
   index index.html index.htm index.php;
 
   log_format   main '\$remote_addr - \$remote_user [\$time_local] \$status '


### PR DESCRIPTION
This file (or /etc/nginx in whole) might not exist on the target system.