### PR TITLE
Make urllib3 injection more version specific.

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -8,7 +8,7 @@ from six.moves import http_client  # pylint: disable=import-error
 
 import OpenSSL
 import requests
-import six
+import sys
 import werkzeug
 
 from acme import errors
@@ -19,8 +19,8 @@ from acme import messages
 
 logger = logging.getLogger(__name__)
 
-# https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning
-if six.PY2:
+# Python does not validate certificates by default before version 2.7.9
+if sys.version_info < (2, 7, 9):
     requests.packages.urllib3.contrib.pyopenssl.inject_into_urllib3()
 
 

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -20,7 +20,8 @@ from acme import messages
 logger = logging.getLogger(__name__)
 
 # Python does not validate certificates by default before version 2.7.9
-if sys.version_info < (2, 7, 9):
+# https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning
+if sys.version_info < (2, 7, 9):  # pragma: no cover
     requests.packages.urllib3.contrib.pyopenssl.inject_into_urllib3()
 
 


### PR DESCRIPTION
This is based off of patch 0001-... in the debian branch.  Though I can't find it anywhere, I seem to remember someone requested it use sys.version_info instead of sys.hexversion, so that's the solution I used here.