### PR TITLE
Changes account in achalls to account_key

### DIFF
--- a/letsencrypt-apache/letsencrypt_apache/dvsni.py
+++ b/letsencrypt-apache/letsencrypt_apache/dvsni.py
@@ -164,7 +164,7 @@ class ApacheDvsni(common.Dvsni):
         # https://docs.python.org/2.7/reference/lexical_analysis.html
         return self.VHOST_TEMPLATE.format(
             vhost=ips,
-            server_name=achall.gen_response(achall.account.key).z_domain,
+            server_name=achall.gen_response(achall.account_key).z_domain,
             ssl_options_conf_path=self.configurator.mod_ssl_conf,
             cert_path=self.get_cert_path(achall),
             key_path=self.get_key_path(achall),

--- a/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
+++ b/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
@@ -376,8 +376,8 @@ class TwoVhost80Test(util.ApacheTest):
         account_key, achall1, achall2 = self.get_achalls()
 
         dvsni_ret_val = [
-            achall1.gen_response(account_key.key),
-            achall2.gen_response(account_key.key),
+            achall1.gen_response(account_key),
+            achall2.gen_response(account_key),
         ]
 
         mock_dvsni_perform.return_value = dvsni_ret_val
@@ -584,21 +584,21 @@ class TwoVhost80Test(util.ApacheTest):
 
     def get_achalls(self):
         """Return testing achallenges."""
-        account = mock.MagicMock(key=self.rsa512jwk)
+        account_key = self.rsa512jwk
         achall1 = achallenges.DVSNI(
             challb=acme_util.chall_to_challb(
                 challenges.DVSNI(
                     token="jIq_Xy1mXGN37tb4L6Xj_es58fW571ZNyXekdZzhh7Q"),
                 "pending"),
-            domain="encryption-example.demo", account=account)
+            domain="encryption-example.demo", account_key=account_key)
         achall2 = achallenges.DVSNI(
             challb=acme_util.chall_to_challb(
                 challenges.DVSNI(
                     token="uqnaPzxtrndteOqtrXb0Asl5gOJfWAnnx6QJyvcmlDU"),
                 "pending"),
-            domain="letsencrypt.demo", account=account)
+            domain="letsencrypt.demo", account_key=account_key)
 
-        return account, achall1, achall2
+        return account_key, achall1, achall2
 
     def test_make_addrs_sni_ready(self):
         self.config.version = (2, 2)

--- a/letsencrypt-nginx/letsencrypt_nginx/dvsni.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/dvsni.py
@@ -133,7 +133,7 @@ class NginxDvsni(common.Dvsni):
         block = [['listen', str(addr)] for addr in addrs]
 
         block.extend([['server_name',
-                       achall.gen_response(achall.account.key).z_domain],
+                       achall.gen_response(achall.account_key).z_domain],
                       ['include', self.configurator.parser.loc["ssl_options"]],
                       # access and error logs necessary for
                       # integration testing (non-root)

--- a/letsencrypt-nginx/letsencrypt_nginx/tests/configurator_test.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/tests/configurator_test.py
@@ -173,23 +173,22 @@ class NginxConfiguratorTest(util.NginxTest):
     def test_perform(self, mock_restart, mock_dvsni_perform):
         # Only tests functionality specific to configurator.perform
         # Note: As more challenges are offered this will have to be expanded
-        account = mock.MagicMock(key=self.rsa512jwk)
         achall1 = achallenges.DVSNI(
             challb=messages.ChallengeBody(
                 chall=challenges.DVSNI(token="kNdwjwOeX0I_A8DXt9Msmg"),
                 uri="https://ca.org/chall0_uri",
                 status=messages.Status("pending"),
-            ), domain="localhost", account=account)
+            ), domain="localhost", account_key=self.rsa512jwk)
         achall2 = achallenges.DVSNI(
             challb=messages.ChallengeBody(
                 chall=challenges.DVSNI(token="m8TdO1qik4JVFtgPPurJmg"),
                 uri="https://ca.org/chall1_uri",
                 status=messages.Status("pending"),
-            ), domain="example.com", account=account)
+            ), domain="example.com", account_key=self.rsa512jwk)
 
         dvsni_ret_val = [
-            achall1.gen_response(account.key),
-            achall2.gen_response(account.key),
+            achall1.gen_response(self.rsa512jwk),
+            achall2.gen_response(self.rsa512jwk),
         ]
 
         mock_dvsni_perform.return_value = dvsni_ret_val

