### PR TITLE
Apache include quotes

### DIFF
--- a/letsencrypt-apache/letsencrypt_apache/parser.py
+++ b/letsencrypt-apache/letsencrypt_apache/parser.py
@@ -390,6 +390,9 @@ class ApacheParser(object):
         #     logger.error("Error: Invalid regexp characters in %s", arg)
         #     return []
 
+        # Remove beginning and ending quotes
+        arg = arg.strip("'\"")
+
         # Standardize the include argument based on server root
         if not arg.startswith("/"):
             # Normpath will condense ../

--- a/letsencrypt-apache/letsencrypt_apache/parser.py
+++ b/letsencrypt-apache/letsencrypt_apache/parser.py
@@ -241,6 +241,10 @@ class ApacheParser(object):
         Directives should be in the form of a case insensitive regex currently
 
         .. todo:: arg should probably be a list
+        .. todo:: arg search currently only supports direct matching. It does
+            not handle the case of variables or quoted arguments. This should
+            be adapted to use a generic search for the directive and then do a
+            case-insensitive self.get_arg filter
 
         Note: Augeas is inherently case sensitive while Apache is case
         insensitive.  Augeas 1.0 allows case insensitive regexes like

--- a/letsencrypt-apache/letsencrypt_apache/parser.py
+++ b/letsencrypt-apache/letsencrypt_apache/parser.py
@@ -315,6 +315,14 @@ class ApacheParser(object):
 
         """
         value = self.aug.get(match)
+
+        # No need to strip quotes for variables, as apache2ctl already does this
+        # but we do need to strip quotes for all normal arguments.
+
+        # Note: normal argument may be a quoted variable
+        # e.g. strip now, not later
+        value = value.strip("'\"")
+
         variables = ApacheParser.arg_var_interpreter.findall(value)
 
         for var in variables:

--- a/letsencrypt-apache/letsencrypt_apache/tests/complex_parsing_test.py
+++ b/letsencrypt-apache/letsencrypt_apache/tests/complex_parsing_test.py
@@ -32,6 +32,7 @@ class ComplexParserTest(util.ParserTest):
                 "COMPLEX": "",
                 "tls_port": "1234",
                 "fnmatch_filename": "test_fnmatch.conf",
+                "tls_port_str": "1234"
             }
         )
 
@@ -45,6 +46,12 @@ class ComplexParserTest(util.ParserTest):
 
     def test_basic_variable_parsing(self):
         matches = self.parser.find_dir("TestVariablePort")
+
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(self.parser.get_arg(matches[0]), "1234")
+
+    def test_basic_variable_parsing_quotes(self):
+        matches = self.parser.find_dir("TestVariablePortStr")
 
         self.assertEqual(len(matches), 1)
         self.assertEqual(self.parser.get_arg(matches[0]), "1234")

--- a/letsencrypt-apache/letsencrypt_apache/tests/complex_parsing_test.py
+++ b/letsencrypt-apache/letsencrypt_apache/tests/complex_parsing_test.py
@@ -78,7 +78,7 @@ class ComplexParserTest(util.ParserTest):
         # This is in an IfDefine
         self.assertTrue("ssl_module" in self.parser.modules)
         self.assertTrue("mod_ssl.c" in self.parser.modules)
-
+    #
     def verify_fnmatch(self, arg, hit=True):
         """Test if Include was correctly parsed."""
         from letsencrypt_apache import parser
@@ -89,6 +89,7 @@ class ComplexParserTest(util.ParserTest):
         else:
             self.assertFalse(self.parser.find_dir("FNMATCH_DIRECTIVE"))
 
+    # NOTE: Only run one test per function otherwise you will have inf recursion
     def test_include(self):
         self.verify_fnmatch("test_fnmatch.?onf")
 
@@ -100,6 +101,12 @@ class ComplexParserTest(util.ParserTest):
 
     def test_include_fullpath_trailing_slash(self):
         self.verify_fnmatch(self.config_path + "//")
+
+    def test_include_single_quotes(self):
+        self.verify_fnmatch("'" + self.config_path + "'")
+
+    def test_include_double_quotes(self):
+        self.verify_fnmatch('"' + self.config_path + '"')
 
     def test_include_variable(self):
         self.verify_fnmatch("../complex_parsing/${fnmatch_filename}")

--- a/letsencrypt-apache/letsencrypt_apache/tests/complex_parsing_test.py
+++ b/letsencrypt-apache/letsencrypt_apache/tests/complex_parsing_test.py
@@ -85,7 +85,7 @@ class ComplexParserTest(util.ParserTest):
         # This is in an IfDefine
         self.assertTrue("ssl_module" in self.parser.modules)
         self.assertTrue("mod_ssl.c" in self.parser.modules)
-    
+
     def verify_fnmatch(self, arg, hit=True):
         """Test if Include was correctly parsed."""
         from letsencrypt_apache import parser

--- a/letsencrypt-apache/letsencrypt_apache/tests/complex_parsing_test.py
+++ b/letsencrypt-apache/letsencrypt_apache/tests/complex_parsing_test.py
@@ -85,7 +85,7 @@ class ComplexParserTest(util.ParserTest):
         # This is in an IfDefine
         self.assertTrue("ssl_module" in self.parser.modules)
         self.assertTrue("mod_ssl.c" in self.parser.modules)
-    #
+    
     def verify_fnmatch(self, arg, hit=True):
         """Test if Include was correctly parsed."""
         from letsencrypt_apache import parser

--- a/letsencrypt-apache/letsencrypt_apache/tests/testdata/complex_parsing/apache2.conf
+++ b/letsencrypt-apache/letsencrypt_apache/tests/testdata/complex_parsing/apache2.conf
@@ -46,6 +46,8 @@ IncludeOptional sites-enabled/*.conf
 Define COMPLEX
 
 Define tls_port 1234
+Define tls_port_str "1234"
+
 Define fnmatch_filename test_fnmatch.conf
 
 

--- a/letsencrypt-apache/letsencrypt_apache/tests/testdata/complex_parsing/test_variables.conf
+++ b/letsencrypt-apache/letsencrypt_apache/tests/testdata/complex_parsing/test_variables.conf
@@ -1,4 +1,5 @@
 TestVariablePort ${tls_port}
+TestVariablePortStr "${tls_port_str}"
 
 LoadModule status_module modules/mod_status.so
 


### PR DESCRIPTION
A follow up of #781 except for single and double quotes around Include directive parameters

I played around with the parsing a bit, and think that this handles all valid cases of quotes in Include directives.

I also decided to play around with quotes around arguments and was disappointed to learn that they also appear valid.  ie.  Listen "80" is valid.

I went through and fixed all Include directive searches.  I then setup the framework for getting arguments correctly.  I made a note about the current limitations of find_dir and gave a path forward.  I will file an associated issue.