### PR TITLE
ManualAuthenticator -> Authenticator

### DIFF
--- a/letsencrypt/plugins/manual.py
+++ b/letsencrypt/plugins/manual.py
@@ -23,7 +23,7 @@ from letsencrypt.plugins import common
 logger = logging.getLogger(__name__)
 
 
-class ManualAuthenticator(common.Plugin):
+class Authenticator(common.Plugin):
     """Manual Authenticator.
 
     .. todo:: Support for `~.challenges.DVSNI`.
@@ -87,7 +87,7 @@ s.serve_forever()" """
     """
 
     def __init__(self, *args, **kwargs):
-        super(ManualAuthenticator, self).__init__(*args, **kwargs)
+        super(Authenticator, self).__init__(*args, **kwargs)
         self.template = (self.HTTP_TEMPLATE if self.config.no_simple_http_tls
                          else self.HTTPS_TEMPLATE)
         self._root = (tempfile.mkdtemp() if self.conf("test-mode")

--- a/letsencrypt/plugins/manual_test.py
+++ b/letsencrypt/plugins/manual_test.py
@@ -17,22 +17,22 @@ from letsencrypt.tests import test_util
 KEY = jose.JWKRSA.load(test_util.load_vector("rsa512_key.pem"))
 
 
-class ManualAuthenticatorTest(unittest.TestCase):
-    """Tests for letsencrypt.plugins.manual.ManualAuthenticator."""
+class AuthenticatorTest(unittest.TestCase):
+    """Tests for letsencrypt.plugins.manual.Authenticator."""
 
     def setUp(self):
-        from letsencrypt.plugins.manual import ManualAuthenticator
+        from letsencrypt.plugins.manual import Authenticator
         self.config = mock.MagicMock(
             no_simple_http_tls=True, simple_http_port=4430,
             manual_test_mode=False)
-        self.auth = ManualAuthenticator(config=self.config, name="manual")
+        self.auth = Authenticator(config=self.config, name="manual")
         self.achalls = [achallenges.SimpleHTTP(
             challb=acme_util.SIMPLE_HTTP_P, domain="foo.com", account_key=KEY)]
 
         config_test_mode = mock.MagicMock(
             no_simple_http_tls=True, simple_http_port=4430,
             manual_test_mode=True)
-        self.auth_test_mode = ManualAuthenticator(
+        self.auth_test_mode = Authenticator(
             config=config_test_mode, name="manual")
 
     def test_more_info(self):

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ setup(
             'letsencrypt-renewer = letsencrypt.renewer:main',
         ],
         'letsencrypt.plugins': [
-            'manual = letsencrypt.plugins.manual:ManualAuthenticator',
+            'manual = letsencrypt.plugins.manual:Authenticator',
             # TODO: null should probably not be presented to the user
             'null = letsencrypt.plugins.null:Installer',
             'standalone = letsencrypt.plugins.standalone.authenticator'


### PR DESCRIPTION
Step towards unifying plugin class names (new standalone, or current `null.Installer` also follow this scheme).