### PR TITLE
Add development Dockerfile and instructions

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,0 +1,65 @@
+# This Dockerfile builds an image for development.
+FROM ubuntu:trusty
+MAINTAINER Jakub Warmuz <jakub@warmuz.org>
+MAINTAINER William Budington <bill@eff.org>
+MAINTAINER Yan <yan@eff.org>
+
+# Note: this only exposes the port to other docker containers. You
+# still have to bind to 443@host at runtime, as per the ACME spec.
+EXPOSE 443
+
+# TODO: make sure --config-dir and --work-dir cannot be changed
+# through the CLI (letsencrypt-docker wrapper that uses standalone
+# authenticator and text mode only?)
+VOLUME /etc/letsencrypt /var/lib/letsencrypt
+
+WORKDIR /opt/letsencrypt
+
+# no need to mkdir anything:
+# https://docs.docker.com/reference/builder/#copy
+# If <dest> doesn't exist, it is created along with all missing
+# directories in its path.
+
+# TODO: Install non-default Python versions for tox.
+# TODO: Install Apache/Nginx for plugin development.
+COPY bootstrap/ubuntu.sh /opt/letsencrypt/src/
+RUN /opt/letsencrypt/src/ubuntu.sh && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* \
+           /tmp/* \
+           /var/tmp/*
+
+# the above is not likely to change, so by putting it further up the
+# Dockerfile we make sure we cache as much as possible
+
+COPY setup.py README.rst CHANGES.rst MANIFEST.in requirements.txt EULA linter_plugin.py tox.cover.sh tox.ini /opt/letsencrypt/src/
+
+# all above files are necessary for setup.py, however, package source
+# code directory has to be copied separately to a subdirectory...
+# https://docs.docker.com/reference/builder/#copy: "If <src> is a
+# directory, the entire contents of the directory are copied,
+# including filesystem metadata. Note: The directory itself is not
+# copied, just its contents." Order again matters, three files are far
+# more likely to be cached than the whole project directory
+
+COPY letsencrypt /opt/letsencrypt/src/letsencrypt/
+COPY acme /opt/letsencrypt/src/acme/
+COPY letsencrypt-apache /opt/letsencrypt/src/letsencrypt-apache/
+COPY letsencrypt-nginx /opt/letsencrypt/src/letsencrypt-nginx/
+COPY tests /opt/letsencrypt/src/tests/
+
+RUN virtualenv --no-site-packages -p python2 /opt/letsencrypt/venv && \
+    /opt/letsencrypt/venv/bin/pip install \
+    -r /opt/letsencrypt/src/requirements.txt \
+    -e /opt/letsencrypt/src/acme \
+    -e /opt/letsencrypt/src \
+    -e /opt/letsencrypt/src/letsencrypt-apache \
+    -e /opt/letsencrypt/src/letsencrypt-nginx \
+    -e /opt/letsencrypt/src[dev,docs,testing]
+
+# install in editable mode (-e) to save space: it's not possible to
+# "rm -rf /opt/letsencrypt/src" (it's stays in the underlaying image);
+# this might also help in debugging: you can "docker run --entrypoint
+# bash" and investigate, apply patches, etc.
+
+ENV PATH /opt/letsencrypt/venv/bin:$PATH

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -121,6 +121,28 @@ Support for other Linux distributions coming soon.
 .. _related issue: https://github.com/ClusterHQ/flocker/issues/516
 
 
+Docker
+------
+
+OSX users will probably find it easiest to set up a Docker container for
+development. Let's Encrypt comes with a Dockerfile (``Dockerfile-dev``)
+for doing so. To use Docker on OSX, install boot2docker using the
+instructions at https://docs.docker.com/installation/mac/ and start it
+from the command line (``boot2docker init``).
+
+To build the development Docker image::
+
+  docker build -t letsencrypt -f Dockerfile-dev .
+
+Now run tests inside the Docker image:
+
+.. code-block:: shell
+
+  docker run -it letsencrypt bash
+  cd src
+  tox -e py27
+
+
 Code components and layout
 ==========================
 


### PR DESCRIPTION
Since Vagrant is so slow and some of the pip dependencies don't work on OSX for me, the only sane dev environment on OSX seems to be Docker.

`Dockerfile-dev` has only a few minor changes from `Dockerfile` right now. To avoid having to re-run Docker every time code changes, we should probably just mount the letsencrypt directory in the Docker container (`docker run -v /path/to/letsencrypt:/opt/letsencrypt`). 