### PR TITLE
Autodeployment

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -342,12 +342,6 @@ def _auth_from_domains(le_client, config, domains, plugins):
             raise errors.Error("Certificate could not be obtained")
 
     _report_new_cert(lineage.cert)
-    reporter_util = zope.component.getUtility(interfaces.IReporter)
-    reporter_util.add_message(
-        "Your certificate will expire on {0}. To obtain a new version of the "
-        "certificate in the future, simply run this client again.".format(
-            lineage.notafter().date()),
-        reporter_util.MEDIUM_PRIORITY)
 
     return lineage
 

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -284,7 +284,7 @@ def _report_renewal_status(cert, authenticator, installer):
 
     """
     reporter_util = zope.component.getUtility(interfaces.IReporter)
-    msg = ["Your certificate will expire at {0}. ".format(
+    msg = ["Your certificate will expire on {0}. ".format(
         cert.notafter().date())]
     # pylint: disable=no-member
     if (installer is not None or
@@ -305,7 +305,7 @@ def _report_renewal_status(cert, authenticator, installer):
             msg.append("automatic renewal and deployment has not ")
         msg.append(
             "been enabled for your certificate. These settings can be "
-            "configured in the directories under {0}.".format(
+            "configured with the files in {0}.".format(
                 cert.cli_config.renewal_configs_dir))
     else:
         # Since no installer was used, don't suggested the renewer

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -287,8 +287,8 @@ def _report_renewal_status(cert, authenticator, installer):
     msg = ["Your certificate will expire at {0}. ".format(
         cert.notafter().ctime())]
     # pylint: disable=no-member
-    if (installer is not None or
-            interfaces.IInstaller.implementedBy(authenticator)):
+    if (installer is not None or (authenticator is not None and
+            interfaces.IInstaller.implementedBy(authenticator))):
         msg.append(
             "Let's Encrypt can automatically renew and deploy new versions of "
             "this certificate for you. To do this, use a job scheduler like "
@@ -377,6 +377,7 @@ def run(args, config, plugins):  # pylint: disable=too-many-branches,too-many-lo
     le_client = _init_le_client(args, config, authenticator, installer)
 
     lineage = _auth_from_domains(le_client, config, domains, plugins)
+    _report_renewal_status(lineage, authenticator, installer)
 
     le_client.deploy_certificate(
         domains, lineage.privkey, lineage.cert,
@@ -419,7 +420,8 @@ def auth(args, config, plugins):
         _report_new_cert(args.cert_path)
     else:
         domains = _find_domains(args, installer)
-        _auth_from_domains(le_client, config, domains, plugins)
+        lineage = _auth_from_domains(le_client, config, domains, plugins)
+        _report_renewal_status(lineage, authenticator, installer)
 
 
 def install(args, config, plugins):

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -313,7 +313,7 @@ def _report_renewal_status(cert, authenticator, installer):
             "To obtain new versions of this certificate, simply run the Let's "
             "Encrypt client again.")
 
-    reporter_util.add_message(''.join(msg), reporter_util.MEDIUM_PRIORITY)
+    reporter_util.add_message("".join(msg), reporter_util.MEDIUM_PRIORITY)
 
 
 def _auth_from_domains(le_client, config, domains, plugins):

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -287,8 +287,8 @@ def _report_renewal_status(cert, authenticator, installer):
     msg = ["Your certificate will expire at {0}. ".format(
         cert.notafter().ctime())]
     # pylint: disable=no-member
-    if (installer is not None or (authenticator is not None and
-            interfaces.IInstaller.implementedBy(authenticator))):
+    if (installer is not None or
+            interfaces.IInstaller.providedBy(authenticator)):
         msg.append(
             "Let's Encrypt can automatically renew and deploy new versions of "
             "this certificate for you. To do this, use a job scheduler like "

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -285,7 +285,7 @@ def _report_renewal_status(cert, authenticator, installer):
     """
     reporter_util = zope.component.getUtility(interfaces.IReporter)
     msg = ["Your certificate will expire at {0}. ".format(
-        cert.notafter().ctime())]
+        cert.notafter().date())]
     # pylint: disable=no-member
     if (installer is not None or
             interfaces.IInstaller.providedBy(authenticator)):

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -128,8 +128,8 @@ class CLITest(unittest.TestCase):
         self._auth_new_request_common(mock_client)
         self.assertEqual(
             mock_client.obtain_and_enroll_certificate.call_count, 1)