--- a/letsencrypt-nginx/letsencrypt_nginx/tests/dvsni_test.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/tests/dvsni_test.py
@@ -19,26 +19,26 @@ from letsencrypt_nginx.tests import util
 class DvsniPerformTest(util.NginxTest):
     """Test the NginxDVSNI challenge."""
 
-    account = mock.MagicMock(key=common_test.DvsniTest.auth_key)
+    account_key = common_test.DvsniTest.auth_key
     achalls = [
         achallenges.DVSNI(
             challb=acme_util.chall_to_challb(
                 challenges.DVSNI(token="kNdwjwOeX0I_A8DXt9Msmg"), "pending"),
-            domain="www.example.com", account=account),
+            domain="www.example.com", account_key=account_key),
         achallenges.DVSNI(
             challb=acme_util.chall_to_challb(
                 challenges.DVSNI(
                     token="\xba\xa9\xda?<m\xaewmx\xea\xad\xadv\xf4\x02\xc9y"
                           "\x80\xe2_X\t\xe7\xc7\xa4\t\xca\xf7&\x945"
                 ), "pending"),
-            domain="blah", account=account),
+            domain="blah", account_key=account_key),
         achallenges.DVSNI(
             challb=acme_util.chall_to_challb(
                 challenges.DVSNI(
                     token="\x8c\x8a\xbf_-f\\cw\xee\xd6\xf8/\xa5\xe3\xfd"
                           "\xeb9\xf1\xf5\xb9\xefVM\xc9w\xa4u\x9c\xe1\x87\xb4"
                 ), "pending"),
-            domain="www.example.org", account=account),
+            domain="www.example.org", account_key=account_key),
     ]
 
 
@@ -71,7 +71,7 @@ class DvsniPerformTest(util.NginxTest):
     @mock.patch("letsencrypt_nginx.configurator.NginxConfigurator.save")
     def test_perform1(self, mock_save):
         self.sni.add_chall(self.achalls[0])
-        response = self.achalls[0].gen_response(self.account.key)
+        response = self.achalls[0].gen_response(self.account_key)
         mock_setup_cert = mock.MagicMock(return_value=response)
 
         # pylint: disable=protected-access
@@ -92,7 +92,7 @@ class DvsniPerformTest(util.NginxTest):
         acme_responses = []
         for achall in self.achalls:
             self.sni.add_chall(achall)
-            acme_responses.append(achall.gen_response(self.account.key))
+            acme_responses.append(achall.gen_response(self.account_key))
 
         mock_setup_cert = mock.MagicMock(side_effect=acme_responses)
         # pylint: disable=protected-access
@@ -138,9 +138,9 @@ class DvsniPerformTest(util.NginxTest):
 
         for vhost in vhs:
             if vhost.addrs == set(v_addr1):
-                response = self.achalls[0].gen_response(self.account.key)
+                response = self.achalls[0].gen_response(self.account_key)
             else:
-                response = self.achalls[2].gen_response(self.account.key)
+                response = self.achalls[2].gen_response(self.account_key)
                 self.assertEqual(vhost.addrs, set(v_addr2))
             self.assertEqual(vhost.names, set([response.z_domain]))
 

--- a/letsencrypt/achallenges.py
+++ b/letsencrypt/achallenges.py
@@ -50,10 +50,10 @@ class AnnotatedChallenge(jose.ImmutableMap):
 class DVSNI(AnnotatedChallenge):
     """Client annotated "dvsni" ACME challenge.
 
-    :ivar .Account account:
+    :ivar .JWK account_key: Authorized Account Key
 
     """
-    __slots__ = ('challb', 'domain', 'account')
+    __slots__ = ('challb', 'domain', 'account_key')
     acme_type = challenges.DVSNI
 
     def gen_cert_and_response(self, key_pem=None, bits=2048, alg=jose.RS256):
