### PR TITLE
Module deps apache

### DIFF
--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -1004,17 +1004,52 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
                 "Unsupported directory layout. You may try to enable mod %s "
                 "and try again." % mod_name)
 
+        deps = self._get_mod_deps(mod_name)
+
+        # Enable all dependencies
+        for dep in deps:
+            if dep not in self.parser.modules:
+                self._enable_mod_debian(dep, temp)
+                self._add_parser_mod(dep)
+
+                note = "Enabled dependency of module %s - %s" % (mod_name, dep)
+                self.save_notes += note + os.linesep
+                logger.debug(note)
+
+        # Enable actual module
         self._enable_mod_debian(mod_name, temp)
-        self.save_notes += "Enabled %s module in Apache" % mod_name
-        logger.debug("Enabled Apache %s module", mod_name)
+        self._add_parser_mod(mod_name)
+
+        self.save_notes += "Enabled %s module in Apache\n" % mod_name
+        logger.info("Enabled Apache %s module", mod_name)
 
         # Modules can enable additional config files. Variables may be defined
         # within these new configuration sections.
         # Restart is not necessary as DUMP_RUN_CFG uses latest config.
         self.parser.update_runtime_variables(self.conf("ctl"))
 
+    def _add_parser_mod(self, mod_name):
+        """Shortcut for updating parser modules."""
         self.parser.modules.add(mod_name + "_module")
         self.parser.modules.add("mod_" + mod_name + ".c")
+
+    def _get_mod_deps(self, mod_name):
+        """Get known module dependencies.
+
+        .. note:: This does not need to be accurate in order for the client to
+            run.  This simply keeps things clean if the user decides to revert
+            changes.
+        .. warning:: If all deps are not included, it may cause incorrect parsing
+            behavior, due to enable_mod's shortcut for updating the parser's
+            currently defined modules (:method:`._add_parser_mod`)
+            This would only present a major problem in extremely atypical
+            configs that use ifmod for the missing deps.
+
+        """
+        deps = {
+            "ssl": ["setenvif", "mime", "socache_shmcb"]
+        }
+        return deps.get(mod_name, [])
 
     def _enable_mod_debian(self, mod_name, temp):
         """Assumes mods-available, mods-enabled layout."""

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -492,7 +492,6 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
 
         """
         if "ssl_module" not in self.parser.modules:
-            logger.info("Loading mod_ssl into Apache Server")
             self.enable_mod("ssl", temp=temp)
 
         # Check for Listen <port>
@@ -1012,7 +1011,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
                 self._enable_mod_debian(dep, temp)
                 self._add_parser_mod(dep)
 
-                note = "Enabled dependency of module %s - %s" % (mod_name, dep)
+                note = "Enabled dependency of %s module - %s" % (mod_name, dep)
                 self.save_notes += note + os.linesep
                 logger.debug(note)
 

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -1012,14 +1012,16 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
                 self._add_parser_mod(dep)
 
                 note = "Enabled dependency of %s module - %s" % (mod_name, dep)
-                self.save_notes += note + os.linesep
+                if not temp:
+                    self.save_notes += note + os.linesep
                 logger.debug(note)
 
         # Enable actual module
         self._enable_mod_debian(mod_name, temp)
         self._add_parser_mod(mod_name)
 
-        self.save_notes += "Enabled %s module in Apache\n" % mod_name
+        if not temp:
+            self.save_notes += "Enabled %s module in Apache\n" % mod_name
         logger.info("Enabled Apache %s module", mod_name)
 
         # Modules can enable additional config files. Variables may be defined

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -1003,7 +1003,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
                 "Unsupported directory layout. You may try to enable mod %s "
                 "and try again." % mod_name)
 
-        deps = self._get_mod_deps(mod_name)
+        deps = _get_mod_deps(mod_name)
 
         # Enable all dependencies
         for dep in deps:
@@ -1033,24 +1033,6 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         """Shortcut for updating parser modules."""
         self.parser.modules.add(mod_name + "_module")
         self.parser.modules.add("mod_" + mod_name + ".c")
-
-    def _get_mod_deps(self, mod_name):
-        """Get known module dependencies.
-
-        .. note:: This does not need to be accurate in order for the client to
-            run.  This simply keeps things clean if the user decides to revert
-            changes.
-        .. warning:: If all deps are not included, it may cause incorrect parsing
-            behavior, due to enable_mod's shortcut for updating the parser's
-            currently defined modules (:method:`._add_parser_mod`)
-            This would only present a major problem in extremely atypical
-            configs that use ifmod for the missing deps.
-
-        """
-        deps = {
-            "ssl": ["setenvif", "mime", "socache_shmcb"]
-        }
-        return deps.get(mod_name, [])
 
     def _enable_mod_debian(self, mod_name, temp):
         """Assumes mods-available, mods-enabled layout."""
@@ -1174,6 +1156,25 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
             self.revert_challenge_config()
             self.restart()
             self.parser.init_modules()
+
+
+def _get_mod_deps(mod_name):
+    """Get known module dependencies.
+
+    .. note:: This does not need to be accurate in order for the client to
+        run.  This simply keeps things clean if the user decides to revert
+        changes.
+    .. warning:: If all deps are not included, it may cause incorrect parsing
+        behavior, due to enable_mod's shortcut for updating the parser's
+        currently defined modules (:method:`._add_parser_mod`)
+        This would only present a major problem in extremely atypical
+        configs that use ifmod for the missing deps.
+
+    """
+    deps = {
+        "ssl": ["setenvif", "mime", "socache_shmcb"]
+    }
+    return deps.get(mod_name, [])
 
 
 def apache_restart(apache_init_script):

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -1166,7 +1166,7 @@ def _get_mod_deps(mod_name):
         changes.
     .. warning:: If all deps are not included, it may cause incorrect parsing
         behavior, due to enable_mod's shortcut for updating the parser's
-        currently defined modules (:method:`._add_parser_mod`)
+        currently defined modules (:method:`.ApacheConfigurator._add_parser_mod`)
         This would only present a major problem in extremely atypical
         configs that use ifmod for the missing deps.
 

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -1007,7 +1007,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
 
         # Enable all dependencies
         for dep in deps:
-            if dep not in self.parser.modules:
+            if (dep + "_module") not in self.parser.modules:
                 self._enable_mod_debian(dep, temp)
                 self._add_parser_mod(dep)
 


### PR DESCRIPTION
Apache ssl module dependencies are recorded and logged so that they can be cleaned up during the revert.

This cleans up and fixes any failed tests in @bmw testing suite.

I have tested this on a few runs with various mods pre-enabled and I believe it works.

For ssl_module and its dependencies:
No mods enabled.
Some dependencies enabled.
All mods enabled