### PR TITLE
crypto_util: fix bug in crypto_util.pyopenssl_x509_name_as_text()

### DIFF
--- a/letsencrypt/crypto_util.py
+++ b/letsencrypt/crypto_util.py
@@ -276,7 +276,7 @@ def asn1_generalizedtime_to_dt(timestamp):
 
 def pyopenssl_x509_name_as_text(x509name):
     """Convert `OpenSSL.crypto.X509Name` to text."""
-    return "/".join("{0}={1}" for key, value in x509name.get_components())
+    return "/".join("{0}={1}".format(key, value) for key, value in x509name.get_components())
 
 
 def dump_pyopenssl_chain(chain, filetype=OpenSSL.crypto.FILETYPE_PEM):


### PR DESCRIPTION
`crypto_util.pyopenssl_x509_name_as_text()` returns the `"/".join()` of strings of the form `"key=value"`.
It gets these as an array of tuples.

The bug:
During iteration, a string "{0}={1}" was supposed to be formatted with the key and value.
Unfortunately, the format string was never actually formatted with `key` or `value`.

The fix:
Call `.format()` on the format string in the iteration.