@@ -75,7 +75,7 @@ class DVSNI(AnnotatedChallenge):
         """
         key = None if key_pem is None else OpenSSL.crypto.load_privatekey(
             OpenSSL.crypto.FILETYPE_PEM, key_pem)
-        response = self.challb.chall.gen_response(self.account.key, alg=alg)
+        response = self.challb.chall.gen_response(self.account_key, alg=alg)
         cert, key = response.gen_cert(key=key, bits=bits)
 
         cert_pem = OpenSSL.crypto.dump_certificate(
@@ -88,7 +88,7 @@ class DVSNI(AnnotatedChallenge):
 
 class SimpleHTTP(AnnotatedChallenge):
     """Client annotated "simpleHttp" ACME challenge."""
-    __slots__ = ('challb', 'domain', 'account')
+    __slots__ = ('challb', 'domain', 'account_key')
     acme_type = challenges.SimpleHTTP
 
     def gen_response_and_validation(self, tls):
@@ -106,7 +106,7 @@ class SimpleHTTP(AnnotatedChallenge):
         response = challenges.SimpleHTTPResponse(tls=tls)
 
         validation = response.gen_validation(
-            self.challb.chall, self.account.key)
+            self.challb.chall, self.account_key)
         logger.debug("Simple HTTP validation payload: %s", validation.payload)
         return response, validation
 

--- a/letsencrypt/auth_handler.py
+++ b/letsencrypt/auth_handler.py
@@ -322,7 +322,7 @@ class AuthHandler(object):
             challb = self.authzr[domain].body.challenges[index]
             chall = challb.chall
 
-            achall = challb_to_achall(challb, self.account, domain)
+            achall = challb_to_achall(challb, self.account.key, domain)
 
             if isinstance(chall, challenges.ContinuityChallenge):
                 cont_chall.append(achall)
@@ -332,11 +332,11 @@ class AuthHandler(object):
         return cont_chall, dv_chall
 
 
-def challb_to_achall(challb, account, domain):
+def challb_to_achall(challb, account_key, domain):
     """Converts a ChallengeBody object to an AnnotatedChallenge.
 
     :param .ChallengeBody challb: ChallengeBody
-    :param .Account account:
+    :param .JWK account_key: Authorized Account Key
     :param str domain: Domain of the challb
 
     :returns: Appropriate AnnotatedChallenge
@@ -348,10 +348,10 @@ def challb_to_achall(challb, account, domain):
 
     if isinstance(chall, challenges.DVSNI):
         return achallenges.DVSNI(
-            challb=challb, domain=domain, account=account)
+            challb=challb, domain=domain, account_key=account_key)
     elif isinstance(chall, challenges.SimpleHTTP):
         return achallenges.SimpleHTTP(
-            challb=challb, domain=domain, account=account)
+            challb=challb, domain=domain, account_key=account_key)
     elif isinstance(chall, challenges.DNS):
         return achallenges.DNS(challb=challb, domain=domain)
     elif isinstance(chall, challenges.RecoveryContact):

--- a/letsencrypt/plugins/common_test.py
+++ b/letsencrypt/plugins/common_test.py
@@ -115,11 +115,11 @@ class DvsniTest(unittest.TestCase):
         achallenges.DVSNI(
             challb=acme_util.chall_to_challb(
                 challenges.DVSNI(token=b'dvsni1'), "pending"),
-            domain="encryption-example.demo", account=mock.Mock(key=auth_key)),
+            domain="encryption-example.demo", account_key=auth_key),
         achallenges.DVSNI(
             challb=acme_util.chall_to_challb(
                 challenges.DVSNI(token=b'dvsni2'), "pending"),
-            domain="letsencrypt.demo", account=mock.Mock(key=auth_key)),
+            domain="letsencrypt.demo", account_key=auth_key),
     ]
 
     def setUp(self):

