### PR TITLE
Fix minor spelling errors in the code.

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -546,7 +546,7 @@ class ClientNetwork(object):
         """Send HEAD request without checking the response.
 
         Note, that `_check_response` is not called, as it is expected
-        that status code other than successfuly 2xx will be returned, or
+        that status code other than successfully 2xx will be returned, or
         messages2.Error will be raised by the server.
 
         """

--- a/acme/acme/jose/interfaces.py
+++ b/acme/acme/jose/interfaces.py
@@ -41,7 +41,7 @@ class JSONDeSerializable(object):
         be encoded into a JSON document. **Full serialization** produces
         a Python object composed of only basic types as required by the
         :ref:`conversion table <conversion-table>`. **Partial
-        serialization** (acomplished by :meth:`to_partial_json`)
+        serialization** (accomplished by :meth:`to_partial_json`)
         produces a Python object that might also be built from other
         :class:`JSONDeSerializable` objects.
 

--- a/acme/acme/jose/jws.py
+++ b/acme/acme/jose/jws.py
@@ -53,7 +53,7 @@ class Header(json_util.JSONObjectWithFields):
     .. warning:: This class does not support any extensions through
         the "crit" (Critical) Header Parameter (4.1.11) and as a
         conforming implementation, :meth:`from_json` treats its
-        occurence as an error. Please subclass if you seek for
+        occurrence as an error. Please subclass if you seek for
         a different behaviour.
 
     :ivar x5tS256: "x5t#S256"

--- a/acme/acme/jose/util.py
+++ b/acme/acme/jose/util.py
@@ -107,8 +107,8 @@ class ComparableRSAKey(ComparableKey):  # pylint: disable=too-few-public-methods
     """Wrapper for `cryptography` RSA keys.
 
     Wraps around:
-    - `cryptography.hazmat.primitives.assymetric.RSAPrivateKey`
-    - `cryptography.hazmat.primitives.assymetric.RSAPublicKey`
+    - `cryptography.hazmat.primitives.asymmetric.RSAPrivateKey`
+    - `cryptography.hazmat.primitives.asymmetric.RSAPublicKey`
 
     """
 

--- a/acme/acme/other.py
+++ b/acme/acme/other.py
@@ -36,7 +36,7 @@ class Signature(jose.JSONObjectWithFields):
         :param bytes msg: Message to be signed.
 
         :param key: Key used for signing.
-        :type key: `cryptography.hazmat.primitives.assymetric.rsa.RSAPrivateKey`
+        :type key: `cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKey`
             (optionally wrapped in `.ComparableRSAKey`).
 
         :param bytes nonce: Nonce to be used. If None, nonce of

--- a/acme/acme/test_util.py
+++ b/acme/acme/test_util.py
@@ -1,4 +1,4 @@
-# Symlinked in letsencrypt/tests/test_util.py, casues duplicate-code
+# Symlinked in letsencrypt/tests/test_util.py, causes duplicate-code
 # warning that cannot be disabled locally.
 """Test utilities.
 

--- a/letsencrypt-compatibility-test/letsencrypt_compatibility_test/interfaces.py
+++ b/letsencrypt-compatibility-test/letsencrypt_compatibility_test/interfaces.py
@@ -23,7 +23,7 @@ class IPluginProxy(zope.interface.Interface):
     def cleanup_from_tests():
         """Performs any necessary cleanup from running plugin tests.
 
-        This is guarenteed to be called before the program exits.
+        This is guaranteed to be called before the program exits.
 
         """
 

--- a/letsencrypt/account.py
+++ b/letsencrypt/account.py
@@ -62,7 +62,7 @@ class Account(object):  # pylint: disable=too-few-public-methods
         # Implementation note: Email? Multiple accounts can have the
         # same email address. Registration URI? Assigned by the
         # server, not guaranteed to be stable over time, nor
-        # cannonical URI can be generated. ACME protocol doesn't allow
+        # canonical URI can be generated. ACME protocol doesn't allow
         # account key (and thus its fingerprint) to be updated...
 
     @property

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -623,7 +623,7 @@ def _plugins_parsing(helpful, plugins):
         "plugins", description="Let's Encrypt client supports an "
         "extensible plugins architecture. See '%(prog)s plugins' for a "
         "list of all available plugins and their names. You can force "
-        "a particular plugin by setting options provided below. Futher "
+        "a particular plugin by setting options provided below. Further "
         "down this help message you will find plugin-specific options "
         "(prefixed by --{plugin_name}).")
     helpful.add(

--- a/letsencrypt/display/ops.py
+++ b/letsencrypt/display/ops.py
@@ -16,7 +16,7 @@ util = zope.component.getUtility  # pylint: disable=invalid-name
 
 
 def choose_plugin(prepared, question):
-    """Allow the user to choose ther plugin.
+    """Allow the user to choose their plugin.
 
     :param list prepared: List of `~.PluginEntryPoint`.
     :param str question: Question to be presented to the user.

--- a/letsencrypt/interfaces.py
+++ b/letsencrypt/interfaces.py
@@ -142,7 +142,7 @@ class IAuthenticator(IPlugin):
 
         :param str domain: Domain for which challenge preferences are sought.
 
-        :returns: List of challege types (subclasses of
+        :returns: List of challenge types (subclasses of
             :class:`acme.challenges.Challenge`) with the most
             preferred challenges first. If a type is not specified, it means the
             Authenticator cannot perform the challenge.

--- a/letsencrypt/storage.py
+++ b/letsencrypt/storage.py
@@ -626,7 +626,7 @@ class RenewableCert(object):  # pylint: disable=too-many-instance-attributes
 
         """
         # XXX: assumes official archive location rather than examining links
-        # XXX: consider using os.open for availablity of os.O_EXCL
+        # XXX: consider using os.open for availability of os.O_EXCL
         # XXX: ensure file permissions are correct; also create directories
         #      if needed (ensuring their permissions are correct)
         # Figure out what the new version is and hence where to save things


### PR DESCRIPTION
As part of check-all-the-things' run, codespell found some spelling errors.  These aren't necessarily /all/ of them, but they should be fixed regardless.

These spelling errors should all be in pydoc, so no code impact.