### PR TITLE
Make 'auth' and 'run' use the same code (fixes #771)

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -172,6 +172,9 @@ def _find_duplicative_certs(domains, config, renew_config):
     identical_names_cert, subset_names_cert = None, None
 
     configs_dir = renew_config.renewal_configs_dir
+    # Verify the directory is there
+    le_util.make_or_verify_dir(configs_dir, mode=0o755, uid=os.geteuid())
+
     cli_config = configuration.RenewerConfiguration(config)
     for renewal_file in os.listdir(configs_dir):
         try:
@@ -220,15 +223,15 @@ def _treat_as_renewal(config, domains):
         if ident_names_cert is not None:
             question = (
                 "You have an existing certificate that contains exactly the "
-                "same domains you requested (ref: {0})\n\nDo you want to "
+                "same domains you requested (ref: {0}){br}{br}Do you want to "
                 "renew and replace this certificate with a newly-issued one?"
             ).format(ident_names_cert.configfile.filename)
         elif subset_names_cert is not None:
             question = (
                 "You have an existing certificate that contains a portion of "
-                "the domains you requested (ref: {0})\n\nIt contains these "
-                "names: {1}\n\nYou requested these names for the new "
-                "certificate: {2}.\n\nDo you want to replace this existing "
+                "the domains you requested (ref: {0}){br}{br}It contains these "
+                "names: {1}{br}{br}You requested these names for the new "
+                "certificate: {2}.{br}{br}Do you want to replace this existing "
                 "certificate with the new certificate?"
             ).format(subset_names_cert.configfile.filename,
                      ", ".join(subset_names_cert.names()),
@@ -245,7 +248,7 @@ def _treat_as_renewal(config, domains):
             reporter_util.add_message(
                 "To obtain a new certificate that {0} an existing certificate "
                 "in its domain-name coverage, you must use the --duplicate "
-                "option.\n\nFor example:\n\n{1} --duplicate {2}".format(
+                "option.{br}{br}For example:{br}{br}{1} --duplicate {2}".format(
                     "duplicates" if ident_names_cert is not None else
                     "overlaps with", sys.argv[0], " ".join(sys.argv[1:])),
                 reporter_util.HIGH_PRIORITY)
@@ -285,7 +288,7 @@ def _auth_from_domains(le_client, config, domains, plugins):
 
     return lineage
 
-#  TODO: Make run as close to auth + install as possible
+# TODO: Make run as close to auth + install as possible
 # Possible difficulties: args.csr was hacked into auth
 def run(args, config, plugins):  # pylint: disable=too-many-branches,too-many-locals
     """Obtain a certificate and install."""

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -325,7 +325,7 @@ def run(args, config, plugins):  # pylint: disable=too-many-branches,too-many-lo
         domains, lineage.privkey, lineage.cert, lineage.chain)
     le_client.enhance_config(domains, args.redirect)
 
-    if lineage.available_versions("cert") == 1:
+    if len(lineage.available_versions("cert")) == 1:
         display_ops.success_installation(domains)
     else:
         display_ops.success_renewal(domains)

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -250,7 +250,7 @@ def _treat_as_renewal(config, domains):
                     "overlaps with", sys.argv[0], " ".join(sys.argv[1:])),
                 reporter_util.HIGH_PRIORITY)
             raise errors.Error(
-                "BUser did not use proper CLI and would like "
+                "User did not use proper CLI and would like "
                 "to reinvoke the client.")
 
         if renewal:
@@ -259,7 +259,7 @@ def _treat_as_renewal(config, domains):
     return None
 
 
-def auth_from_domains(le_client, config, domains, plugins):
+def _auth_from_domains(le_client, config, domains, plugins):
     """Authenticate and enroll certificate."""
     # Note: This can raise errors... caught above us though.
     lineage = _treat_as_renewal(config, domains)
@@ -312,12 +312,11 @@ def run(args, config, plugins):  # pylint: disable=too-many-branches,too-many-lo
 
     domains = _find_domains(args, installer)
 
-    # Attempting to obtain the certificate
     # TODO: Handle errors from _init_le_client?
     le_client = _init_le_client(args, config, authenticator, installer)
 
     try:
-        lineage = auth_from_domains(le_client, config, domains, plugins)
+        lineage = _auth_from_domains(le_client, config, domains, plugins)
     except errors.Error as err:
         return str(err)
 
@@ -363,7 +362,7 @@ def auth(args, config, plugins):
     else:
         domains = _find_domains(args, installer)
         try:
