### PR TITLE
Update README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Browser-trusted certificates will be available in the coming months.
 
 For more information regarding the status of the project, please see
 https://letsencrypt.org. Be sure to checkout the
-`Frequently Asked Questions (FAQ)<https://letsencrypt.org/faq/>`_.
+`Frequently Asked Questions (FAQ) <https://letsencrypt.org/faq/>`_.
 
 About the Let's Encrypt Client
 ==============================

--- a/README.rst
+++ b/README.rst
@@ -1,14 +1,15 @@
 .. notice for github users
 
-Generic information about Let's Encrypt project can be found at
-https://letsencrypt.org. Please read `Frequently Asked Questions (FAQ)
+Notice
+======
+
+The Let's Encrypt Project is not LIVE yet.  All certificates are currently
+issued by a test CA.  Browser-trusted certificates will be available in the
+coming months.
+
+For more information regarding the status of the project, please see
+https://letsencrypt.org. Checkout the `Frequently Asked Questions (FAQ)
 <https://letsencrypt.org/faq/>`_.
-
-Installation Instructions
-=========================
-
-Official **documentation**, including `installation instructions`_, is
-available at https://letsencrypt.readthedocs.org.
 
 About the Let's Encrypt Client
 ==============================
@@ -20,7 +21,7 @@ In short: getting and installing SSL/TLS certificates made easy (`watch demo vid
 The Let's Encrypt Client is a tool to automatically receive and install
 X.509 certificates to enable TLS on servers. The client will
 interoperate with the Let's Encrypt CA which will be issuing browser-trusted
-certificates for free beginning the summer of 2015.
+certificates for free.
 
 It's all automated:
 
@@ -34,7 +35,7 @@ All you need to do to sign a single domain is::
   user@www:~$ sudo letsencrypt -d www.example.org auth
 
 For multiple domains (SAN) use::
-  
+
   user@www:~$ sudo letsencrypt -d www.example.org -d example.org auth
 
 and if you have a compatible web server (Apache or Nginx), Let's Encrypt can
@@ -99,6 +100,13 @@ Current Features
 * configuration changes are logged and can be reverted using the CLI
 * text and ncurses UI
 * Free and Open Source Software, made with Python.
+
+
+Installation Instructions
+=========================
+
+Official **documentation**, including `installation instructions`_, is
+available at https://letsencrypt.readthedocs.org.
 
 
 Links

--- a/README.rst
+++ b/README.rst
@@ -1,15 +1,18 @@
 .. notice for github users
 
-Notice
-======
+Disclaimer
+----------
 
-The Let's Encrypt Project is not LIVE yet.  All certificates are currently
-issued by a test CA.  Browser-trusted certificates will be available in the
-coming months.
+This is a **DEVELOPER PREVIEW** intended for developers and testers only.
+
+**DO NOT RUN THIS CODE ON A PRODUCTION SERVER. IT WILL INSTALL CERTIFICATES
+SIGNED BY A TEST CA, AND WILL CAUSE CERT WARNINGS FOR USERS.**
+
+Browser-trusted certificates will be available in the coming months.
 
 For more information regarding the status of the project, please see
-https://letsencrypt.org. Checkout the `Frequently Asked Questions (FAQ)
-<https://letsencrypt.org/faq/>`_.
+https://letsencrypt.org. Be sure to checkout the
+`Frequently Asked Questions (FAQ)<https://letsencrypt.org/faq/>`_.
 
 About the Let's Encrypt Client
 ==============================
@@ -68,15 +71,6 @@ server automatically!::
    https://letsencrypt.readthedocs.org/en/latest/using.html
 
 .. _watch demo video: https://www.youtube.com/watch?v=Gas_sSB-5SU
-
-
-Disclaimer
-----------
-
-This is a **DEVELOPER PREVIEW** intended for developers and testers only.
-
-**DO NOT RUN THIS CODE ON A PRODUCTION SERVER. IT WILL INSTALL CERTIFICATES
-SIGNED BY A TEST CA, AND WILL CAUSE CERT WARNINGS FOR USERS.**
 
 
 Current Features

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 .. notice for github users
 
 Disclaimer
-----------
+==========
 
 This is a **DEVELOPER PREVIEW** intended for developers and testers only.
 
@@ -97,7 +97,7 @@ Current Features
 
 
 Installation Instructions
-=========================
+-------------------------
 
 Official **documentation**, including `installation instructions`_, is
 available at https://letsencrypt.readthedocs.org.


### PR DESCRIPTION
There have been a number of people coming onto IRC expecting trusted certificates.  Since we have lost the preview status from the github repo name, I think moving the disclaimer up to the top is reasonable.

This builds off of #538 and gives the Installation instructions there own subsection.