### PR TITLE
Removed py3+ tests in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 # acme and letsencrypt are not yet on pypi, so when Tox invokes
 # "install *.zip", it will not find deps
 skipsdist = true
-envlist = py26,py27,py33,py34,cover,lint
+envlist = py26,py27,cover,lint
 
 [testenv]
 commands =
@@ -21,16 +21,6 @@ setenv =
     PYTHONPATH = {toxinidir}
     PYTHONHASHSEED = 0
 # https://testrun.org/tox/latest/example/basic.html#special-handling-of-pythonhas
-
-[testenv:py33]
-commands =
-    pip install -e acme[testing]
-    nosetests acme
-
-[testenv:py34]
-commands =
-    pip install -e acme[testing]
-    nosetests acme
 
 [testenv:cover]
 basepython = python2.7


### PR DESCRIPTION
This PR removes py3+ tests from tox since we removed the tests from travis in #654. We should add these tests again if we resume testing for py3+ compatibility in the future.