-            auth_from_domains(le_client, config, domains, plugins)
+            _auth_from_domains(le_client, config, domains, plugins)
         except errors.Error as err:
             return str(err)
 

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -241,8 +241,8 @@ def _treat_as_renewal(config, domains):
             # We aren't in a duplicative-names situation at all, so we don't
             # have to tell or ask the user anything about this.
             pass
-        elif zope.component.getUtility(interfaces.IDisplay).yesno(
-                question, "Replace", "Cancel"):
+        elif config.no_confirm or zope.component.getUtility(
+                interfaces.IDisplay).yesno(question, "Replace", "Cancel"):
             renewal = True
         else:
             reporter_util = zope.component.getUtility(interfaces.IReporter)
@@ -661,7 +661,7 @@ def create_parser(plugins, args):
         help="show program's version number and exit")
     helpful.add(
         "automation", "--no-confirm", dest="no_confirm", action="store_true",
-        help="Turn off confirmation screens, currently used for --revoke")
+        help="Turn off confirmation screens, used for renewal screens")
     helpful.add(
         "automation", "--agree-eula", dest="eula", action="store_true",
         help="Agree to the Let's Encrypt Developer Preview EULA")

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -323,10 +323,7 @@ def run(args, config, plugins):  # pylint: disable=too-many-branches,too-many-lo
     # TODO: Handle errors from _init_le_client?
     le_client = _init_le_client(args, config, authenticator, installer)
 
-    try:
-        lineage = _auth_from_domains(le_client, config, domains, plugins)
-    except errors.Error as err:
-        return str(err)
+    lineage = _auth_from_domains(le_client, config, domains, plugins)
 
     # TODO: We also need to pass the fullchain (for Nginx)
     le_client.deploy_certificate(
@@ -369,10 +366,7 @@ def auth(args, config, plugins):
             certr, chain, args.cert_path, args.chain_path)
     else:
         domains = _find_domains(args, installer)
-        try:
-            _auth_from_domains(le_client, config, domains, plugins)
-        except errors.Error as err:
-            return str(err)
+        _auth_from_domains(le_client, config, domains, plugins)
 
 
 def install(args, config, plugins):

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -225,7 +225,7 @@ def _treat_as_renewal(config, domains):
                 "You have an existing certificate that contains exactly the "
                 "same domains you requested (ref: {0}){br}{br}Do you want to "
                 "renew and replace this certificate with a newly-issued one?"
-            ).format(ident_names_cert.configfile.filename)
+            ).format(ident_names_cert.configfile.filename, br=os.linesep)
         elif subset_names_cert is not None:
             question = (
                 "You have an existing certificate that contains a portion of "
@@ -235,7 +235,8 @@ def _treat_as_renewal(config, domains):
                 "certificate with the new certificate?"
             ).format(subset_names_cert.configfile.filename,
                      ", ".join(subset_names_cert.names()),
-                     ", ".join(domains))
+                     ", ".join(domains),
+                     br=os.linesep)
         if question is None:
             # We aren't in a duplicative-names situation at all, so we don't
             # have to tell or ask the user anything about this.
