### PR TITLE
Revert "Release 0.0.0.dev20151008"

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 
-version = '0.0.0.dev20151008'
+version = '0.1.0.dev0'
 
 install_requires = [
     # load_pem_private/public_key (>=0.6)

--- a/letsencrypt-apache/setup.py
+++ b/letsencrypt-apache/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 
-version = '0.0.0.dev20151008'
+version = '0.1.0.dev0'
 
 install_requires = [
     'acme=={0}'.format(version),

--- a/letsencrypt-nginx/setup.py
+++ b/letsencrypt-nginx/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 
-version = '0.0.0.dev20151008'
+version = '0.1.0.dev0'
 
 install_requires = [
     'acme=={0}'.format(version),

--- a/letsencrypt/__init__.py
+++ b/letsencrypt/__init__.py
@@ -1,4 +1,4 @@
 """Let's Encrypt client."""
 
 # version number like 1.2.3a0, must have at least 2 parts, like 1.2
-__version__ = '0.0.0.dev20151008'
+__version__ = '0.1.0.dev0'

--- a/letshelp-letsencrypt/setup.py
+++ b/letshelp-letsencrypt/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 
-version = '0.0.0.dev20151008'
+version = '0.1.0.dev0'
 
 install_requires = [
     'setuptools',  # pkg_resources


### PR DESCRIPTION
This reverts commit 9e1477faa48148ad5b2c3664375a3520d589eb94.

Dev release commits must NOT be integrated with `master` -  they are intended to live in their own branches only. This is intentional and `master` should always be kept in `0.1.0.dev0` until we move into "real" (non dev) releases.

@bmw, did you pull this in as a part of my request in #926?