### PR TITLE
RTFD: install subpkgs.

### DIFF
--- a/readthedocs.org.requirements.txt
+++ b/readthedocs.org.requirements.txt
@@ -7,4 +7,7 @@
 # in --editable mode (-e), just "pip install .[docs]" does not work as
 # expected and "pip install -e .[docs]" must be used instead
 
+-e acme
 -e .[docs]
+-e letsencrypt-apache
+-e letsencrypt-nginx


### PR DESCRIPTION
This fixes current ReadTheDocs build errors. You can view this branch built at http://letsencryptkuba.readthedocs.org/en/rtfd/