### PR TITLE
Change as_string to __str__ in nginxparser to make it more pythonic.

### DIFF
--- a/letsencrypt-nginx/letsencrypt_nginx/nginxparser.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/nginxparser.py
@@ -88,10 +88,6 @@ class RawNginxDumper(object):
         """Return the parsed block as a string."""
         return '\n'.join(self) + '\n'
 
-    def as_string(self):
-        """Return the parsed block as a string."""
-        return str(self)
-
 
 # Shortcut functions to respect Python's serialization interface
 # (like pyyaml, picker or json)

--- a/letsencrypt-nginx/letsencrypt_nginx/nginxparser.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/nginxparser.py
@@ -84,9 +84,13 @@ class RawNginxDumper(object):
                     else:
                         yield spacer * current_indent + key + spacer + values + ';'
 
-    def as_string(self):
+    def __str__(self):
         """Return the parsed block as a string."""
         return '\n'.join(self) + '\n'
+    
+    def as_string(self):
+        """Return the parsed block as a string."""
+        return str(self)
 
 
 # Shortcut functions to respect Python's serialization interface
@@ -122,7 +126,7 @@ def dumps(blocks, indentation=4):
     :rtype: str
 
     """
-    return RawNginxDumper(blocks, indentation).as_string()
+    return str(RawNginxDumper(blocks, indentation))
 
 
 def dump(blocks, _file, indentation=4):

--- a/letsencrypt-nginx/letsencrypt_nginx/nginxparser.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/nginxparser.py
@@ -87,7 +87,7 @@ class RawNginxDumper(object):
     def __str__(self):
         """Return the parsed block as a string."""
         return '\n'.join(self) + '\n'
-    
+
     def as_string(self):
         """Return the parsed block as a string."""
         return str(self)


### PR DESCRIPTION
This change would make the RawNginxDumper more in line with other Python libraries and the standard library.