### PR TITLE
letsencrypt-auto implements bootstrapping, venv install, and pip autoupdate before running the client

### DIFF
--- a/bootstrap/mac.sh
+++ b/bootstrap/mac.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 if ! hash brew 2>/dev/null; then
     echo "Homebrew Not Installed\nDownloading..."
     ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"

--- a/bootstrap/venv.sh
+++ b/bootstrap/venv.sh
@@ -1,0 +1,35 @@
+#!/bin/sh -e
+#
+# Installs and updates letencrypt virtualenv
+#
+# USAGE: source ./dev/venv.sh
+
+
+XDG_DATA_HOME=${XDG_DATA_HOME:-~/.local/share}
+VENV_NAME="letsencrypt"
+VENV_PATH=${VENV_PATH:-"$XDG_DATA_HOME/$VENV_NAME"}
+
+# virtualenv call is not idempotent: it overwrites pip upgraded in
+# later steps, causing "ImportError: cannot import name unpack_url"
+if [ ! -d $VENV_PATH ]
+then
+  virtualenv --no-site-packages --python python2 $VENV_PATH
+fi
+
+. $VENV_PATH/bin/activate
+pip install -U setuptools
+pip install -U pip
+
+# TODO: install apache and nginx plugins by default?
+# --pre is not necessary for dev releases in more recent pip versions
+pip install -U letsencrypt letsencrypt-apache letsencrypt-nginx
+
+echo
+echo "Congratulations, Let's Encrypt has been successfully installed/updated!"
+echo
+echo -n "Your prompt should now be prepended with ($VENV_NAME). Next "
+echo -n "time, if the prompt is different, 'source' this script again "
+echo -n "before running 'letsencrypt'."
+echo
+echo
+echo "You can now run 'letsencrypt --help'."

--- a/bootstrap/venv.sh
+++ b/bootstrap/venv.sh
@@ -20,9 +20,7 @@ fi
 pip install -U setuptools
 pip install -U pip
 
-# TODO: install apache and nginx plugins by default?
-# --pre is not necessary for dev releases in more recent pip versions
-pip install -U letsencrypt letsencrypt-apache letsencrypt-nginx
+pip install -U letsencrypt letsencrypt-apache # letsencrypt-nginx
 
 echo
 echo "Congratulations, Let's Encrypt has been successfully installed/updated!"

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -371,24 +371,3 @@ i.e. it does not use ports.
 FreeBSD by default uses ``tcsh``. In order to activate virtulenv (see
 below), you will need a compatbile shell, e.g. ``pkg install bash &&
 bash``.
-
-
-Running with Docker
-===================
-
-Docker_ is another way to quickly obtaintesting certs. From the
-server that the domain your requesting a cert for resolves to,
-`install Docker`_, issue the following command:
-
-.. code-block:: shell
-
-   sudo docker auth -it --rm -p 443:443 --name letsencrypt \
-               -v "/etc/letsencrypt:/etc/letsencrypt" \
-               -v "/var/lib/letsencrypt:/var/lib/letsencrypt" \
-               quay.io/letsencrypt/letsencrypt:latest
-
-and follow the instructions. Your new cert will be available in
-``/etc/letsencrypt/certs``.
-
-.. _Docker: https://docker.com
-.. _`install Docker`: https://docs.docker.com/docker/userguide/

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -312,6 +312,8 @@ In general:
 * ``virtualenv`` and ``pip`` are used for managing other python library
   dependencies
 
+.. _Augeas: http://augeas.net/
+.. _Virtualenv: https://virtualenv.pypa.io
 
 Ubuntu
 ------

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -297,6 +297,8 @@ commands:
 This should generate documentation in the ``docs/_build/html``
 directory.
 
+.. _prerequisites:
+
 Notes on OS depedencies
 =======================
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -296,3 +296,99 @@ commands:
 
 This should generate documentation in the ``docs/_build/html``
 directory.
