### PR TITLE
Revert PR #708.

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -9,6 +9,7 @@ install_requires = [
     # load_pem_private/public_key (>=0.6)
     # rsa_recover_prime_factors (>=0.8)
     'cryptography>=0.8',
+    'mock<1.1.0',  # py26
     'pyrfc3339',
     'ndg-httpsclient',  # urllib3 InsecurePlatformWarning (#304)
     'pyasn1',  # urllib3 InsecurePlatformWarning (#304)
@@ -22,13 +23,8 @@ install_requires = [
 
 # env markers in extras_require cause problems with older pip: #517
 if sys.version_info < (2, 7):
-    install_requires.extend([
-        # only some distros recognize stdlib argparse as already satisfying
-        'argparse',
-        'mock<1.1.0',
-    ])
-else:
-    install_requires.append('mock')
+    # only some distros recognize stdlib argparse as already satisfying
+    install_requires.append('argparse')
 
 testing_extras = [
     'nose',

--- a/letsencrypt-apache/setup.py
+++ b/letsencrypt-apache/setup.py
@@ -1,5 +1,3 @@
-import sys
-
 from setuptools import setup
 from setuptools import find_packages
 
@@ -7,15 +5,11 @@ from setuptools import find_packages
 install_requires = [
     'acme',
     'letsencrypt',
+    'mock<1.1.0',  # py26
     'python-augeas',
     'zope.component',
     'zope.interface',
 ]
-
-if sys.version_info < (2, 7):
-    install_requires.append('mock<1.1.0')
-else:
-    install_requires.append('mock')
 
 setup(
     name='letsencrypt-apache',

--- a/letsencrypt-compatibility-test/setup.py
+++ b/letsencrypt-compatibility-test/setup.py
@@ -1,5 +1,3 @@
-import sys
-
 from setuptools import setup
 from setuptools import find_packages
 
@@ -9,13 +7,9 @@ install_requires = [
     'letsencrypt-apache',
     'letsencrypt-nginx',
     'docker-py',
+    'mock<1.1.0',  # py26
     'zope.interface',
 ]
-
-if sys.version_info < (2, 7):
-    install_requires.append('mock<1.1.0')
-else:
-    install_requires.append('mock')
 
 setup(
     name='letsencrypt-compatibility-test',

--- a/letsencrypt-nginx/setup.py
+++ b/letsencrypt-nginx/setup.py
@@ -1,5 +1,3 @@
-import sys
-
 from setuptools import setup
 from setuptools import find_packages
 
@@ -8,13 +6,9 @@ install_requires = [
     'acme',
     'letsencrypt',
     'pyparsing>=1.5.5',  # Python3 support; perhaps unnecessary?
+    'mock<1.1.0',  # py26
     'zope.interface',
 ]
-
-if sys.version_info < (2, 7):
-    install_requires.append('mock<1.1.0')
-else:
-    install_requires.append('mock')
 
 setup(
     name='letsencrypt-nginx',

--- a/letshelp-letsencrypt/setup.py
+++ b/letshelp-letsencrypt/setup.py
@@ -6,17 +6,17 @@ from setuptools import find_packages
 
 install_requires = []
 if sys.version_info < (2, 7):
-    install_requires.append('mock<1.1.0')
+    install_requires.append("mock<1.1.0")
 else:
-    install_requires.append('mock')
+    install_requires.append("mock")
 
 setup(
-    name='letshelp-letsencrypt',
+    name="letshelp-letsencrypt",
     packages=find_packages(),
     install_requires=install_requires,
     entry_points={
         'console_scripts': [
-            'letshelp-letsencrypt-apache = letshelp_letsencrypt.apache:main',
+            "letshelp-letsencrypt-apache = letshelp_letsencrypt.apache:main",
         ],
     },
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ install_requires = [
     'ConfigArgParse',
     'configobj',
     'cryptography>=0.7',  # load_pem_x509_certificate
+    'mock<1.1.0',  # py26
     'parsedatetime',
     'psutil>=2.1.0',  # net_connections introduced in 2.1.0
     'PyOpenSSL',
@@ -46,13 +47,8 @@ install_requires = [
 
 # env markers in extras_require cause problems with older pip: #517
 if sys.version_info < (2, 7):
-    install_requires.extend([
-        # only some distros recognize stdlib argparse as already satisfying
-        'argparse',
-        'mock<1.1.0',
-    ])
-else:
-    install_requires.append('mock')
+    # only some distros recognize stdlib argparse as already satisfying
+    install_requires.append('argparse')
 
 dev_extras = [
     # Pin astroid==1.3.5, pylint==1.4.2 as a workaround for #289


### PR DESCRIPTION
https://github.com/letsencrypt/letsencrypt/pull/708 broke the Boulder CI build
because Travis runs Ubuntu 12.04, which has an older setuptools. See
https://github.com/letsencrypt/boulder/issues/681.