### PR TITLE
Make sure the LICENSE file is accurate for first pre-relase

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
-Let's Encrypt:
-Copyright (c) Internet Security Research Group
+Let's Encrypt Python Client
+Copyright (c) Electronic Frontier Foundation and others
 Licensed Apache Version 2.0
 
 Incorporating code from nginxparser


### PR DESCRIPTION
 - In general copyrights remain with their respective authors or authors'
   organizations, but with license granted by clause 5 of the Apache License.
 - Presently the plurality of the copyright in the client is held by EFF as a result of
   work-for-hire by jdkasten, bmw, schoen, pde, rolandshoemaker and jsha;
   or by Jakub Warmuz or his employer, Google.