+
+Notes on OS depedencies
+=======================
+
+OS level dependencies are managed by scripts in ``bootstrap``.  Some notes
+are provided here mainly for the :ref:`developers <hacking>` reference.
+
+In general:
+
+* ``sudo`` is required as a suggested way of running privileged process
+* `Augeas`_ is required for the Python bindings
+* ``virtualenv`` and ``pip`` are used for managing other python library
+  dependencies
+
+
+Ubuntu
+------
+
+.. code-block:: shell
+
+   sudo ./bootstrap/ubuntu.sh
+
+
+Debian
+------
+
+.. code-block:: shell
+
+   sudo ./bootstrap/debian.sh
+
+For squeeze you will need to:
+
+- Use ``virtualenv --no-site-packages -p python`` instead of ``-p python2``.
+
+
+.. _`#280`: https://github.com/letsencrypt/letsencrypt/issues/280
+
+
+Mac OSX
+-------
+
+.. code-block:: shell
+
+   ./bootstrap/mac.sh
+
+
+Fedora
+------
+
+.. code-block:: shell
+
+   sudo ./bootstrap/fedora.sh
+
+
+Centos 7
+--------
+
+.. code-block:: shell
+
+   sudo ./bootstrap/centos.sh
+
+
+FreeBSD
+-------
+
+.. code-block:: shell
+
+   sudo ./bootstrap/freebsd.sh
+
+Bootstrap script for FreeBSD uses ``pkg`` for package installation,
+i.e. it does not use ports.
+
+FreeBSD by default uses ``tcsh``. In order to activate virtulenv (see
+below), you will need a compatbile shell, e.g. ``pkg install bash &&
+bash``.
+
+
+Running with Docker
+===================
+
+Docker_ is another way to quickly obtaintesting certs. From the
+server that the domain your requesting a cert for resolves to,
+`install Docker`_, issue the following command:
+
+.. code-block:: shell
+
+   sudo docker auth -it --rm -p 443:443 --name letsencrypt \
+               -v "/etc/letsencrypt:/etc/letsencrypt" \
+               -v "/var/lib/letsencrypt:/var/lib/letsencrypt" \
+               quay.io/letsencrypt/letsencrypt:latest
+
+and follow the instructions. Your new cert will be available in
+``/etc/letsencrypt/certs``.
+
+.. _Docker: https://docker.com
+.. _`install Docker`: https://docs.docker.com/docker/userguide/

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -68,83 +68,6 @@ By default, the following locations are searched:
 .. _Augeas: http://augeas.net/
 .. _Virtualenv: https://virtualenv.pypa.io
 
-Notes on OS depedencies
-=======================
-
-OS level dependencies are managed by scripts in ``bootstrap``.  Some notes
-are provided here mainly for the :ref:`developers <hacking>` reference.
-
-In general:
-
-* ``sudo`` is required as a suggested way of running privileged process
-* `Augeas`_ is required for the Python bindings
-* ``virtualenv`` and ``pip`` are used for managing other python library
-  dependencies
-
-
-Ubuntu
-------
-
-.. code-block:: shell
-
-   sudo ./bootstrap/ubuntu.sh
-
-
-Debian
-------
-
-.. code-block:: shell
-
-   sudo ./bootstrap/debian.sh
-
-For squeeze you will need to:
-
-- Use ``virtualenv --no-site-packages -p python`` instead of ``-p python2``.
-
-
-.. _`#280`: https://github.com/letsencrypt/letsencrypt/issues/280
-
-
-Mac OSX
--------
-
-.. code-block:: shell
-
-   ./bootstrap/mac.sh
-
-
-Fedora
-------
-
-.. code-block:: shell
-
-   sudo ./bootstrap/fedora.sh
-
-
-Centos 7
---------
-
-.. code-block:: shell
-
-   sudo ./bootstrap/centos.sh
-
-
-FreeBSD
--------
-
-.. code-block:: shell
-
-   sudo ./bootstrap/freebsd.sh
-
-Bootstrap script for FreeBSD uses ``pkg`` for package installation,
-i.e. it does not use ports.
-
-FreeBSD by default uses ``tcsh``. In order to activate virtulenv (see
-below), you will need a compatbile shell, e.g. ``pkg install bash &&
-bash``.
-
-
-
 
 Running with Docker
 ===================
