### PR TITLE
Easier coverage testing for subpackages.

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -52,7 +52,8 @@ The following tools are there to help you:
   before submitting a new pull request.
 
 - ``tox -e cover`` checks the test coverage only. Calling the
-  ``./tox.cover.sh`` script directly might be a bit quicker, though.
+  ``./tox.cover.sh`` script directly (or even ``./tox.cover.sh $pkg1
+  $pkg2 ...`` for any subpackages) might be a bit quicker, though.
 
 - ``tox -e lint`` checks the style of the whole project, while
   ``pylint --rcfile=.pylintrc path`` will check a single file or

--- a/tox.cover.sh
+++ b/tox.cover.sh
@@ -1,10 +1,35 @@
-#!/bin/sh
+#!/bin/sh -xe
 
+# USAGE: ./tox.cover.sh [package]
+#
 # This script is used by tox.ini (and thus Travis CI) in order to
 # generate separate stats for each package. It should be removed once
 # those packages are moved to separate repo.
+#
+# -e makes sure we fail fast and don't submit coveralls submit
+
+if [ "xxx$1" = "xxx" ]; then
+  pkgs="letsencrypt acme letsencrypt_apache letsencrypt_nginx letshelp_letsencrypt"
+else
+  pkgs="$@"
+fi
 
 cover () {
+  if [ "$1" = "letsencrypt" ]; then
+    min=97
+  elif [ "$1" = "acme" ]; then
+    min=100
+  elif [ "$1" = "letsencrypt_apache" ]; then
+    min=100
+  elif [ "$1" = "letsencrypt_nginx" ]; then
+    min=96
+  elif [ "$1" = "letshelp_letsencrypt" ]; then
+    min=100
+  else
+    echo "Unrecognized package: $1"
+    exit 1
+  fi
+
   # "-c /dev/null" makes sure setup.cfg is not loaded (multiple
   # --with-cover add up, --cover-erase must not be set for coveralls
   # to get all the data); --with-cover scopes coverage to only
@@ -12,16 +37,11 @@ cover () {
   # specific package directory; --cover-tests makes sure every tests
   # is run (c.f. #403)
   nosetests -c /dev/null --with-cover --cover-tests --cover-package  \
-            "$1" --cover-min-percentage="$2" "$1"
+            "$1" --cover-min-percentage="$min" "$1"
 }
 
 rm -f .coverage  # --cover-erase is off, make sure stats are correct
-
-# don't use sequential composition (;), if letsencrypt_nginx returns
-# 0, coveralls submit will be triggered (c.f. .travis.yml,
-# after_success)
-cover letsencrypt 97 && \
-    cover acme 100 && \
-    cover letsencrypt_apache 100 && \
-    cover letsencrypt_nginx 96 && \
-    cover letshelp_letsencrypt 100
+for pkg in $pkgs
+do
+  cover $pkg
+done


### PR DESCRIPTION
You can now call `./tox.cover.sh acme`, `./tox.cover acme letsencrypt` etc. to scope down coverage testing to particular subpackages. `./tox.cover.sh` checks coverage for all packages.