### PR TITLE
Get precompiled Goose from GithHub.

### DIFF
--- a/tests/boulder-start.sh
+++ b/tests/boulder-start.sh
@@ -32,11 +32,10 @@ export PATH="$GOPATH/bin:$PATH"
 go get -d github.com/letsencrypt/boulder/...
 cd $GOPATH/src/github.com/letsencrypt/boulder
 # goose is needed for ./test/create_db.sh
-if ! go get bitbucket.org/liamstask/goose/cmd/goose ; then
-  echo Problems installing goose... perhaps rm -rf \$GOPATH \("$GOPATH"\)
-  echo and try again...
-  exit 1
-fi
+wget https://github.com/jsha/boulder-tools/raw/master/goose.gz && \
+  mkdir $GOPATH/bin && \
+  zcat goose.gz > $GOPATH/bin/goose && \
+  chmod +x $GOPATH/bin/goose
 ./test/create_db.sh
 ./start.py &
 # Hopefully start.py bootstraps before integration test is started...


### PR DESCRIPTION
Rather than fetching from bitbucket and building. Bitbucket is often down, and
building from scratch is slow. Github is sometimes down, but at least now we
have our eggs in one basket.