### PR TITLE
Emit error when simple_verify fails.

### DIFF
--- a/letsencrypt/plugins/manual.py
+++ b/letsencrypt/plugins/manual.py
@@ -182,6 +182,8 @@ binary for temporary key/certificate generation.""".replace("\n", "")
                 achall.account_key.public_key(), self.config.simple_http_port):
             return response
         else:
+            logger.error(
+                "Self-verify of challenge failed, authorization abandoned.\n")
             if self.conf("test-mode") and self._httpd.poll() is not None:
                 # simply verify cause command failure...
                 return False

--- a/letsencrypt/plugins/manual.py
+++ b/letsencrypt/plugins/manual.py
@@ -183,7 +183,7 @@ binary for temporary key/certificate generation.""".replace("\n", "")
             return response
         else:
             logger.error(
-                "Self-verify of challenge failed, authorization abandoned.\n")
+                "Self-verify of challenge failed, authorization abandoned.")
             if self.conf("test-mode") and self._httpd.poll() is not None:
                 # simply verify cause command failure...
                 return False


### PR DESCRIPTION
When running the manual authenticator, if simple_verify fails, there is no
output to indicate what went wrong, just "Incomplete authorizations."