@@ -250,7 +251,10 @@ def _treat_as_renewal(config, domains):
                 "in its domain-name coverage, you must use the --duplicate "
                 "option.{br}{br}For example:{br}{br}{1} --duplicate {2}".format(
                     "duplicates" if ident_names_cert is not None else
-                    "overlaps with", sys.argv[0], " ".join(sys.argv[1:])),
+                    "overlaps with",
+                    sys.argv[0], " ".join(sys.argv[1:]),
+                    br=os.linesep
+                ),
                 reporter_util.HIGH_PRIORITY)
             raise errors.Error(
                 "User did not use proper CLI and would like "
@@ -287,6 +291,7 @@ def _auth_from_domains(le_client, config, domains, plugins):
             raise errors.Error("Certificate could not be obtained")
 
     return lineage
+
 
 # TODO: Make run as close to auth + install as possible
 # Possible difficulties: args.csr was hacked into auth
@@ -708,7 +713,7 @@ def create_parser(plugins, args):
 
 # For now unfortunately this constant just needs to match the code below;
 # there isn't an elegant way to autogenerate it in time.
-VERBS = ["run", "auth", "install", "revoke", "rollback", "config_changes",\
+VERBS = ["run", "auth", "install", "revoke", "rollback", "config_changes",
          "plugins"]
 
 
@@ -862,7 +867,8 @@ def _handle_exception(exc_type, exc_value, trace, args):
 
     """
     logger.debug(
-        "Exiting abnormally:\n%s",
+        "Exiting abnormally:%s%s",
+        os.linesep,
         "".join(traceback.format_exception(exc_type, exc_value, trace)))
 
     if issubclass(exc_type, Exception) and (args is None or not args.debug):

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -241,7 +241,7 @@ def _treat_as_renewal(config, domains):
             # We aren't in a duplicative-names situation at all, so we don't
             # have to tell or ask the user anything about this.
             pass
-        elif config.no_confirm or zope.component.getUtility(
+        elif config.renew_by_default or zope.component.getUtility(
                 interfaces.IDisplay).yesno(question, "Replace", "Cancel"):
             renewal = True
         else:
@@ -654,8 +654,9 @@ def create_parser(plugins, args):
         version="%(prog)s {0}".format(letsencrypt.__version__),
         help="show program's version number and exit")
     helpful.add(
-        "automation", "--no-confirm", dest="no_confirm", action="store_true",
-        help="Turn off confirmation screens, used for renewal screens")
+        "automation", "--renew-by-default", action="store_true",
+        help="Select renewal by default when domains are a superset of a "
+             "a previously attained cert")
     helpful.add(
         "automation", "--agree-eula", dest="eula", action="store_true",
         help="Agree to the Let's Encrypt Developer Preview EULA")

--- a/letsencrypt/client.py
+++ b/letsencrypt/client.py
@@ -213,8 +213,7 @@ class Client(object):
 
         return self._obtain_certificate(domains, csr) + (key, csr)
 
-    def obtain_and_enroll_certificate(
-            self, domains, authenticator, installer, plugins):
+    def obtain_and_enroll_certificate(self, domains, plugins):
         """Obtain and enroll certificate.
 
         Get a new certificate for the specified domains using the specified
@@ -222,12 +221,6 @@ class Client(object):
         containing it.
 
         :param list domains: Domains to request.
-        :param authenticator: The authenticator to use.
-        :type authenticator: :class:`letsencrypt.interfaces.IAuthenticator`
-
-        :param installer: The installer to use.
-        :type installer: :class:`letsencrypt.interfaces.IInstaller`
-
         :param plugins: A PluginsFactory object.
 
         :returns: A new :class:`letsencrypt.storage.RenewableCert` instance
@@ -239,9 +232,10 @@ class Client(object):
 
         # TODO: remove this dirty hack
         self.config.namespace.authenticator = plugins.find_init(
-            authenticator).name
-        if installer is not None:
-            self.config.namespace.installer = plugins.find_init(installer).name
+            self.dv_auth).name
+        if self.installer is not None:
+            self.config.namespace.installer = plugins.find_init(
+                self.installer).name
 
         # XXX: We clearly need a more general and correct way of getting
         # options into the configobj for the RenewableCert instance.

--- a/letsencrypt/client.py
+++ b/letsencrypt/client.py
@@ -111,6 +111,8 @@ class Client(object):
     :ivar .AuthHandler auth_handler: Authorizations handler that will
         dispatch DV and Continuity challenges to appropriate
         authenticators (providing `.IAuthenticator` interface).
+    :ivar .IAuthenticator dv_auth: Prepared (`.IAuthenticator.prepare`)
+        authenticator that can solve the `.constants.DV_CHALLENGES`.
     :ivar .IInstaller installer: Installer.
     :ivar acme.client.Client acme: Optional ACME client API handle.
        You might already have one from `register`.
@@ -118,14 +120,10 @@ class Client(object):
     """
 
     def __init__(self, config, account_, dv_auth, installer, acme=None):
-        """Initialize a client.
-
-        :param .IAuthenticator dv_auth: Prepared (`.IAuthenticator.prepare`)
-            authenticator that can solve the `.constants.DV_CHALLENGES`.
-
-        """
+        """Initialize a client."""
         self.config = config
         self.account = account_
+        self.dv_auth = dv_auth
         self.installer = installer
 
         # Initialize ACME if account is provided

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -177,7 +177,7 @@ class DuplicativeCertsTest(renewer_test.BaseRenewableCertTest):
         shutil.rmtree(self.tempdir)
 
     @mock.patch("letsencrypt.le_util.make_or_verify_dir")
-    def test_find_duplicative_names(self, unused):
+    def test_find_duplicative_names(self, unused):  # pylint: disable=unused-argument
         from letsencrypt.cli import _find_duplicative_certs
         test_cert = test_util.load_vector("cert-san.pem")
         with open(self.test_rc.cert, "w") as f:

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -176,7 +176,8 @@ class DuplicativeCertsTest(renewer_test.BaseRenewableCertTest):
     def tearDown(self):
         shutil.rmtree(self.tempdir)
 
-    def test_find_duplicative_names(self):
+    @mock.patch("letsencrypt.le_util.make_or_verify_dir")
+    def test_find_duplicative_names(self, unused):
         from letsencrypt.cli import _find_duplicative_certs
         test_cert = test_util.load_vector("cert-san.pem")
         with open(self.test_rc.cert, "w") as f:

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -177,7 +177,7 @@ class DuplicativeCertsTest(renewer_test.BaseRenewableCertTest):
         shutil.rmtree(self.tempdir)
 
     @mock.patch("letsencrypt.le_util.make_or_verify_dir")
-    def test_find_duplicative_names(self, unused):  # pylint: disable=unused-argument
+    def test_find_duplicative_names(self, unused_makedir):
         from letsencrypt.cli import _find_duplicative_certs
         test_cert = test_util.load_vector("cert-san.pem")
         with open(self.test_rc.cert, "w") as f:

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -206,5 +206,5 @@ class DuplicativeCertsTest(renewer_test.BaseRenewableCertTest):
         self.assertEqual(result, (None, None))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()  # pragma: no cover

--- a/letsencrypt/tests/configuration_test.py
+++ b/letsencrypt/tests/configuration_test.py
@@ -59,9 +59,9 @@ class RenewerConfigurationTest(unittest.TestCase):
 
     @mock.patch('letsencrypt.configuration.constants')
     def test_dynamic_dirs(self, constants):
-        constants.ARCHIVE_DIR = "a"
+        constants.ARCHIVE_DIR = 'a'
         constants.LIVE_DIR = 'l'
-        constants.RENEWAL_CONFIGS_DIR = "renewal_configs"
+        constants.RENEWAL_CONFIGS_DIR = 'renewal_configs'
         constants.RENEWER_CONFIG_FILENAME = 'r.conf'
 
         self.assertEqual(self.config.archive_dir, '/tmp/config/a')

--- a/letsencrypt/tests/crypto_util_test.py
+++ b/letsencrypt/tests/crypto_util_test.py
@@ -6,7 +6,9 @@ import unittest
 
 import OpenSSL
 import mock
+import zope.component
 
+from letsencrypt import interfaces
 from letsencrypt.tests import test_util
 
 
@@ -20,6 +22,8 @@ class InitSaveKeyTest(unittest.TestCase):
     """Tests for letsencrypt.crypto_util.init_save_key."""
     def setUp(self):
         logging.disable(logging.CRITICAL)
+        zope.component.provideUtility(
+            mock.Mock(strict_permissions=True), interfaces.IConfig)
         self.key_dir = tempfile.mkdtemp('key_dir')
 
     def tearDown(self):
@@ -48,6 +52,8 @@ class InitSaveCSRTest(unittest.TestCase):
     """Tests for letsencrypt.crypto_util.init_save_csr."""
 
     def setUp(self):
+        zope.component.provideUtility(
+            mock.Mock(strict_permissions=True), interfaces.IConfig)
         self.csr_dir = tempfile.mkdtemp('csr_dir')
 
     def tearDown(self):

--- a/letsencrypt/tests/renewer_test.py
+++ b/letsencrypt/tests/renewer_test.py
@@ -33,7 +33,12 @@ def fill_with_sample_data(rc_object):
 
 
 class BaseRenewableCertTest(unittest.TestCase):
+    """Base class for setting up Renewable Cert tests.
 
+    .. note:: It may be required to write out self.config for
+    your test.  Check :class:`.cli_test.DuplicateCertTest` for an example.
+
+    """
     def setUp(self):
         from letsencrypt import storage
         self.tempdir = tempfile.mkdtemp()

--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -23,7 +23,7 @@ letsencrypt_test () {
         --agree-eula \
         --agree-tos \
         --email "" \
-        --no-confirm \
+        --renew-by-default \
         --debug \
         -vvvvvvv \
         "$@"

--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -23,6 +23,7 @@ letsencrypt_test () {
         --agree-eula \
         --agree-tos \
         --email "" \
+        --no-confirm \
         --debug \
         -vvvvvvv \
         "$@"


### PR DESCRIPTION
This is a refactoring of the renew lineage under the run command.  This extends it to also work with auth.

I believe I tested all of the common cases through integration testing.

(These functions could really use unittests, but I didn't investigate the exact proper renewer behavior in order to guarantee correctness.  @schoen might want to do this later as he is most familiar with the renewer code and wrote the functionality originally)

If you are interested in testing this out... I might recommend checking out the cert_manager branch (which is already merged with this branch).  It makes viewing/modifying the structure of the certificates much easier.  With cert_manager, it is possible to run ```venv/bin/letsencrypt revoke``` which gives you menu with all of the certificates and their layout.