### PR TITLE
OS X Integration Tests Environment Setup

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -67,6 +67,8 @@ The following tools are there to help you:
 
 Integration
 ~~~~~~~~~~~
+Mac OS X users: Run `./tests/mac-integration.sh` to configure the
+integration tests environment and start boulder
 
 First, install `Go`_ 1.5, libtool-ltdl, mariadb-server and
 rabbitmq-server and then start Boulder_, an ACME CA server::

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -67,10 +67,10 @@ The following tools are there to help you:
 
 Integration
 ~~~~~~~~~~~
-Mac OS X users: Run `./tests/mac-integration.sh` to configure the
-integration tests environment and start boulder
+Mac OS X users: Run `./tests/mac-bootstrap.sh` instead of `boulder-start.sh` to
+install dependencies, configure the environment, and start boulder.
 
-First, install `Go`_ 1.5, libtool-ltdl, mariadb-server and
+Otherwise, install `Go`_ 1.5, libtool-ltdl, mariadb-server and
 rabbitmq-server and then start Boulder_, an ACME CA server::
 
   ./tests/boulder-start.sh

--- a/tests/mac-bootstrap.sh
+++ b/tests/mac-bootstrap.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+#Check Homebrew
+if ! hash brew 2>/dev/null; then
+    echo "Homebrew Not Installed\nDownloading..."
+    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+fi
+
+brew install libtool mariadb rabbitmq coreutils go
+
+mysql.server start
+
+rabbit_pid=`ps | grep rabbitmq | grep -v grep | awk '{ print $1}'`
+if [ -n rabbit_pid ]; then
+  echo "RabbitMQ already running"
+else
+  rabbitmq-server &
+fi
+
+hosts_entry=`cat /etc/hosts | grep "127.0.0.1 le.wtf"`
+if [ -z hosts_entry ]; then
+  echo "Adding hosts entry for le.wtf..."
+  sudo sh -c "echo 127.0.0.1 le.wtf >> /etc/hosts"
+fi
+
+./tests/boulder-start.sh

--- a/tests/mac-bootstrap.sh
+++ b/tests/mac-bootstrap.sh
@@ -11,14 +11,14 @@ brew install libtool mariadb rabbitmq coreutils go
 mysql.server start
 
 rabbit_pid=`ps | grep rabbitmq | grep -v grep | awk '{ print $1}'`
-if [ -n rabbit_pid ]; then
+if [ -n "$rabbit_pid" ]; then
   echo "RabbitMQ already running"
 else
   rabbitmq-server &
 fi
 
 hosts_entry=`cat /etc/hosts | grep "127.0.0.1 le.wtf"`
-if [ -z hosts_entry ]; then
+if [ -z "$hosts_entry" ]; then
   echo "Adding hosts entry for le.wtf..."
   sudo sh -c "echo 127.0.0.1 le.wtf >> /etc/hosts"
 fi


### PR DESCRIPTION
Adds script and documentation to configure and setup environment for integration tests on OS X