@@ -158,12 +81,10 @@ server that the domain your requesting a cert for resolves to,
    sudo docker auth -it --rm -p 443:443 --name letsencrypt \
                -v "/etc/letsencrypt:/etc/letsencrypt" \
                -v "/var/lib/letsencrypt:/var/lib/letsencrypt" \
-               quay.io/letsencrypt/letsencrypt:latest
+               quay.io/letsencrypt/letsencrypt:latest auth
 
 and follow the instructions. Your new cert will be available in
 ``/etc/letsencrypt/certs``.
 
 .. _Docker: https://docker.com
 .. _`install Docker`: https://docs.docker.com/docker/userguide/
-
-

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -22,8 +22,6 @@ above method instead.
    https://github.com/letsencrypt/letsencrypt/archive/master.zip
 
 
-.. _prerequisites:
-
 Installation and Usage
 ======================
 
@@ -33,9 +31,13 @@ To install and run the client you just need to type:
 
    ./letsencrypt-auto
 
-.. warning:: Please do **not** use ``python setup.py install``.  That mode of
-             operation might corrupt your operating system and is **not supported**
-             by the Let's Encrypt team!
+(Once letsencrypt is packaged by distributions, the command will just be
+``letsencrypt``.  ``letsencrypt-auto`` is a wrapper which installs virtualized
+dependencies and provides automated updates during the beta program)
+
+.. warning:: Please do **not** use ``python setup.py install`` or ``sudo pip install`.
+             Those mode of operation might corrupt your operating system and is
+             **not supported** by the Let's Encrypt team!
 
 The ``letsencrypt`` commandline tool has a builtin help:
 
@@ -48,7 +50,7 @@ Configuration file
 ------------------
 
 It is possible to specify configuration file with
-``letsencrypt --config cli.ini`` (or shorter ``-c cli.ini``). For
+``letsencrypt-auto --config cli.ini`` (or shorter ``-c cli.ini``). For
 instance, if you are a contributor, you might find the following
 handy:
 
@@ -72,7 +74,7 @@ By default, the following locations are searched:
 Running with Docker
 ===================
 
-Docker_ is another way to quickly obtaintesting certs. From the
+Docker_ is another way to quickly obtain testing certs. From the
 server that the domain your requesting a cert for resolves to,
 `install Docker`_, issue the following command:
 

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -122,15 +122,9 @@ bash``.
 Installation
 ============
 
-.. "pip install acme" doesn't search for "acme" in cwd, just like "pip
-   install -e acme" does; `-U setuptools pip` necessary for #722
-
 .. code-block:: shell
 
-   virtualenv --no-site-packages -p python2 venv
-   ./venv/bin/pip install -U setuptools
-   ./venv/bin/pip install -U pip
-   ./venv/bin/pip install -r requirements.txt acme/ . letsencrypt-apache/ letsencrypt-nginx/
+   source ./bootstrap/venv.sh
 
 .. warning:: Please do **not** use ``python setup.py install``. Please
              do **not** attempt the installation commands as
@@ -148,13 +142,13 @@ To get a new certificate run:
 
 .. code-block:: shell
 
-   sudo ./venv/bin/letsencrypt auth
+   (letsencrypt)$ letsencrypt auth
 
 The ``letsencrypt`` commandline tool has a builtin help:
 
 .. code-block:: shell
 
-   ./venv/bin/letsencrypt --help
+   (letsencrypt)$ letsencrypt --help
 
 
 Configuration file

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -2,26 +2,6 @@
 Using the Let's Encrypt client
 ==============================
 
-Quick start
-===========
-
-Using Docker_ you can quickly get yourself a testing cert. From the
-server that the domain your requesting a cert for resolves to,
-`install Docker`_, issue the following command:
-
-.. code-block:: shell
-
-   sudo docker run -it --rm -p 443:443 --name letsencrypt \
-               -v "/etc/letsencrypt:/etc/letsencrypt" \
-               -v "/var/lib/letsencrypt:/var/lib/letsencrypt" \
-               quay.io/letsencrypt/letsencrypt:latest
-
-and follow the instructions. Your new cert will be available in
-``/etc/letsencrypt/certs``.
-
-.. _Docker: https://docker.com
-.. _`install Docker`: https://docs.docker.com/docker/userguide/
-
 
 Getting the code
 ================
@@ -174,3 +154,25 @@ By default, the following locations are searched:
 
 .. _Augeas: http://augeas.net/
 .. _Virtualenv: https://virtualenv.pypa.io
+
+Running with Docker
+===================
+
+Docker_ is another way to quickly obtaintesting certs. From the
+server that the domain your requesting a cert for resolves to,
+`install Docker`_, issue the following command:
+
+.. code-block:: shell
+
+   sudo docker auth -it --rm -p 443:443 --name letsencrypt \
+               -v "/etc/letsencrypt:/etc/letsencrypt" \
+               -v "/var/lib/letsencrypt:/var/lib/letsencrypt" \
+               quay.io/letsencrypt/letsencrypt:latest
+
+and follow the instructions. Your new cert will be available in
+``/etc/letsencrypt/certs``.
+
+.. _Docker: https://docker.com
+.. _`install Docker`: https://docs.docker.com/docker/userguide/
+
+

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -24,17 +24,62 @@ above method instead.
 
 .. _prerequisites:
 
-Prerequisites
-=============
+Installation and Usage
+======================
 
-The demo code is supported and known to work on **Ubuntu and
-Debian**. Therefore, prerequisites for other platforms listed below
-are provided mainly for the :ref:`developers <hacking>` reference.
+To install and run the client you just need to type:
+
+.. code-block:: shell
+
+   ./letsencrypt-auto
+
+.. warning:: Please do **not** use ``python setup.py install``.  That mode of
+             operation might corrupt your operating system and is **not supported**
+             by the Let's Encrypt team!
+
+The ``letsencrypt`` commandline tool has a builtin help:
+
+.. code-block:: shell
+
+   ./letsencrypt-auto --help
+
+
+Configuration file
+------------------
+
+It is possible to specify configuration file with
+``letsencrypt --config cli.ini`` (or shorter ``-c cli.ini``). For
+instance, if you are a contributor, you might find the following
+handy:
+
+.. include:: ../examples/dev-cli.ini
+   :code: ini
+
+By default, the following locations are searched:
+
+- ``/etc/letsencrypt/cli.ini``
+- ``$XDG_CONFIG_HOME/letsencrypt/cli.ini`` (or
+  ``~/.config/letsencrypt/cli.ini`` if ``$XDG_CONFIG_HOME`` is not
+  set).
+
+.. keep it up to date with constants.py
+
+
+.. _Augeas: http://augeas.net/
+.. _Virtualenv: https://virtualenv.pypa.io
+
+Notes on OS depedencies
+=======================
+
+OS level dependencies are managed by scripts in ``bootstrap``.  Some notes
+are provided here mainly for the :ref:`developers <hacking>` reference.
 
 In general:
 
 * ``sudo`` is required as a suggested way of running privileged process
 * `Augeas`_ is required for the Python bindings
+* ``virtualenv`` and ``pip`` are used for managing other python library
+  dependencies
 
 
 Ubuntu
@@ -99,61 +144,7 @@ below), you will need a compatbile shell, e.g. ``pkg install bash &&
 bash``.
 
 
-Installation
-============
 
-.. code-block:: shell
-
-   source ./bootstrap/venv.sh
-
-.. warning:: Please do **not** use ``python setup.py install``. Please
-             do **not** attempt the installation commands as
-             superuser/root and/or without Virtualenv_, e.g. ``sudo
-             python setup.py install``, ``sudo pip install``, ``sudo
-             ./venv/bin/...``. These modes of operation might corrupt
-             your operating system and are **not supported** by the
-             Let's Encrypt team!
-
-
-Usage
-=====
-
-To get a new certificate run:
-
-.. code-block:: shell
-
-   (letsencrypt)$ letsencrypt auth
-
-The ``letsencrypt`` commandline tool has a builtin help:
-
-.. code-block:: shell
-
-   (letsencrypt)$ letsencrypt --help
-
-
-Configuration file
-------------------
-
-It is possible to specify configuration file with
-``letsencrypt --config cli.ini`` (or shorter ``-c cli.ini``). For
-instance, if you are a contributor, you might find the following
-handy:
-
-.. include:: ../examples/dev-cli.ini
-   :code: ini
-
-By default, the following locations are searched:
-
-- ``/etc/letsencrypt/cli.ini``
-- ``$XDG_CONFIG_HOME/letsencrypt/cli.ini`` (or
-  ``~/.config/letsencrypt/cli.ini`` if ``$XDG_CONFIG_HOME`` is not
-  set).
-
-.. keep it up to date with constants.py
-
-
-.. _Augeas: http://augeas.net/
-.. _Virtualenv: https://virtualenv.pypa.io
 
 Running with Docker
 ===================

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -67,10 +67,6 @@ By default, the following locations are searched:
 .. keep it up to date with constants.py
 
 
-.. _Augeas: http://augeas.net/
-.. _Virtualenv: https://virtualenv.pypa.io
-
-
 Running with Docker
 ===================
 

--- a/letsencrypt-auto
+++ b/letsencrypt-auto
@@ -11,7 +11,8 @@ VENV_PATH=${VENV_PATH:-"$XDG_DATA_HOME/$VENV_NAME"}
 VENV_BIN=${VENV_PATH}/bin
 
 for arg in "$@" ; do 
-  if [ "$arg" = "-v" ] || [ "$arg" = "--verbose" ] ; then
+  # This first clause is redundant with the third, but hedging on portability
+  if [ "$arg" = "-v" ] || [ "$arg" = "--verbose" ] || echo "$arg" | grep -E -- -v+ ; then
     VERBOSE=1
   fi
 done

--- a/letsencrypt-auto
+++ b/letsencrypt-auto
@@ -20,6 +20,34 @@ done
 # later steps, causing "ImportError: cannot import name unpack_url"
 if [ ! -d $VENV_PATH ]
 then
+  BOOTSTRAP=`dirname $0`/bootstrap
+  if [ ! -f $BOOTSTRAP/debian.sh ] ; then
+    echo "Cannot find the letsencrypt bootstrap scripts in $BOOTSTRAP"
+    exit 1
+  fi
+  if [ -f /etc/debian_version ] ; then
+    echo "Bootstrapping dependencies for Debian-based OSes..."
+    sudo $BOOTSTRAP/_deb_common.sh
+  elif [ -f /etc/arch-release ] ; then
+    echo "Bootstrapping dependencies for Archlinux..."
+    sudo $BOOTSTRAP/archlinux.sh
+  elif [ -f /etc/redhat-release ] ; then
+    echo "Bootstrapping dependencies for RedHat-based OSes..."
+    sudo $BOOTSTRAP/_rpm_common.sh
+  elif uname | grep -iq FreeBSD ; then
+    echo "Bootstrapping dependencies for FreeBSD..."
+    sudo $BOOTSTRAP/freebsd.sh
+  elif uname | grep -iq Darwin ; then
+    echo "Bootstrapping dependencies for Mac OS X..."
+    sudo $BOOTSTRAP/mac.sh
+  else
+    echo "Sorry, I don't know how to bootstrap Let's Encrypt on your operating system!"
+    echo
+    echo "You will need to bootstrap, configure virtualenv, and run a pip install manually"
+    echo "Please see https://letsencrypt.readthedocs.org/en/latest/using.html#prerequisites"
+    echo "for more info"
+  fi
+
   echo "Creating virtual environment..."
   if [ "$VERBOSE" = 1 ] ; then
     virtualenv --no-site-packages --python python2 $VENV_PATH

--- a/letsencrypt-auto
+++ b/letsencrypt-auto
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 #
 # Installs and updates the letencrypt virtualenv, and runs letsencrypt
 # using that virtual environment.  This allows the client to function decently
@@ -39,7 +39,8 @@ then
     sudo $BOOTSTRAP/freebsd.sh
   elif uname | grep -iq Darwin ; then
     echo "Bootstrapping dependencies for Mac OS X..."
-    sudo $BOOTSTRAP/mac.sh
+    echo "WARNING: Mac support is very experimental at present..."
+    $BOOTSTRAP/mac.sh
   else
     echo "Sorry, I don't know how to bootstrap Let's Encrypt on your operating system!"
     echo

--- a/letsencrypt-auto
+++ b/letsencrypt-auto
@@ -86,4 +86,4 @@ fi
 # Explain what's about to happen, for the benefit of those getting sudo
 # password prompts...
 echo "Running with virtualenv:" $SUDO $VENV_BIN/letsencrypt "$@"
-$SUDO $VENV_BIN/letsencrypt $@
+$SUDO $VENV_BIN/letsencrypt "$@"

--- a/letsencrypt-auto
+++ b/letsencrypt-auto
@@ -64,17 +64,23 @@ then
   fi
 fi
 
-echo "Updating letsencrypt and virtual environment dependencies..."
+echo -n "Updating letsencrypt and virtual environment dependencies..."
 if [ "$VERBOSE" = 1 ]  ; then
+  echo
   $VENV_BIN/pip install -U setuptools
   $VENV_BIN/pip install -U pip
   # nginx is buggy / disabled for now...
   $VENV_BIN/pip install -U letsencrypt letsencrypt-apache #letsencrypt-nginx
 else
   $VENV_BIN/pip install -U setuptools > /dev/null
+  echo -n .
   $VENV_BIN/pip install -U pip > /dev/null
+  echo -n .
   # nginx is buggy / disabled for now...
-  $VENV_BIN/pip install -U letsencrypt letsencrypt-apache > /dev/null
+  $VENV_BIN/pip install -U letsencrypt > /dev/null
+  echo -n .
+  $VENV_BIN/pip install -U letsencrypt-apache > /dev/null
+  echo
 fi
 
 # Explain what's about to happen, for the benefit of those getting sudo

--- a/letsencrypt-auto
+++ b/letsencrypt-auto
@@ -1,0 +1,45 @@
+#!/bin/bash -e
+#
+# Installs and updates the letencrypt virtualenv, and runs letsencrypt
+# using that virtual environment.  This allows the client to function decently
+# without requiring specific versions of its dependencies from the operating
+# system.
+
+XDG_DATA_HOME=${XDG_DATA_HOME:-~/.local/share}
+VENV_NAME="letsencrypt"
+VENV_PATH=${VENV_PATH:-"$XDG_DATA_HOME/$VENV_NAME"}
+VENV_BIN=${VENV_PATH}/bin
+
+for arg in "$@" ; do 
+  if [ "$arg" = "-v" ] || [ "$arg" = "--verbose" ] ; then
+    VERBOSE=1
+  fi
+done
+
+# virtualenv call is not idempotent: it overwrites pip upgraded in
+# later steps, causing "ImportError: cannot import name unpack_url"
+if [ ! -d $VENV_PATH ]
+then
+  echo "Creating virtual environment..."
+  if [ "$VERBOSE" = 1 ] ; then
+    virtualenv --no-site-packages --python python2 $VENV_PATH
+  else
+    virtualenv --no-site-packages --python python2 $VENV_PATH > /dev/null
+  fi
+fi
+
+echo "Updating letsencrypt and virtual environment dependencies..."
+if [ "$VERBOSE" = 1 ]  ; then
+  $VENV_BIN/pip install -U setuptools
+  $VENV_BIN/pip install -U pip
+  $VENV_BIN/pip install -U letsencrypt letsencrypt-apache letsencrypt-nginx
+else
+  $VENV_BIN/pip install -U setuptools > /dev/null
+  $VENV_BIN/pip install -U pip > /dev/null
+  $VENV_BIN/pip install -U letsencrypt letsencrypt-apache letsencrypt-nginx > /dev/null
+fi
+
+# TODO: install apache and nginx plugins by default?
+# --pre is not necessary for dev releases in more recent pip versions
+
+sudo $VENV_BIN/letsencrypt $@

--- a/letsencrypt-auto
+++ b/letsencrypt-auto
@@ -68,7 +68,7 @@ else
   $VENV_BIN/pip install -U letsencrypt letsencrypt-apache letsencrypt-nginx > /dev/null
 fi
 
-# TODO: install apache and nginx plugins by default?
-# --pre is not necessary for dev releases in more recent pip versions
-
+# Explain what's about to happen, for the benefit of those getting sudo
+# password prompts...
+echo "Running with virtualenv:" sudo $VENV_BIN/letsencrypt "$@"
 sudo $VENV_BIN/letsencrypt $@

--- a/letsencrypt-auto
+++ b/letsencrypt-auto
@@ -52,7 +52,7 @@ then
     echo "Sorry, I don't know how to bootstrap Let's Encrypt on your operating system!"
     echo
     echo "You will need to bootstrap, configure virtualenv, and run a pip install manually"
-    echo "Please see https://letsencrypt.readthedocs.org/en/latest/using.html#prerequisites"
+    echo "Please see https://letsencrypt.readthedocs.org/en/latest/contributing.html#prerequisites"
     echo "for more info"
   fi
 

--- a/letsencrypt-auto
+++ b/letsencrypt-auto
@@ -10,6 +10,12 @@ VENV_NAME="letsencrypt"
 VENV_PATH=${VENV_PATH:-"$XDG_DATA_HOME/$VENV_NAME"}
 VENV_BIN=${VENV_PATH}/bin
 
+if test "`id -u`" -ne "0" ; then
+  SUDO=sudo
+else
+  SUDO=
+fi
+
 for arg in "$@" ; do 
   # This first clause is redundant with the third, but hedging on portability
   if [ "$arg" = "-v" ] || [ "$arg" = "--verbose" ] || echo "$arg" | grep -E -- -v+ ; then
@@ -28,16 +34,16 @@ then
   fi
   if [ -f /etc/debian_version ] ; then
     echo "Bootstrapping dependencies for Debian-based OSes..."
-    sudo $BOOTSTRAP/_deb_common.sh
+    $SUDO $BOOTSTRAP/_deb_common.sh
   elif [ -f /etc/arch-release ] ; then
     echo "Bootstrapping dependencies for Archlinux..."
-    sudo $BOOTSTRAP/archlinux.sh
+    $SUDO $BOOTSTRAP/archlinux.sh
   elif [ -f /etc/redhat-release ] ; then
     echo "Bootstrapping dependencies for RedHat-based OSes..."
-    sudo $BOOTSTRAP/_rpm_common.sh
+    $SUDO $BOOTSTRAP/_rpm_common.sh
   elif uname | grep -iq FreeBSD ; then
     echo "Bootstrapping dependencies for FreeBSD..."
-    sudo $BOOTSTRAP/freebsd.sh
+    $SUDO $BOOTSTRAP/freebsd.sh
   elif uname | grep -iq Darwin ; then
     echo "Bootstrapping dependencies for Mac OS X..."
     echo "WARNING: Mac support is very experimental at present..."
@@ -71,5 +77,5 @@ fi
 
 # Explain what's about to happen, for the benefit of those getting sudo
 # password prompts...
-echo "Running with virtualenv:" sudo $VENV_BIN/letsencrypt "$@"
-sudo $VENV_BIN/letsencrypt $@
+echo "Running with virtualenv:" $SUDO $VENV_BIN/letsencrypt "$@"
+$SUDO $VENV_BIN/letsencrypt $@

--- a/letsencrypt-auto
+++ b/letsencrypt-auto
@@ -68,11 +68,13 @@ echo "Updating letsencrypt and virtual environment dependencies..."
 if [ "$VERBOSE" = 1 ]  ; then
   $VENV_BIN/pip install -U setuptools
   $VENV_BIN/pip install -U pip
-  $VENV_BIN/pip install -U letsencrypt letsencrypt-apache letsencrypt-nginx
+  # nginx is buggy / disabled for now...
+  $VENV_BIN/pip install -U letsencrypt letsencrypt-apache #letsencrypt-nginx
 else
   $VENV_BIN/pip install -U setuptools > /dev/null
   $VENV_BIN/pip install -U pip > /dev/null
-  $VENV_BIN/pip install -U letsencrypt letsencrypt-apache letsencrypt-nginx > /dev/null
+  # nginx is buggy / disabled for now...
+  $VENV_BIN/pip install -U letsencrypt letsencrypt-apache > /dev/null
 fi
 
 # Explain what's about to happen, for the benefit of those getting sudo


### PR DESCRIPTION
You can just run `./letsencrypt-auto` ... this will handle everything most users should need in a single command.