### PR TITLE
Require argparse only in Python 2.6.

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -1,3 +1,5 @@
+import sys
+
 from setuptools import setup
 from setuptools import find_packages
 
@@ -17,6 +19,11 @@ install_requires = [
     'six',
     'werkzeug',
 ]
+
+# env markers in extras_require cause problems with older pip: #517
+if sys.version_info < (2, 7):
+    # only some distros recognize stdlib argparse as already satisfying
+    install_requires.append('argparse')
 
 testing_extras = [
     'nose',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import codecs
 import os
 import re
+import sys
 
 from setuptools import setup
 from setuptools import find_packages
@@ -30,7 +31,6 @@ changes = read_file(os.path.join(here, 'CHANGES.rst'))
 
 install_requires = [
     'acme',
-    'argparse',
     'ConfigArgParse',
     'configobj',
     'cryptography>=0.7',  # load_pem_x509_certificate
@@ -45,6 +45,11 @@ install_requires = [
     'zope.component',
     'zope.interface',
 ]
+
+# env markers in extras_require cause problems with older pip: #517
+if sys.version_info < (2, 7):
+    # only some distros recognize stdlib argparse as already satisfying
+    install_requires.append('argparse')
 
 dev_extras = [
     # Pin astroid==1.3.5, pylint==1.4.2 as a workaround for #289


### PR DESCRIPTION
Fixes packaging issues.