### PR TITLE
config/work/logs dirs in ~ (XDG Base Directory Spec).

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ WORKDIR /opt/letsencrypt
 # If <dest> doesn't exist, it is created along with all missing
 # directories in its path.
 
+COPY examples/debian-cli.ini /root/.config/letsencrypt/cli.ini
 COPY bootstrap/ubuntu.sh /opt/letsencrypt/src/
 RUN /opt/letsencrypt/src/ubuntu.sh && \
     apt-get clean && \

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -22,6 +22,7 @@ WORKDIR /opt/letsencrypt
 
 # TODO: Install non-default Python versions for tox.
 # TODO: Install Apache/Nginx for plugin development.
+COPY examples/debian-cli.ini /root/.config/letsencrypt/cli.ini
 COPY bootstrap/ubuntu.sh /opt/letsencrypt/src/
 RUN /opt/letsencrypt/src/ubuntu.sh && \
     apt-get clean && \

--- a/examples/debian-cli.ini
+++ b/examples/debian-cli.ini
@@ -1,0 +1,5 @@
+# If you're using Debian/Ubuntu, put this file into
+# /etc/letsencrypt/cli.ini
+config-dir = /etc/letsencrypt
+work-dir = /var/lib/letsencrypt
+logs-dir = /var/log/letsencrypt

--- a/letsencrypt/constants.py
+++ b/letsencrypt/constants.py
@@ -8,20 +8,24 @@ from acme import challenges
 SETUPTOOLS_PLUGINS_ENTRY_POINT = "letsencrypt.plugins"
 """Setuptools entry point group name for plugins."""
 
+# http://standards.freedesktop.org/basedir-spec/latest/ar01s03.html
+XDG_CONFIG_HOME = os.path.expanduser(
+    os.environ.get("XDG_CONFIG_HOME", "~/.config"))
+XDG_DATA_HOME = os.path.expanduser(
+    os.environ.get("XDG_DATA_HOME", "~/.local/share"))
+
 CLI_DEFAULTS = dict(
     config_files=[
         "/etc/letsencrypt/cli.ini",
-        # http://freedesktop.org/wiki/Software/xdg-user-dirs/
-        os.path.join(os.environ.get("XDG_CONFIG_HOME", "~/.config"),
-                     "letsencrypt", "cli.ini"),
+        os.path.join(XDG_CONFIG_HOME, "letsencrypt", "cli.ini"),
     ],
     verbose_count=-(logging.WARNING / 10),
     server="https://acme-staging.api.letsencrypt.org/directory",
     rsa_key_size=2048,
     rollback_checkpoints=1,
-    config_dir="/etc/letsencrypt",
-    work_dir="/var/lib/letsencrypt",
-    logs_dir="/var/log/letsencrypt",
+    config_dir=os.path.join(XDG_CONFIG_HOME, "letsencrypt"),
+    work_dir=os.path.join(XDG_DATA_HOME, "letsencrypt", "work"),
+    logs_dir=os.path.join(XDG_DATA_HOME, "letsencrypt", "logs"),
     no_verify_ssl=False,
     dvsni_port=challenges.DVSNI.PORT,
 


### PR DESCRIPTION
`letsencrypt plugins` should now work without sudo, yay! :)

This change requires users to manually move:
- /etc/letsencrypt to ~/.config/letsencrypt
- /var/lib/letsencrypt to ~/.local/share/letsencrypt/work
- /var/log/letsencrypt to ~/.local/share/letsencrypt/logs

Otherwise new account, keys, lineages and certs will be issued on the
first invocation of the client.