### PR TITLE
Specify python2 and clarify coverage requirements

### DIFF
--- a/bootstrap/dev/venv.sh
+++ b/bootstrap/dev/venv.sh
@@ -1,6 +1,8 @@
 #!/bin/sh -xe
 # Developer virtualenv setup for Let's Encrypt client
 
+export VENV_ARGS="--python python2"
+
 ./bootstrap/dev/_venv_common.sh \
   -r requirements.txt \
   -e acme[testing] \

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -7,9 +7,9 @@ Contributing
 Hacking
 =======
 
-The code base, including your pull requests, **must** have 100% unit
-test coverage, pass our `integration`_ tests **and** be compliant with
-the :ref:`coding style <coding-style>`.
+All changes in your pull request **must** have 100% unit test coverage, pass
+our `integration`_ tests, **and** be compliant with the
+:ref:`coding style <coding-style>`.
 
 
 Bootstrap


### PR DESCRIPTION
Please take a look at this @kuba. Not sure how I missed this yesterday. `venv.sh` needs to specify `python2` (Arch problems) and we can't require contributors to have 100% unit test coverage of the code base as that's not something we currently have.