### PR TITLE
Consume longest possible match

### DIFF
--- a/letsencrypt-nginx/letsencrypt_nginx/nginxparser.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/nginxparser.py
@@ -37,7 +37,7 @@ class RawNginxParser(object):
         + Group(ZeroOrMore(Group(comment | assignment) | block))
         + right_bracket)
 
-    script = OneOrMore(Group(comment | assignment) | block) + stringEnd
+    script = OneOrMore(Group(comment | assignment) ^ block) + stringEnd
 
     def __init__(self, source):
         self.source = source

--- a/letsencrypt-nginx/letsencrypt_nginx/tests/nginxparser_test.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/tests/nginxparser_test.py
@@ -5,7 +5,7 @@ import unittest
 from pyparsing import ParseException
 
 from letsencrypt_nginx.nginxparser import (
-    RawNginxParser, load, dumps, dump)
+    RawNginxParser, loads, load, dumps, dump)
 from letsencrypt_nginx.tests import util
 
 
@@ -160,6 +160,13 @@ class TestRawNginxParser(unittest.TestCase):
               ['#', ' listen 80;']]],
         ])
 
+    def test_issue_518(self):
+        parsed = loads('if ($http_accept ~* "webp") { set $webp "true"; }')
+
+        self.assertEqual(parsed, [
+            [['if', '($http_accept ~* "webp")'],
+             [['set', '$webp "true"']]]
+        ])
 
 if __name__ == '__main__':
     unittest.main()  # pragma: no cover


### PR DESCRIPTION
Fixes #518, and according to `tox` doesn't break anything on py27.