### PR TITLE
ErrorHandler should ignore sys.exit

### DIFF
--- a/letsencrypt/error_handler.py
+++ b/letsencrypt/error_handler.py
@@ -50,7 +50,7 @@ class ErrorHandler(object):
         self.set_signal_handlers()
 
     def __exit__(self, exec_type, exec_value, trace):
-        if exec_value is not None:
+        if exec_type not in (None, SystemExit):
             logger.debug("Encountered exception:\n%s", "".join(
                 traceback.format_exception(exec_type, exec_value, trace)))
             self.call_registered()

--- a/letsencrypt/error_handler.py
+++ b/letsencrypt/error_handler.py
@@ -22,8 +22,8 @@ class ErrorHandler(object):
     """Registers functions to be called if an exception or signal occurs.
 
     This class allows you to register functions that will be called when
-    an exception or signal is encountered. The class works best as a
-    context manager. For example:
+    an exception (excluding SystemExit) or signal is encountered. The
+    class works best as a context manager. For example:
 
     with ErrorHandler(cleanup_func):
         do_something()
@@ -50,6 +50,7 @@ class ErrorHandler(object):
         self.set_signal_handlers()
 
     def __exit__(self, exec_type, exec_value, trace):
+        # SystemExit is ignored to properly handle forks that don't exec
         if exec_type not in (None, SystemExit):
             logger.debug("Encountered exception:\n%s", "".join(
                 traceback.format_exception(exec_type, exec_value, trace)))

--- a/letsencrypt/tests/error_handler_test.py
+++ b/letsencrypt/tests/error_handler_test.py
@@ -1,5 +1,6 @@
 """Tests for letsencrypt.error_handler."""
 import signal
+import sys
 import unittest
 
 import mock
@@ -49,6 +50,14 @@ class ErrorHandlerTest(unittest.TestCase):
         self.handler.call_registered()
         self.init_func.assert_called_once_with()
         bad_func.assert_called_once_with()
+
+    def test_sysexit_ignored(self):
+        try:
+            with self.handler:
+                sys.exit(0)
+        except SystemExit:
+            pass
+        self.assertFalse(self.init_func.called)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`letsencrypt.error_handler.ErrorHandler` was calling cleanup functions when encountering `SystemExit`. We should ignore `SystemExit` as it will cause unexpected behaviour when used with code that forks like `Standalone`.