-        self.assertTrue(
-            cert_path in mock_get_utility().add_message.call_args[0][0])
+        msg = mock_get_utility().add_message.call_args_list[0][0][0]
+        self.assertTrue(cert_path in msg)
 
     def test_auth_new_request_failure(self):
         mock_client = mock.MagicMock()
@@ -164,8 +164,8 @@ class CLITest(unittest.TestCase):
         self.assertEqual(mock_lineage.save_successor.call_count, 1)
         mock_lineage.update_all_links_to.assert_called_once_with(
             mock_lineage.latest_common_version())
-        self.assertTrue(
-            cert_path in mock_get_utility().add_message.call_args[0][0])
+        msg = mock_get_utility().add_message.call_args_list[0][0][0]
+        self.assertTrue(cert_path in msg)
 
     @mock.patch('letsencrypt.cli.display_ops.pick_installer')
     @mock.patch('letsencrypt.cli.zope.component.getUtility')

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -117,38 +117,38 @@ class CLITest(unittest.TestCase):
         from letsencrypt import cli
         # pylint: disable=protected-access
         cert = mock.MagicMock()
-        cert.notafter().date.return_value = "1970-01-01"
+        cert.notafter().date.return_value = '1970-01-01'
 
         cli._report_renewal_status(cert, None, None)
         msg = mock_get_utility().add_message.call_args[0][0]
-        self.assertTrue("1970-01-01" in msg)
-        self.assertTrue("client again" in msg)
+        self.assertTrue('1970-01-01' in msg)
+        self.assertTrue('client again' in msg)
 
         installer = mock.MagicMock()
         cert.autorenewal_is_enabled.return_value = True
         cert.autodeployment_is_enabled.return_value = True
         cli._report_renewal_status(cert, None, installer)
         msg = mock_get_utility().add_message.call_args[0][0]
-        self.assertTrue("1970-01-01" in msg)
-        self.assertTrue("automatic renewal and deployment has" in msg)
+        self.assertTrue('1970-01-01' in msg)
+        self.assertTrue('automatic renewal and deployment has' in msg)
 
         cert.autodeployment_is_enabled.return_value = False
         cli._report_renewal_status(cert, None, installer)
         msg = mock_get_utility().add_message.call_args[0][0]
-        self.assertTrue("1970-01-01" in msg)
-        self.assertTrue("automatic renewal but not automatic deploy" in msg)
+        self.assertTrue('1970-01-01' in msg)
+        self.assertTrue('automatic renewal but not automatic deploy' in msg)
 
         cert.autorenewal_is_enabled.return_value = False
         cli._report_renewal_status(cert, None, installer)
         msg = mock_get_utility().add_message.call_args[0][0]
-        self.assertTrue("1970-01-01" in msg)
-        self.assertTrue("automatic renewal and deployment has not" in msg)
+        self.assertTrue('1970-01-01' in msg)
+        self.assertTrue('automatic renewal and deployment has not' in msg)
 
         cert.autodeployment_is_enabled.return_value = True
         cli._report_renewal_status(cert, None, installer)
         msg = mock_get_utility().add_message.call_args[0][0]
-        self.assertTrue("1970-01-01" in msg)
-        self.assertTrue("automatic deployment but not automatic renew" in msg)
+        self.assertTrue('1970-01-01' in msg)
+        self.assertTrue('automatic deployment but not automatic renew' in msg)
 
     def test_auth_bad_args(self):
         ret, _, _, _ = self._call(['-d', 'foo.bar', 'auth', '--csr', CSR])

