### PR TITLE
Remove Python 3 Travis checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ env:
   matrix:
     - TOXENV=py26 BOULDER_INTEGRATION=1
     - TOXENV=py27 BOULDER_INTEGRATION=1
-    - TOXENV=py33
-    - TOXENV=py34
     - TOXENV=lint
     - TOXENV=cover
 


### PR DESCRIPTION
Like @jsha's branch except only removing checks for Python 3, not for Python 2.6.