--- a/letsencrypt/plugins/manual.py
+++ b/letsencrypt/plugins/manual.py
@@ -162,7 +162,7 @@ binary for temporary key/certificate generation.""".replace("\n", "")
 
         if response.simple_verify(
                 achall.chall, achall.domain,
-                achall.account.key.public_key(), self.config.simple_http_port):
+                achall.account_key.public_key(), self.config.simple_http_port):
             return response
         else:
             if self.conf("test-mode") and self._httpd.poll() is not None:

--- a/letsencrypt/plugins/manual_test.py
+++ b/letsencrypt/plugins/manual_test.py
@@ -26,9 +26,8 @@ class ManualAuthenticatorTest(unittest.TestCase):
             no_simple_http_tls=True, simple_http_port=4430,
             manual_test_mode=False)
         self.auth = ManualAuthenticator(config=self.config, name="manual")
-        account = mock.MagicMock(key=KEY)
         self.achalls = [achallenges.SimpleHTTP(
-            challb=acme_util.SIMPLE_HTTP_P, domain="foo.com", account=account)]
+            challb=acme_util.SIMPLE_HTTP_P, domain="foo.com", account_key=KEY)]
 
         config_test_mode = mock.MagicMock(
             no_simple_http_tls=True, simple_http_port=4430,

--- a/letsencrypt/plugins/standalone/tests/authenticator_test.py
+++ b/letsencrypt/plugins/standalone/tests/authenticator_test.py
@@ -17,8 +17,7 @@ from letsencrypt.tests import acme_util
 from letsencrypt.tests import test_util
 
 
-ACCOUNT = mock.Mock(key=jose.JWKRSA.load(
-    test_util.load_vector("rsa512_key.pem")))
+ACCOUNT_KEY = jose.JWKRSA.load(test_util.load_vector("rsa512_key.pem"))
 CHALL_KEY_PEM = test_util.load_vector("rsa512_key_2.pem")
 CHALL_KEY = OpenSSL.crypto.load_privatekey(
     OpenSSL.crypto.FILETYPE_PEM, CHALL_KEY_PEM)
@@ -76,7 +75,8 @@ class SNICallbackTest(unittest.TestCase):
         self.cert = achallenges.DVSNI(
             challb=acme_util.DVSNI_P,
             domain="example.com",
-            account=ACCOUNT).gen_cert_and_response(key_pem=CHALL_KEY_PEM)[1]
+            account_key=ACCOUNT_KEY
+        ).gen_cert_and_response(key_pem=CHALL_KEY_PEM)[1]
         self.authenticator.private_key = CHALL_KEY
         self.authenticator.sni_names = {"abcdef.acme.invalid": self.cert}
         self.authenticator.child_pid = 12345
@@ -300,11 +300,11 @@ class PerformTest(unittest.TestCase):
         self.achall1 = achallenges.DVSNI(
             challb=acme_util.chall_to_challb(
                 challenges.DVSNI(token=b"foo"), "pending"),
-            domain="foo.example.com", account=ACCOUNT)
+            domain="foo.example.com", account_key=ACCOUNT_KEY)
         self.achall2 = achallenges.DVSNI(
             challb=acme_util.chall_to_challb(
                 challenges.DVSNI(token=b"bar"), "pending"),
-            domain="bar.example.com", account=ACCOUNT)
+            domain="bar.example.com", account_key=ACCOUNT_KEY)
         bad_achall = ("This", "Represents", "A Non-DVSNI", "Challenge")
         self.achalls = [self.achall1, self.achall2, bad_achall]
 
@@ -448,7 +448,7 @@ class DoChildProcessTest(unittest.TestCase):
         self.cert = achallenges.DVSNI(
             challb=acme_util.chall_to_challb(
                 challenges.DVSNI(token=b"abcdef"), "pending"),
-            domain="example.com", account=ACCOUNT).gen_cert_and_response(
+            domain="example.com", account_key=ACCOUNT_KEY).gen_cert_and_response(
                 key_pem=CHALL_KEY_PEM)[1]
         self.authenticator.private_key = CHALL_KEY
         self.authenticator.tasks = {"abcdef.acme.invalid": self.cert}
@@ -535,7 +535,7 @@ class CleanupTest(unittest.TestCase):
         self.achall = achallenges.DVSNI(
             challb=acme_util.chall_to_challb(
                 challenges.DVSNI(token=b"footoken"), "pending"),
-            domain="foo.example.com", account=mock.Mock(key="key"))
+            domain="foo.example.com", account_key="key")
         self.authenticator.tasks = {self.achall.token: "stuff"}
         self.authenticator.child_pid = 12345
 
@@ -555,7 +555,7 @@ class CleanupTest(unittest.TestCase):
             ValueError, self.authenticator.cleanup, [achallenges.DVSNI(
                 challb=acme_util.chall_to_challb(
                     challenges.DVSNI(token=b"badtoken"), "pending"),
-                domain="bad.example.com", account=mock.Mock(key="key"))])
+                domain="bad.example.com", account_key="key")])
 
 
 class MoreInfoTest(unittest.TestCase):

--- a/letsencrypt/tests/achallenges_test.py
+++ b/letsencrypt/tests/achallenges_test.py
@@ -1,8 +1,6 @@
 """Tests for letsencrypt.achallenges."""
 import unittest
 
-import mock
-
 from acme import challenges
 from acme import jose
 
@@ -15,11 +13,10 @@ class DVSNITest(unittest.TestCase):
 
     def setUp(self):
         self.challb = acme_util.chall_to_challb(acme_util.DVSNI, "pending")
-        account = mock.Mock(key=jose.JWKRSA.load(
-            test_util.load_vector("rsa512_key.pem")))
+        key = jose.JWKRSA.load(test_util.load_vector("rsa512_key.pem"))
         from letsencrypt.achallenges import DVSNI
         self.achall = DVSNI(
-            challb=self.challb, domain="example.com", account=account)
+            challb=self.challb, domain="example.com", account_key=key)
 
     def test_proxy(self):
         self.assertEqual(self.challb.token, self.achall.token)

--- a/letsencrypt/tests/auth_handler_test.py
+++ b/letsencrypt/tests/auth_handler_test.py
@@ -436,19 +436,19 @@ class ReportFailedChallsTest(unittest.TestCase):
         self.simple_http = achallenges.SimpleHTTP(
             challb=messages.ChallengeBody(**kwargs),# pylint: disable=star-args
             domain="example.com",
-            account=mock.Mock(key=acme_util.KEY))
+            account_key="key")
 
         kwargs["chall"] = acme_util.DVSNI
         self.dvsni_same = achallenges.DVSNI(
             challb=messages.ChallengeBody(**kwargs),# pylint: disable=star-args
             domain="example.com",
-            account=mock.Mock(key=acme_util.KEY))
+            account_key="key")
 
         kwargs["error"] = messages.Error(typ="dnssec", detail="detail")
         self.dvsni_diff = achallenges.DVSNI(
             challb=messages.ChallengeBody(**kwargs),# pylint: disable=star-args
             domain="foo.bar",
-            account=mock.Mock(key=acme_util.KEY))
+            account_key="key")
 
     @mock.patch("letsencrypt.auth_handler.zope.component.getUtility")
     def test_same_error_and_domain(self, mock_zope):

--- a/letsencrypt/tests/continuity_auth_test.py
+++ b/letsencrypt/tests/continuity_auth_test.py
@@ -34,8 +34,8 @@ class PerformTest(unittest.TestCase):
     def test_unexpected(self):
         self.assertRaises(
             errors.ContAuthError, self.auth.perform, [
-                achallenges.DVSNI(challb=None, domain="0",
-                                  account=mock.Mock(key="invalid_key"))])
+                achallenges.DVSNI(
+                    challb=None, domain="0", account_key="invalid_key"),])
 
     def test_chall_pref(self):
         self.assertEqual(
@@ -54,7 +54,7 @@ class CleanupTest(unittest.TestCase):
 
     def test_unexpected(self):
         unexpected = achallenges.DVSNI(
-            challb=None, domain="0", account=mock.Mock("dummy_key"))
+            challb=None, domain="0", account_key="dummy_key")
         self.assertRaises(errors.ContAuthError, self.auth.cleanup, [unexpected])
 
 


### PR DESCRIPTION
This PR changes the `account` variable in `letsencrypt.achallenges` to an `account_key` variable. Since no challenges rely on any account data besides the key, I think this simplifies achalls and removes unnecessary coupling between achalls and accounts.