### PR TITLE
Set server_names_hash_bucket_size.

### DIFF
--- a/letsencrypt-nginx/letsencrypt_nginx/configurator.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/configurator.py
@@ -110,10 +110,6 @@ class NginxConfigurator(common.Plugin):
         self.parser = parser.NginxParser(
             self.conf('server-root'), self.mod_ssl_conf)
 
-        filep = self.parser.loc["root"]
-        self.parser.add_http_directives(filep,
-            ['server_names_hash_bucket_size', '128'])
-
         # Set Version
         if self.version is None:
             self.version = self.get_version()

--- a/letsencrypt-nginx/letsencrypt_nginx/configurator.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/configurator.py
@@ -110,6 +110,10 @@ class NginxConfigurator(common.Plugin):
         self.parser = parser.NginxParser(
             self.conf('server-root'), self.mod_ssl_conf)
 
+        filep = self.parser.loc["root"]
+        self.parser.add_http_directives(filep,
+            ['server_names_hash_bucket_size', '128'])
+
         # Set Version
         if self.version is None:
             self.version = self.get_version()

--- a/letsencrypt-nginx/letsencrypt_nginx/dvsni.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/dvsni.py
@@ -93,8 +93,7 @@ class NginxDvsni(common.Dvsni):
         directive = ['include', self.challenge_conf]
         root = self.configurator.parser.loc["root"]
 
-        self.configurator.parser.add_http_directives(root,
-            ['server_names_hash_bucket_size', '128'])
+        bucket_directive = ['server_names_hash_bucket_size', '128']
 
         main = self.configurator.parser.parsed[root]
         for entry in main:
@@ -102,6 +101,8 @@ class NginxDvsni(common.Dvsni):
                 body = entry[1]
                 if directive not in body:
                     body.append(directive)
+                if bucket_directive not in body:
+                    body.append(bucket_directive)
                 included = True
                 break
         if not included:

--- a/letsencrypt-nginx/letsencrypt_nginx/dvsni.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/dvsni.py
@@ -99,10 +99,10 @@ class NginxDvsni(common.Dvsni):
         for entry in main:
             if entry[0] == ['http']:
                 body = entry[1]
-                if directive not in body:
-                    body.append(directive)
                 if bucket_directive not in body:
-                    body.append(bucket_directive)
+                    body.insert(0, directive)
+                if directive not in body:
+                    body.insert(0, directive)
                 included = True
                 break
         if not included:

--- a/letsencrypt-nginx/letsencrypt_nginx/dvsni.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/dvsni.py
@@ -92,6 +92,10 @@ class NginxDvsni(common.Dvsni):
         included = False
         directive = ['include', self.challenge_conf]
         root = self.configurator.parser.loc["root"]
+
+        self.configurator.parser.add_http_directives(root,
+            ['server_names_hash_bucket_size', '128'])
+
         main = self.configurator.parser.parsed[root]
         for entry in main:
             if entry[0] == ['http']:

--- a/letsencrypt-nginx/letsencrypt_nginx/tests/dvsni_test.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/tests/dvsni_test.py
@@ -1,6 +1,7 @@
 """Test for letsencrypt_nginx.dvsni."""
 import unittest
 import shutil
+import ipdb
 
 import mock
 
@@ -108,7 +109,8 @@ class DvsniPerformTest(util.NginxTest):
         http = self.sni.configurator.parser.parsed[
             self.sni.configurator.parser.loc["root"]][-1]
         self.assertTrue(['include', self.sni.challenge_conf] in http[1])
-        self.assertTrue(['server_name', 'blah'] in http[1][-2][1])
+        ipdb.set_trace()
+        self.assertTrue(['server_name', 'blah'] in http[1][-1][1])
 
         self.assertEqual(len(sni_responses), 3)
         for i in xrange(3):

--- a/letsencrypt-nginx/tests/boulder-integration.conf.sh
+++ b/letsencrypt-nginx/tests/boulder-integration.conf.sh
@@ -45,6 +45,7 @@ http {
     '"\$http_user_agent" "\$http_x_forwarded_for"';
 
   default_type application/octet-stream;
+  $directives
 
   server {
     # IPv4.

--- a/letsencrypt-nginx/tests/boulder-integration.conf.sh
+++ b/letsencrypt-nginx/tests/boulder-integration.conf.sh
@@ -20,7 +20,6 @@ events {
 }
 
 http {
-  server_names_hash_bucket_size 2048;
   # Set an array of temp and cache file options that will otherwise default to
   # restricted locations accessible only to root.
   client_body_temp_path $root/client_body;

--- a/letsencrypt-nginx/tests/boulder-integration.sh
+++ b/letsencrypt-nginx/tests/boulder-integration.sh
@@ -6,23 +6,34 @@
 export PATH="/usr/sbin:$PATH"  # /usr/sbin/nginx
 nginx_root="$root/nginx"
 mkdir $nginx_root
-root="$nginx_root" ./letsencrypt-nginx/tests/boulder-integration.conf.sh > $nginx_root/nginx.conf
+run_with () {
+  directives=$(shift)
+  echo "DIRECTIVES $directives"
+  export directives
+  root="$nginx_root" ./letsencrypt-nginx/tests/boulder-integration.conf.sh > $nginx_root/nginx.conf
 
-killall nginx || true
-nginx -c $nginx_root/nginx.conf
+  killall nginx || true
+  nginx -c $nginx_root/nginx.conf
 
-letsencrypt_test_nginx () {
-    letsencrypt_test \
-        --configurator nginx \
-        --nginx-server-root $nginx_root \
-        "$@"
+  letsencrypt_test_nginx () {
+      letsencrypt_test \
+          --configurator nginx \
+          --nginx-server-root $nginx_root \
+          "$@"
+  }
+
+  letsencrypt_test_nginx --domains nginx.wtf run
+  echo | openssl s_client -connect localhost:5001 \
+      | openssl x509 -out $root/nginx.pem
+  diff -q $root/nginx.pem $root/conf/live/nginx.wtf/cert.pem
+
+  # note: not reached if anything above fails, hence "killall" at the
+  # top
+  nginx -c $nginx_root/nginx.conf -s stop
 }
 
-letsencrypt_test_nginx --domains nginx.wtf run
-echo | openssl s_client -connect localhost:5001 \
-    | openssl x509 -out $root/nginx.pem
-diff -q $root/nginx.pem $root/conf/live/nginx.wtf/cert.pem
-
-# note: not reached if anything above fails, hence "killall" at the
-# top
-nginx -c $nginx_root/nginx.conf -s stop
+# Run with and without server_names_hash_bucket_size, to ensure that the
+# configurator correctly adds it when it is needed and doesn't add it when
+# it's already there.
+run_with ""
+run_with "server_names_hash_bucket_size 128;"


### PR DESCRIPTION
This is necessary for nginx to load its config file.
Fixes https://github.com/letsencrypt/letsencrypt/issues/922

Note: I am very uncertain at where in the Nginx plugin I should put this code. I found this spot, which seems to work. However, it does not properly clean up after itself: the directive sticks around even after letsencrypt is done running.