### PR TITLE
Report cert issuance to the user

### DIFF
--- a/letsencrypt/account.py
+++ b/letsencrypt/account.py
@@ -92,13 +92,13 @@ def report_new_account(acc, config):
         "contain certificates and private keys obtained by Let's Encrypt "
         "so making regular backups of this folder is ideal.".format(
             config.config_dir),
-        reporter.MEDIUM_PRIORITY, True)
+        reporter.MEDIUM_PRIORITY)
 
     if acc.regr.body.emails:
         recovery_msg = ("If you lose your account credentials, you can "
                         "recover through e-mails sent to {0}.".format(
                             ", ".join(acc.regr.body.emails)))
-        reporter.add_message(recovery_msg, reporter.HIGH_PRIORITY, True)
+        reporter.add_message(recovery_msg, reporter.HIGH_PRIORITY)
 
 
 class AccountMemoryStorage(interfaces.AccountStorage):

--- a/letsencrypt/auth_handler.py
+++ b/letsencrypt/auth_handler.py
@@ -531,7 +531,7 @@ def _report_failed_challs(failed_achalls):
     reporter = zope.component.getUtility(interfaces.IReporter)
     for achalls in problems.itervalues():
         reporter.add_message(
-            _generate_failed_chall_msg(achalls), reporter.MEDIUM_PRIORITY, True)
+            _generate_failed_chall_msg(achalls), reporter.MEDIUM_PRIORITY)
 
 
 def _generate_failed_chall_msg(failed_achalls):

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -267,6 +267,14 @@ def _treat_as_renewal(config, domains):
     return None
 
 
+def _report_new_cert(cert_path):
+    """Reports the creation of a new certificate to the user."""
+    reporter_util = zope.component.getUtility(interfaces.IReporter)
+    reporter_util.add_message("Congratulations! Your certificate has been "
+                              "saved at {0}.".format(cert_path),
+                               reporter.MEDIUM_PRIORITY)
+
+
 def _auth_from_domains(le_client, config, domains, plugins):
     """Authenticate and enroll certificate."""
     # Note: This can raise errors... caught above us though.
@@ -291,6 +299,8 @@ def _auth_from_domains(le_client, config, domains, plugins):
         lineage = le_client.obtain_and_enroll_certificate(domains, plugins)
         if not lineage:
             raise errors.Error("Certificate could not be obtained")
+
+    _report_new_cert(lineage.cert)
 
     return lineage
 
@@ -365,6 +375,7 @@ def auth(args, config, plugins):
             file=args.csr[0], data=args.csr[1], form="der"))
         le_client.save_certificate(
             certr, chain, args.cert_path, args.chain_path)
+        _report_new_cert(args.cert_path)
     else:
         domains = _find_domains(args, installer)
         _auth_from_domains(le_client, config, domains, plugins)

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -518,7 +518,7 @@ class HelpfulArgumentParser(object):
         help2 = self.prescan_for_flag("--help", self.help_topics)
         assert max(True, "a") == "a", "Gravity changed direction"
         help_arg = max(help1, help2)
-        if help_arg == True:
+        if help_arg is True:
             # just --help with no topic; avoid argparse altogether
             print USAGE
             sys.exit(0)

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -272,7 +272,7 @@ def _report_new_cert(cert_path):
     reporter_util = zope.component.getUtility(interfaces.IReporter)
     reporter_util.add_message("Congratulations! Your certificate has been "
                               "saved at {0}.".format(cert_path),
-                               reporter.MEDIUM_PRIORITY)
+                              reporter_util.MEDIUM_PRIORITY)
 
 
 def _auth_from_domains(le_client, config, domains, plugins):

--- a/letsencrypt/client.py
+++ b/letsencrypt/client.py
@@ -286,7 +286,7 @@ class Client(object):
                 "configured in the directories under {0}.").format(
                     cert.cli_config.renewal_configs_dir)
         reporter = zope.component.getUtility(interfaces.IReporter)
-        reporter.add_message(msg, reporter.LOW_PRIORITY, True)
+        reporter.add_message(msg, reporter.LOW_PRIORITY)
 
     def save_certificate(self, certr, chain_cert, cert_path, chain_path):
         # pylint: disable=no-self-use

--- a/letsencrypt/interfaces.py
+++ b/letsencrypt/interfaces.py
@@ -478,7 +478,7 @@ class IReporter(zope.interface.Interface):
     LOW_PRIORITY = zope.interface.Attribute(
         "Used to denote low priority messages")
 
-    def add_message(self, msg, priority, on_crash=False):
+    def add_message(self, msg, priority, on_crash=True):
         """Adds msg to the list of messages to be printed.
 
         :param str msg: Message to be displayed to the user.

--- a/letsencrypt/reporter.py
+++ b/letsencrypt/reporter.py
@@ -36,7 +36,7 @@ class Reporter(object):
     def __init__(self):
         self.messages = Queue.PriorityQueue()
 
-    def add_message(self, msg, priority, on_crash=False):
+    def add_message(self, msg, priority, on_crash=True):
         """Adds msg to the list of messages to be printed.
 
         :param str msg: Message to be displayed to the user.

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -98,8 +98,7 @@ class CLITest(unittest.TestCase):
             mock_renewal.return_value = None
             with mock.patch('letsencrypt.cli._init_le_client') as mock_init:
                 mock_init.return_value = mock_client
