### PR TITLE
Make boulder-start.sh more robust & helpful

### DIFF
--- a/tests/boulder-start.sh
+++ b/tests/boulder-start.sh
@@ -1,5 +1,22 @@
-#!/bin/sh -xe
+#!/bin/bash
 # Download and run Boulder instance for integration testing
+
+
+# ugh, go version output is like:
+# go version go1.4.2 linux/amd64
+GOVER=`go version | cut -d" " -f3 | cut -do -f2`  
+
+# version comparison
+function verlte {
+    [  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
+}
+
+if ! verlte 1.5 "$GOVER" ; then
+  echo "We require go version 1.5 or later; you have... $GOVER"
+  exit 1
+fi
+
+set -xe
 
 export GOPATH="${GOPATH:-/tmp/go}"
 
@@ -8,7 +25,11 @@ export GOPATH="${GOPATH:-/tmp/go}"
 go get -d github.com/letsencrypt/boulder/...
 cd $GOPATH/src/github.com/letsencrypt/boulder
 # goose is needed for ./test/create_db.sh
-go get bitbucket.org/liamstask/goose/cmd/goose
+if ! go get bitbucket.org/liamstask/goose/cmd/goose ; then
+  echo Problems installing goose... perhaps rm -rf \$GOPATH \("$GOPATH"\)
+  echo and try again...
+  exit 1
+fi
 ./test/create_db.sh
 ./start.py &
 # Hopefully start.py bootstraps before integration test is started...


### PR DESCRIPTION
Don't try to run with go versions that are going to fail, and perhaps detect broken states if that happened in the past.