--- a/letsencrypt/tests/renewer_test.py
+++ b/letsencrypt/tests/renewer_test.py
@@ -639,12 +639,15 @@ class RenewableCertTests(BaseRenewableCertTest):
         with open(self.test_rc.cert, "w") as f:
             f.write(test_cert)
 
-        # Fails because renewalparams are missing
+        # Fails because renewalparams are invalid
         renewer.renew(self.test_rc)
         self.assertEqual(self.test_rc.latest_common_version(), 1)
-        self.test_rc.configfile["renewalparams"] = {"dvsni_port": "4430"}
+        self.test_rc.configfile["renewalparams"] = {"dvsni_port": ""}
         self.test_rc.configfile["renewalparams"]["rsa_key_size"] = "2048"
+        renewer.renew(self.test_rc)
+        self.assertEqual(self.test_rc.latest_common_version(), 1)
         # Fails because there's no authenticator specified
+        self.test_rc.configfile["renewalparams"]["dvsni_port"] = "4430"
         renewer.renew(self.test_rc)
         self.assertEqual(self.test_rc.latest_common_version(), 1)
         self.test_rc.configfile["renewalparams"]["server"] = "acme.example.com"
@@ -688,17 +691,12 @@ class RenewableCertTests(BaseRenewableCertTest):
         mock_notify.assert_not_called()
         mock_install.restart.assert_not_called()
 
-        self.test_rc.configfile["renewalparams"] = {"dvsni_port": "4430"}
+        self.test_rc.configfile["renewalparams"] = {"rsa_key_size": "4096"}
         renewer.deploy(self.test_rc)
         mock_notify.assert_not_called()
         mock_install.restart.assert_not_called()
 
-        self.test_rc.configfile["renewalparams"]["rsa_key_size"] = "2048"
-        renewer.deploy(self.test_rc)
-        mock_notify.assert_not_called()
-        mock_install.restart.assert_not_called()
-
-        self.test_rc.configfile["renewalparams"]["installer"] = "fake"
+        self.test_rc.configfile["renewalparams"] = {"installer": "fake"}
         renewer.deploy(self.test_rc)
         mock_notify.assert_not_called()
         mock_install.restart.assert_not_called()

--- a/letsencrypt/tests/renewer_test.py
+++ b/letsencrypt/tests/renewer_test.py
@@ -626,9 +626,8 @@ class RenewableCertTests(BaseRenewableCertTest):
                              datetime.timedelta(intended[time]))
 
     @mock.patch("letsencrypt.renewer.plugins_disco")
-    @mock.patch("letsencrypt.account.AccountFileStorage")
     @mock.patch("letsencrypt.client.Client")
-    def test_renew(self, mock_c, mock_acc_storage, mock_pd):
+    def test_renew(self, mock_c, mock_pd):
         from letsencrypt import renewer
 
         test_cert = test_util.load_vector("cert-san.pem")
@@ -641,10 +640,12 @@ class RenewableCertTests(BaseRenewableCertTest):
             f.write(test_cert)
 
         # Fails because renewalparams are missing
-        self.assertFalse(renewer.renew(self.test_rc, 1))
+        renewer.renew(self.test_rc)
+        self.assertEqual(self.test_rc.latest_common_version(), 1)
         self.test_rc.configfile["renewalparams"] = {"some": "stuff"}
         # Fails because there's no authenticator specified
-        self.assertFalse(renewer.renew(self.test_rc, 1))
+        renewer.renew(self.test_rc)
+        self.assertEqual(self.test_rc.latest_common_version(), 1)
         self.test_rc.configfile["renewalparams"]["rsa_key_size"] = "2048"
         self.test_rc.configfile["renewalparams"]["server"] = "acme.example.com"
         self.test_rc.configfile["renewalparams"]["authenticator"] = "fake"
