### PR TITLE
Fix enable_mod register_undo_command in challenges

### DIFF
--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -482,7 +482,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         logger.debug(msg)
         self.save_notes += msg
 
-    def prepare_server_https(self, port):
+    def prepare_server_https(self, port, temp=False):
         """Prepare the server for HTTPS.
 
         Make sure that the ssl_module is loaded and that the server
@@ -493,7 +493,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         """
         if "ssl_module" not in self.parser.modules:
             logger.info("Loading mod_ssl into Apache Server")
-            self.enable_mod("ssl")
+            self.enable_mod("ssl", temp)
 
         # Check for Listen <port>
         # Note: This could be made to also look for ip:443 combo

--- a/letsencrypt-apache/letsencrypt_apache/dvsni.py
+++ b/letsencrypt-apache/letsencrypt_apache/dvsni.py
@@ -62,7 +62,7 @@ class ApacheDvsni(common.Dvsni):
 
         # Prepare the server for HTTPS
         self.configurator.prepare_server_https(
-            str(self.configurator.config.dvsni_port))
+            str(self.configurator.config.dvsni_port), True)
 
         responses = []
 

--- a/letsencrypt-apache/letsencrypt_apache/tests/dvsni_test.py
+++ b/letsencrypt-apache/letsencrypt_apache/tests/dvsni_test.py
@@ -38,6 +38,9 @@ class DvsniPerformTest(util.ApacheTest):
     @mock.patch("letsencrypt.le_util.exe_exists")
     @mock.patch("letsencrypt.le_util.run_script")
     def test_perform1(self, _, mock_exists):
+        mock_register = mock.Mock()
+        self.sni.configurator.reverter.register_undo_command = mock_register
+
         mock_exists.return_value = True
         self.sni.configurator.parser.update_runtime_variables = mock.Mock()
 
@@ -49,6 +52,9 @@ class DvsniPerformTest(util.ApacheTest):
         self.sni._setup_challenge_cert = mock_setup_cert
 
         responses = self.sni.perform()
+
+        # Make sure that register_undo_command was called into temp directory.
+        self.assertEqual(True, mock_register.call_args[0][0])
 
         mock_setup_cert.assert_called_once_with(achall)
 


### PR DESCRIPTION
This bug was found with @bmw's testing suite in #628.  I believe I have fixed the bug and have written a test case against it.

I will address the module dependencies cleanup in a separate PR.

Once ^ is complete, I will work on getting the plugin tests into the integration flow.