### PR TITLE
Mac OSX bootstrap: Add dialog dependency and homebrew installation

### DIFF
--- a/bootstrap/mac.sh
+++ b/bootstrap/mac.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
-if hash brew 2>/dev/null; then
-    echo "Homebrew Installed"
-else
+if ! hash brew 2>/dev/null; then
     echo "Homebrew Not Installed\nDownloading..."
     ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 fi

--- a/bootstrap/mac.sh
+++ b/bootstrap/mac.sh
@@ -1,2 +1,10 @@
 #!/bin/sh
+if hash brew 2>/dev/null; then
+    echo "Homebrew Installed"
+else
+    echo "Homebrew Not Installed\nDownloading..."
+    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+fi
+
 brew install augeas
+brew install dialog


### PR DESCRIPTION
Add dialog dependency identified in #413 and install homebrew for user if not currently installed