### PR TITLE
Replace mktemp with mkstemp

### DIFF
--- a/letsencrypt/revoker.py
+++ b/letsencrypt/revoker.py
@@ -288,12 +288,12 @@ class Revoker(object):
             :class:`letsencrypt.revoker.Cert`
 
         """
-        _, list_path2 = tempfile.mkstemp(".tmp", "LIST")
+        newfile_handle, list_path2 = tempfile.mkstemp(".tmp", "LIST")
         idx = 0
 
         with open(self.list_path, "rb") as orgfile:
             csvreader = csv.reader(orgfile)
-            with open(list_path2, "wb") as newfile:
+            with os.fdopen(newfile_handle, "wb") as newfile:
                 csvwriter = csv.writer(newfile)
 
                 for row in csvreader:
@@ -308,7 +308,7 @@ class Revoker(object):
                 "Did not find all cert_list items to remove from LIST")
 
         shutil.copy2(list_path2, self.list_path)
-        os.remove(list_path2)
+        newfile.close()
 
     def _row_to_backup(self, row):
         """Convenience function

--- a/letsencrypt/revoker.py
+++ b/letsencrypt/revoker.py
@@ -308,7 +308,7 @@ class Revoker(object):
                 "Did not find all cert_list items to remove from LIST")
 
         shutil.copy2(list_path2, self.list_path)
-        newfile.close()
+        os.remove(list_path2)
 
     def _row_to_backup(self, row):
         """Convenience function

--- a/letsencrypt/revoker.py
+++ b/letsencrypt/revoker.py
@@ -288,7 +288,7 @@ class Revoker(object):
             :class:`letsencrypt.revoker.Cert`
 
         """
-        list_path2 = tempfile.mktemp(".tmp", "LIST")
+        _, list_path2 = tempfile.mkstemp(".tmp", "LIST")
         idx = 0
 
         with open(self.list_path, "rb") as orgfile:


### PR DESCRIPTION
I'm using [Bandit](https://github.com/openstack/bandit) to evaluate potential vulnerabilities in a few Python projects and came across one here:

```
>> Issue: Use of insecure and deprecated function (mktemp).
   Severity: Medium   Confidence: High
   Location: letsencrypt/letsencrypt/revoker.py:291
287         :param list cert_list: Must contain valid certs, each is of type
288             :class:`letsencrypt.revoker.Cert`
289
290         """
291         list_path2 = tempfile.mktemp(".tmp", "LIST")
292         idx = 0
293
294         with open(self.list_path, "rb") as orgfile:

```

As per [Python's documentation](https://docs.python.org/2/library/tempfile.html#tempfile.mktemp) and the [OpenStack security docs](https://security.openstack.org/guidelines/dg_using-temporary-files-securely.html), we should use one of the following as a replacement for tempfile.mktemp: tempfile.mkstemp (for files), tempfile.mkdtemp (for dirs), or tempfile.NamedTemporaryFile. 

I went with mkstemp in this case. The first parameter, which we're referencing as an underscore, is the filehandle.

Please let me know if you have any questions. Thanks!