### PR TITLE
revert the nginx port change

### DIFF
--- a/letsencrypt-nginx/tests/boulder-integration.conf.sh
+++ b/letsencrypt-nginx/tests/boulder-integration.conf.sh
@@ -48,9 +48,9 @@ http {
 
   server {
     # IPv4.
-    listen 8081;
+    listen 8080;
     # IPv6.
-    listen [::]:8081 default ipv6only=on;
+    listen [::]:8080 default ipv6only=on;
 
     root $root/webroot;
 


### PR DESCRIPTION
This was fixed in the boulder codebase with letsencrypt/boulder#482.

This is a partial reversion of #618.