### PR TITLE
Minor: use sudo for auth command in using.rst

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -129,7 +129,7 @@ To get a new certificate run:
 
 .. code-block:: shell
 
-   ./venv/bin/letsencrypt auth
+   sudo ./venv/bin/letsencrypt auth
 
 The ``letsencrypt`` commandline tool has a builtin help:
 


### PR DESCRIPTION
    ./venv/bin/letsencrypt auth

will fail if it's not run as root. As sudo is used in the rest of the document and referred to recommended way of running letsencrypt client, it should be added IMHO.

    sudo ./venv/bin/letsencrypt auth
