### PR TITLE
Remove `signal.SIGPWR` from error_handler.py

### DIFF
--- a/letsencrypt/error_handler.py
+++ b/letsencrypt/error_handler.py
@@ -2,7 +2,6 @@
 import logging
 import os
 import signal
-import sys
 import traceback
 
 
@@ -14,14 +13,9 @@ logger = logging.getLogger(__name__)
 # potentially occur from inside Python. Signals such as SIGILL were not
 # included as they could be a sign of something devious and we should terminate
 # immediately.
-if os.name == "nt":
-    _SIGNALS = [signal.SIGTERM]
-elif sys.platform == "darwin":
-    _SIGNALS = [signal.SIGTERM, signal.SIGHUP, signal.SIGQUIT, signal.SIGXCPU,
-                signal.SIGXFSZ]
-else:
-    _SIGNALS = [signal.SIGTERM, signal.SIGHUP, signal.SIGQUIT, signal.SIGXCPU,
-                signal.SIGXFSZ, signal.SIGPWR]
+_SIGNALS = ([signal.SIGTERM] if os.name == "nt" else
+            [signal.SIGTERM, signal.SIGHUP, signal.SIGQUIT,
+             signal.SIGXCPU, signal.SIGXFSZ])
 
 
 class ErrorHandler(object):


### PR DESCRIPTION
As pointed out over the weekend, `signal.SIGPWR` isn't specified in POSIX and causes issues on systems such as Mac OS X. While special casing OS X helps, it could cause issues on other systems as well and I think it's better to remove handling for the signal entirely.