### PR TITLE
Fixed indentation in storage.py

### DIFF
--- a/letsencrypt/storage.py
+++ b/letsencrypt/storage.py
@@ -520,7 +520,7 @@ class RenewableCert(object):  # pylint: disable=too-many-instance-attributes
             remaining = expiry - now
             if remaining < autorenew_interval:
                 return True
-            return False
+        return False
 
     @classmethod
     def new_lineage(cls, lineagename, cert, privkey, chain,


### PR DESCRIPTION
While looking through `storage.py` I noticed that `should_autorenew()` returns `None` if `autorenewal` either hasn't been configured or disabled. While this shouldn't cause a problem (same behaviour with `if cert.should_autorenew():`), it is also incorrect and should be fixed.