### PR TITLE
Remove Hardcoded Signature

### DIFF
--- a/letsencrypt/plugins/manual_test.py
+++ b/letsencrypt/plugins/manual_test.py
@@ -58,8 +58,7 @@ class ManualAuthenticatorTest(unittest.TestCase):
             self.achalls[0].challb.chall, "foo.com", KEY.public_key(), 4430)
 
         message = mock_stdout.write.mock_calls[0][1][0]
-        token = self.achalls[0].challb.chall.encode("token")
-        self.assertTrue(token in message)
+        self.assertTrue(self.achalls[0].chall.encode("token") in message)
 
         mock_verify.return_value = False
         self.assertEqual([None], self.auth.perform(self.achalls))


### PR DESCRIPTION
Recently, `tox` began failing for me locally for me due to the following error:

```
======================================================================
FAIL: test_perform (letsencrypt.plugins.manual_test.ManualAuthenticatorTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/bmw/Code/le/.tox/py27/lib/python2.7/site-packages/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/home/bmw/Code/le/letsencrypt/plugins/manual_test.py", line 83, in test_perform
    s.serve_forever()" \n""")
AssertionError: 'Make sure your web server displays the following content at\nhttp://foo.com/.well-known/acme-challenge/ZXZhR3hmQURzNnBTUmIyTEF2OUlaZjE3RHQzanV4R0orUEN0OTJ3citvQQ before continuing:\n\n{"header": {"alg": "RS256", "jwk": {"e": "AQAB", "kty": "RSA", "n": "rHVztFHtH92ucFJD_N_HW9AsdRsUuHUBBBDlHwNlRd3fp580rv2-6QWE30cWgdmJS86ObRz6lUTor4R0T-3C5Q"}}, "payload": "eyJ0bHMiOiBmYWxzZSwgInRva2VuIjogIlpYWmhSM2htUVVSek5uQlRVbUl5VEVGMk9VbGFaakUzUkhRemFuVjRSMG9yVUVOME9USjNjaXR2UVEiLCAidHlwZSI6ICJzaW1wbGVIdHRwIn0", "signature": "R9SBqaLIXJ84TBT8l-QcZ8dkcOeCbJJjulQ9m9Z65LPAWpNH0lJwIW-hUrgRoDRD-Q4zyda1dOC3B4F5dQ9a4A"}\n\nContent-Type header MUST be set to application/jose+json.\n\nIf you don\'t have HTTP server configured, you can run the following\ncommand on the target server (as root):\n\nmkdir -p /tmp/letsencrypt/public_html/.well-known/acme-challenge\ncd /tmp/letsencrypt/public_html\necho -n \'{"header": {"alg": "RS256", "jwk": {"e": "AQAB", "kty": "RSA", "n": "rHVztFHtH92ucFJD_N_HW9AsdRsUuHUBBBDlHwNlRd3fp580rv2-6QWE30cWgdmJS86ObRz6lUTor4R0T-3C5Q"}}, "payload": "eyJ0bHMiOiBmYWxzZSwgInRva2VuIjogIlpYWmhSM2htUVVSek5uQlRVbUl5VEVGMk9VbGFaakUzUkhRemFuVjRSMG9yVUVOME9USjNjaXR2UVEiLCAidHlwZSI6ICJzaW1wbGVIdHRwIn0", "signature": "R9SBqaLIXJ84TBT8l-QcZ8dkcOeCbJJjulQ9m9Z65LPAWpNH0lJwIW-hUrgRoDRD-Q4zyda1dOC3B4F5dQ9a4A"}\' > .well-known/acme-challenge/ZXZhR3hmQURzNnBTUmIyTEF2OUlaZjE3RHQzanV4R0orUEN0OTJ3citvQQ\n# run only once per server:\n$(command -v python2 || command -v python2.7 || command -v python2.6) -c \\\n"import BaseHTTPServer, SimpleHTTPServer; \\\nSimpleHTTPServer.SimpleHTTPRequestHandler.extensions_map = {\'\': \'application/jose+json\'}; \\\ns = BaseHTTPServer.HTTPServer((\'\', 4430), SimpleHTTPServer.SimpleHTTPRequestHandler); \\\ns.serve_forever()" \n' != 'Make sure your web server displays the following content at\nhttp://foo.com/.well-known/acme-challenge/ZXZhR3hmQURzNnBTUmIyTEF2OUlaZjE3RHQzanV4R0orUEN0OTJ3citvQQ before continuing:\n\n{"header": {"alg": "RS256", "jwk": {"e": "AQAB", "kty": "RSA", "n": "rHVztFHtH92ucFJD_N_HW9AsdRsUuHUBBBDlHwNlRd3fp580rv2-6QWE30cWgdmJS86ObRz6lUTor4R0T-3C5Q"}}, "payload": "eyJ0bHMiOiBmYWxzZSwgInRva2VuIjogIlpYWmhSM2htUVVSek5uQlRVbUl5VEVGMk9VbGFaakUzUkhRemFuVjRSMG9yVUVOME9USjNjaXR2UVEiLCAidHlwZSI6ICJzaW1wbGVIdHRwIn0", "signature": "jFPJFC-2eRyBw7Sl0wyEBhsdvRZtKk8hc6HykEPAiofZlIwdIu76u2xHqMVZWSZdpxwMNUnnawTEAqgMWFydMA"}\n\nContent-Type header MUST be set to application/jose+json.\n\nIf you don\'t have HTTP server configured, you can run the following\ncommand on the target server (as root):\n\nmkdir -p /tmp/letsencrypt/public_html/.well-known/acme-challenge\ncd /tmp/letsencrypt/public_html\necho -n \'{"header": {"alg": "RS256", "jwk": {"e": "AQAB", "kty": "RSA", "n": "rHVztFHtH92ucFJD_N_HW9AsdRsUuHUBBBDlHwNlRd3fp580rv2-6QWE30cWgdmJS86ObRz6lUTor4R0T-3C5Q"}}, "payload": "eyJ0bHMiOiBmYWxzZSwgInRva2VuIjogIlpYWmhSM2htUVVSek5uQlRVbUl5VEVGMk9VbGFaakUzUkhRemFuVjRSMG9yVUVOME9USjNjaXR2UVEiLCAidHlwZSI6ICJzaW1wbGVIdHRwIn0", "signature": "jFPJFC-2eRyBw7Sl0wyEBhsdvRZtKk8hc6HykEPAiofZlIwdIu76u2xHqMVZWSZdpxwMNUnnawTEAqgMWFydMA"}\' > .well-known/acme-challenge/ZXZhR3hmQURzNnBTUmIyTEF2OUlaZjE3RHQzanV4R0orUEN0OTJ3citvQQ\n# run only once per server:\n$(command -v python2 || command -v python2.7 || command -v python2.6) -c \\\n"import BaseHTTPServer, SimpleHTTPServer; \\\nSimpleHTTPServer.SimpleHTTPRequestHandler.extensions_map = {\'\': \'application/jose+json\'}; \\\ns = BaseHTTPServer.HTTPServer((\'\', 4430), SimpleHTTPServer.SimpleHTTPRequestHandler); \\\ns.serve_forever()" \n'

----------------------------------------------------------------------
```

Examining the output of `strace`, some requests for `urandom` get through instead of returning the dummy value. This PR fixes this by removing the hardcoded value.