### PR TITLE
Add Mac compatibility to integration tests

### DIFF
--- a/letsencrypt/plugins/manual.py
+++ b/letsencrypt/plugins/manual.py
@@ -159,6 +159,7 @@ binary for temporary key/certificate generation.""".replace("\n", "")
                     # don't care about setting stdout and stderr,
                     # we're in test mode anyway
                     shell=True,
+                    executable="/bin/bash",
                     # "preexec_fn" is UNIX specific, but so is "command"
                     preexec_fn=os.setsid)
             except OSError as error:  # ValueError should not happen!

--- a/letsencrypt/plugins/manual.py
+++ b/letsencrypt/plugins/manual.py
@@ -134,7 +134,6 @@ binary for temporary key/certificate generation.""".replace("\n", "")
                 executable = "/bin/bash"
             else:
                 executable = None
-                
             try:
                 self._httpd = subprocess.Popen(
                     command,

--- a/letsencrypt/plugins/manual.py
+++ b/letsencrypt/plugins/manual.py
@@ -133,7 +133,7 @@ binary for temporary key/certificate generation.""".replace("\n", "")
             if sys.platform == "darwin":
                 executable = "/bin/bash"
             else:
-                executable = "/bin/sh"
+                executable = None
                 
             try:
                 self._httpd = subprocess.Popen(

--- a/letsencrypt/plugins/manual.py
+++ b/letsencrypt/plugins/manual.py
@@ -153,13 +153,13 @@ binary for temporary key/certificate generation.""".replace("\n", "")
             ct=response.CONTENT_TYPE, port=port)
         if self.conf("test-mode"):
             logger.debug("Test mode. Executing the manual command: %s", command)
+            # sh shipped with OS X does't support echo -n
+            if sys.platform == "darwin":
+                executable = "/bin/bash"
+            else:
+                executable = "/bin/sh"
+                
             try:
-                # sh shipped with OS X does't support echo -n
-                if sys.platform == "darwin":
-                    executable = "/bin/bash"
-                else:
-                    executable = "/bin/sh"
-
                 self._httpd = subprocess.Popen(
                     command,
                     # don't care about setting stdout and stderr,

--- a/letsencrypt/plugins/manual.py
+++ b/letsencrypt/plugins/manual.py
@@ -154,12 +154,18 @@ binary for temporary key/certificate generation.""".replace("\n", "")
         if self.conf("test-mode"):
             logger.debug("Test mode. Executing the manual command: %s", command)
             try:
+                # sh shipped with OS X does't support echo -n
+                if sys.platform == "darwin":
+                    executable = "/bin/bash"
+                else:
+                    executable = "/bin/sh"
+
                 self._httpd = subprocess.Popen(
                     command,
                     # don't care about setting stdout and stderr,
                     # we're in test mode anyway
                     shell=True,
-                    executable="/bin/bash",
+                    executable=executable,
                     # "preexec_fn" is UNIX specific, but so is "command"
                     preexec_fn=os.setsid)
             except OSError as error:  # ValueError should not happen!

--- a/letsencrypt/plugins/standalone/authenticator.py
+++ b/letsencrypt/plugins/standalone/authenticator.py
@@ -301,11 +301,14 @@ class StandaloneAuthenticator(common.Plugin):
         :param int port: The TCP port in question.
         :returns: True or False."""
 
-        listeners = [conn.pid for conn in psutil.net_connections()
-                     if conn.status == 'LISTEN' and
-                     conn.type == socket.SOCK_STREAM and
-                     conn.laddr[1] == port]
         try:
+
+            # net_connections() can raise AccessDenied on certain OSs
+            listeners = [conn.pid for conn in psutil.net_connections()
+                         if conn.status == 'LISTEN' and
+                         conn.type == socket.SOCK_STREAM and
+                         conn.laddr[1] == port]
+
             if listeners and listeners[0] is not None:
                 # conn.pid may be None if the current process doesn't have
                 # permission to identify the listening process!  Additionally,

--- a/letsencrypt/plugins/standalone/authenticator.py
+++ b/letsencrypt/plugins/standalone/authenticator.py
@@ -309,7 +309,7 @@ class StandaloneAuthenticator(common.Plugin):
             net_connections = psutil.net_connections()
         except psutil.AccessDenied as error:
             logger.info("Access denied when trying to list network "
-            "connections: %s. Are you root?", error)
+                        "connections: %s. Are you root?", error)
             # this function is just a pre-check that often causes false
             # positives and problems in testing (c.f. #680 on Mac, #255
             # generally); we will fail later in bind() anyway

--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -50,7 +50,11 @@ dir="$root/conf/archive/le1.wtf"
 for x in cert chain fullchain privkey;
 do
     latest="$(ls -1t $dir/ | grep -e "^${x}" | head -n1)"
-    live="$(readlink -f "$root/conf/live/le1.wtf/${x}.pem")"
+    if [ `uname`  == 'Darwin' ]; then
+      live="$(greadlink -f "$root/conf/live/le1.wtf/${x}.pem")"
+    else
+      live="$(readlink -f "$root/conf/live/le1.wtf/${x}.pem")"
+    fi
     [ "${dir}/${latest}" = "$live" ]  # renewer fails this test
 done
 

--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -14,6 +14,12 @@ export PATH="/usr/sbin:$PATH"  # /usr/sbin/nginx
 export GOPATH="${GOPATH:-/tmp/go}"
 export PATH="$GOPATH/bin:$PATH"
 
+if [ `uname`  == 'Darwin' ]; then
+  readlink="greadlink"
+else
+  readlink="readlink"
+fi
+
 common() {
     letsencrypt_test \
         --authenticator standalone \
@@ -50,11 +56,7 @@ dir="$root/conf/archive/le1.wtf"
 for x in cert chain fullchain privkey;
 do
     latest="$(ls -1t $dir/ | grep -e "^${x}" | head -n1)"
-    if [ `uname`  == 'Darwin' ]; then
-      live="$(greadlink -f "$root/conf/live/le1.wtf/${x}.pem")"
-    else
-      live="$(readlink -f "$root/conf/live/le1.wtf/${x}.pem")"
-    fi
+    live="$($readlink -f "$root/conf/live/le1.wtf/${x}.pem")"
     [ "${dir}/${latest}" = "$live" ]  # renewer fails this test
 done
 


### PR DESCRIPTION
Adds OS X compatibility to integration tests by addressing #680, #857, and #724.

greadlink dependency introduced for OS X will be installed with #883.