### PR TITLE
Don't run tox for temporarily-disabled python versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 # acme and letsencrypt are not yet on pypi, so when Tox invokes
 # "install *.zip", it will not find deps
 skipsdist = true
-envlist = py26,py27,py33,py34,cover,lint
+envlist = py27,cover,lint
 
 [testenv]
 commands =


### PR DESCRIPTION
Additional tweak for #630 