### PR TITLE
Quick renewal status fix

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -303,9 +303,9 @@ def _auth_from_domains(le_client, config, domains, plugins):
     _report_new_cert(lineage.cert)
     reporter_util = zope.component.getUtility(interfaces.IReporter)
     reporter_util.add_message(
-        "Your certificate will expire at {0}. To obtain a new version of the "
+        "Your certificate will expire on {0}. To obtain a new version of the "
         "certificate in the future, simply run this client again.".format(
-            lineage.notafter().ctime()),
+            lineage.notafter().date()),
         reporter_util.MEDIUM_PRIORITY)
 
     return lineage

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -301,6 +301,12 @@ def _auth_from_domains(le_client, config, domains, plugins):
             raise errors.Error("Certificate could not be obtained")
 
     _report_new_cert(lineage.cert)
+    reporter_util = zope.component.getUtility(interfaces.IReporter)
+    reporter_util.add_message(
+        "Your certificate will expire at {0}. To obtain a new version of the "
+        "certificate in the future, simply run this client again.".format(
+            lineage.notafter().ctime()),
+        reporter_util.MEDIUM_PRIORITY)
 
     return lineage
 

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -128,8 +128,9 @@ class CLITest(unittest.TestCase):
         self._auth_new_request_common(mock_client)
         self.assertEqual(
             mock_client.obtain_and_enroll_certificate.call_count, 1)
-        self.assertTrue(
-            cert_path in mock_get_utility().add_message.call_args[0][0])
+        msg = mock_get_utility().add_message.call_args_list[0][0][0]
+        self.assertTrue(cert_path in msg)
+        self.assertEqual(mock_get_utility().add_message.call_count, 2)
 
     def test_auth_new_request_failure(self):
         mock_client = mock.MagicMock()
@@ -164,8 +165,9 @@ class CLITest(unittest.TestCase):
         self.assertEqual(mock_lineage.save_successor.call_count, 1)
         mock_lineage.update_all_links_to.assert_called_once_with(
             mock_lineage.latest_common_version())
-        self.assertTrue(
-            cert_path in mock_get_utility().add_message.call_args[0][0])
+        msg = mock_get_utility().add_message.call_args_list[0][0][0]
+        self.assertTrue(cert_path in msg)
+        self.assertEqual(mock_get_utility().add_message.call_count, 2)
 
     @mock.patch('letsencrypt.cli.display_ops.pick_installer')
     @mock.patch('letsencrypt.cli.zope.component.getUtility')


### PR DESCRIPTION
Unfortunately, I wasn't quite able to get all of my renewer changes finished in time (see my progress on the autodeploy branch). Throwing this up here as a quick fix for reporting certificate expiration to the user. It basically tells the user they're on their own for renewal and doesn't say anything if you run the client with your own CSR.