### PR TITLE
Update Dockerfile-dev and instructions.

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -32,7 +32,7 @@ RUN /opt/letsencrypt/src/ubuntu.sh && \
 # the above is not likely to change, so by putting it further up the
 # Dockerfile we make sure we cache as much as possible
 
-COPY setup.py README.rst CHANGES.rst MANIFEST.in requirements.txt EULA linter_plugin.py tox.cover.sh tox.ini /opt/letsencrypt/src/
+COPY setup.py README.rst CHANGES.rst MANIFEST.in requirements.txt EULA linter_plugin.py tox.cover.sh tox.ini pep8.travis.sh .pep8 .pylintrc /opt/letsencrypt/src/
 
 # all above files are necessary for setup.py, however, package source
 # code directory has to be copied separately to a subdirectory...
@@ -46,6 +46,8 @@ COPY letsencrypt /opt/letsencrypt/src/letsencrypt/
 COPY acme /opt/letsencrypt/src/acme/
 COPY letsencrypt-apache /opt/letsencrypt/src/letsencrypt-apache/
 COPY letsencrypt-nginx /opt/letsencrypt/src/letsencrypt-nginx/
+COPY letshelp-letsencrypt /opt/letsencrypt/src/letshelp-letsencrypt/
+COPY letsencrypt-compatibility-test /opt/letsencrypt/src/letsencrypt-compatibility-test/
 COPY tests /opt/letsencrypt/src/tests/
 
 RUN virtualenv --no-site-packages -p python2 /opt/letsencrypt/venv && \
@@ -55,6 +57,8 @@ RUN virtualenv --no-site-packages -p python2 /opt/letsencrypt/venv && \
     -e /opt/letsencrypt/src \
     -e /opt/letsencrypt/src/letsencrypt-apache \
     -e /opt/letsencrypt/src/letsencrypt-nginx \
+    -e /opt/letsencrypt/src/letshelp-letsencrypt \
+    -e /opt/letsencrypt/src/letsencrypt-compatibility-test \
     -e /opt/letsencrypt/src[dev,docs,testing]
 
 # install in editable mode (-e) to save space: it's not possible to

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -129,9 +129,8 @@ Docker
 
 OSX users will probably find it easiest to set up a Docker container for
 development. Let's Encrypt comes with a Dockerfile (``Dockerfile-dev``)
-for doing so. To use Docker on OSX, install boot2docker using the
-instructions at https://docs.docker.com/installation/mac/ and start it
-from the command line (``boot2docker init``).
+for doing so. To use Docker on OSX, install and setup docker-machine using the
+instructions at https://docs.docker.com/installation/mac/.
 
 To build the development Docker image::
 


### PR DESCRIPTION
1. boot2docker is deprecated in favor of docker-machine
2. update dockerfile-dev to include new files