@@ -653,7 +654,8 @@ class RenewableCertTests(BaseRenewableCertTest):
         mock_auth = mock.MagicMock()
         mock_pd.PluginsRegistry.find_all.return_value = {"apache": mock_auth}
         # Fails because "fake" != "apache"
-        self.assertFalse(renewer.renew(self.test_rc, 1))
+        renewer.renew(self.test_rc)
+        self.assertEqual(self.test_rc.latest_common_version(), 1)
         self.test_rc.configfile["renewalparams"]["authenticator"] = "apache"
         mock_client = mock.MagicMock()
         # pylint: disable=star-args
@@ -661,14 +663,11 @@ class RenewableCertTests(BaseRenewableCertTest):
             mock.MagicMock(body=CERT), [CERT], mock.Mock(pem="key"),
             mock.sentinel.csr)
         mock_c.return_value = mock_client
-        self.assertEqual(2, renewer.renew(self.test_rc, 1))
+        with mock.patch("letsencrypt.account.AccountFileStorage"):
+            renewer.renew(self.test_rc)
+            self.assertEqual(self.test_rc.latest_common_version(), 2)
         # TODO: We could also make several assertions about calls that should
         #       have been made to the mock functions here.
-        mock_acc_storage().load.assert_called_once_with(account_id="abcde")
-        mock_client.obtain_certificate.return_value = (
-            mock.sentinel.certr, [], mock.sentinel.key, mock.sentinel.csr)
-        # This should fail because the renewal itself appears to fail
-        self.assertFalse(renewer.renew(self.test_rc, 1))
 
     def _common_cli_args(self):
         return [
@@ -677,10 +676,9 @@ class RenewableCertTests(BaseRenewableCertTest):
             "--logs-dir", self.cli_config.logs_dir,
         ]
 
-    @mock.patch("letsencrypt.renewer.notify")
     @mock.patch("letsencrypt.storage.RenewableCert")
     @mock.patch("letsencrypt.renewer.renew")
-    def test_main(self, mock_renew, mock_rc, mock_notify):
+    def test_main(self, mock_renew, mock_rc):
         from letsencrypt import renewer
         mock_rc_instance = mock.MagicMock()
         mock_rc_instance.should_autodeploy.return_value = True
@@ -705,7 +703,6 @@ class RenewableCertTests(BaseRenewableCertTest):
         renewer.main(self.defaults, cli_args=self._common_cli_args())
         self.assertEqual(mock_rc.call_count, 2)
         self.assertEqual(mock_rc_instance.update_all_links_to.call_count, 2)
-        self.assertEqual(mock_notify.notify.call_count, 4)
         self.assertEqual(mock_renew.call_count, 2)
         # If we have instances that don't need any work done, no work should
         # be done (call counts associated with processing deployments or
@@ -718,7 +715,6 @@ class RenewableCertTests(BaseRenewableCertTest):
         renewer.main(self.defaults, cli_args=self._common_cli_args())
         self.assertEqual(mock_rc.call_count, 4)
         self.assertEqual(mock_happy_instance.update_all_links_to.call_count, 0)
-        self.assertEqual(mock_notify.notify.call_count, 4)
         self.assertEqual(mock_renew.call_count, 2)
 
     def test_bad_config_file(self):


### PR DESCRIPTION
Fixes #428. This was the code I wanted to submit earlier when I submitted #983. This PR supersedes those changes.

This PR also does a better job of informing users about the renewal. The basic idea is that if the user ran the client with an installer or configurator, it will inform them about the renewer. Otherwise, it will simply tell them when their certificates expire and that they can run the client again to renew them.

I tested this on a server with Apache and it worked properly. I briefly tried to get this to work in integration tests, but I encountered the problem of the renewer trying to autorenew certificates that used manual. This is related to this PR only in that maybe we shouldn't be pointing people towards the renewer until problems like this are fixed.

While the changes I made here are relatively straight forward, I'm not certain whether we want this in the next PyPI release. I wrote all of this in a bit of a hurry today and it hasn't been thoroughly tested.