-                self._call(['-d', 'foo.bar', '-a',
-                            'standalone', '-i', 'bad', 'auth'])
+                self._call(['-d', 'foo.bar', '-a', 'standalone', 'auth'])
 
     @mock.patch('letsencrypt.cli.zope.component.getUtility')
     @mock.patch('letsencrypt.cli._treat_as_renewal')
@@ -124,16 +123,20 @@ class CLITest(unittest.TestCase):
         self.assertTrue(
             cert_path in mock_get_utility().add_message.call_args[0][0])
 
+    @mock.patch('letsencrypt.cli.display_ops.pick_installer')
     @mock.patch('letsencrypt.cli.zope.component.getUtility')
     @mock.patch('letsencrypt.cli._init_le_client')
-    def test_auth_csr(self, mock_init, mock_get_utility):
+    def test_auth_csr(self, mock_init, mock_get_utility, mock_pick_installer):
         cert_path = '/etc/letsencrypt/live/foo.bar'
         mock_client = mock.MagicMock()
         mock_client.obtain_certificate_from_csr.return_value = ('certr',
                                                                 'chain')
         mock_init.return_value = mock_client
-        self._call(['-a', 'standalone', 'auth', '--csr', CSR,
-                    '--cert-path', cert_path, '--chain-path', '/'])
+        installer = 'installer'
+        self._call(
+            ['-a', 'standalone', '-i', installer, 'auth', '--csr', CSR,
+             '--cert-path', cert_path, '--chain-path', '/'])
+        self.assertEqual(mock_pick_installer.call_args[0][1], installer)
         mock_client.save_certificate.assert_called_once_with(
             'certr', 'chain', cert_path, '/')
         self.assertTrue(

--- a/letsencrypt/tests/reporter_test.py
+++ b/letsencrypt/tests/reporter_test.py
@@ -83,8 +83,10 @@ class ReporterTest(unittest.TestCase):
 
     def _add_messages(self):
         self.reporter.add_message("High", self.reporter.HIGH_PRIORITY)
-        self.reporter.add_message("Med", self.reporter.MEDIUM_PRIORITY, False)
-        self.reporter.add_message("Low", self.reporter.LOW_PRIORITY, False)
+        self.reporter.add_message(
+            "Med", self.reporter.MEDIUM_PRIORITY, on_crash=False)
+        self.reporter.add_message(
+            "Low", self.reporter.LOW_PRIORITY, on_crash=False)
 
 
 if __name__ == "__main__":

--- a/letsencrypt/tests/reporter_test.py
+++ b/letsencrypt/tests/reporter_test.py
@@ -78,13 +78,13 @@ class ReporterTest(unittest.TestCase):
         output = sys.stdout.getvalue()
         self.assertTrue("IMPORTANT NOTES:" in output)
         self.assertTrue("High" in output)
-        self.assertTrue("Med" not in output)
+        self.assertTrue("Med" in output)
         self.assertTrue("Low" not in output)
 
     def _add_messages(self):
-        self.reporter.add_message("High", self.reporter.HIGH_PRIORITY, True)
+        self.reporter.add_message("High", self.reporter.HIGH_PRIORITY)
         self.reporter.add_message("Med", self.reporter.MEDIUM_PRIORITY)
-        self.reporter.add_message("Low", self.reporter.LOW_PRIORITY)
+        self.reporter.add_message("Low", self.reporter.LOW_PRIORITY, False)
 
 
 if __name__ == "__main__":

--- a/letsencrypt/tests/reporter_test.py
+++ b/letsencrypt/tests/reporter_test.py
@@ -78,12 +78,12 @@ class ReporterTest(unittest.TestCase):
         output = sys.stdout.getvalue()
         self.assertTrue("IMPORTANT NOTES:" in output)
         self.assertTrue("High" in output)
-        self.assertTrue("Med" in output)
+        self.assertTrue("Med" not in output)
         self.assertTrue("Low" not in output)
 
     def _add_messages(self):
         self.reporter.add_message("High", self.reporter.HIGH_PRIORITY)
-        self.reporter.add_message("Med", self.reporter.MEDIUM_PRIORITY)
+        self.reporter.add_message("Med", self.reporter.MEDIUM_PRIORITY, False)
         self.reporter.add_message("Low", self.reporter.LOW_PRIORITY, False)
 
 

--- a/tox.cover.sh
+++ b/tox.cover.sh
@@ -16,7 +16,7 @@ fi
 
 cover () {
   if [ "$1" = "letsencrypt" ]; then
-    min=96
+    min=97
   elif [ "$1" = "acme" ]; then
     min=100
   elif [ "$1" = "letsencrypt_apache" ]; then


### PR DESCRIPTION
(Un)fortunately, there are a lot of little fixes in this PR. Main goal was to more clearly report certificate issuance to the user. Fixes #665. Additionally, this PR:

* Fixes PEP8 problems
* Changed `letsencrypt.Reporter` interface. There is an optional parameter in `add_message()` that allowed you to specify whether or not the message you are registering should be displayed if `letsencrypt` exits abnormally. Previously, the default was not to show the message, however, every time the function was used, the opposite behaviour was specified. Because of this, I switched the default and removed the extra parameter from all calls to `add_message`.
* Adds tests so `auth` and `_auth_from_domains` has full test coverage.
* Increases the cover minimum for `letsencrypt`.