### PR TITLE
Make the script POSIX compliant so it works with dash (Fixes #977)

### DIFF
--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -14,7 +14,7 @@ export PATH="/usr/sbin:$PATH"  # /usr/sbin/nginx
 export GOPATH="${GOPATH:-/tmp/go}"
 export PATH="$GOPATH/bin:$PATH"
 
-if [ `uname`  == 'Darwin' ]; then
+if [ `uname` = "Darwin" ];then
   readlink="greadlink"
 else
   readlink="readlink"


### PR DESCRIPTION
Looks like the problem was introduced [here](https://github.com/letsencrypt/letsencrypt/commit/c9e28309ed2d3efb3c2c21301f88796fe87169ab) likely due to @BKreisel having /usr/bin/sh set to bash (which this works on) rather than dash (which this fails on). 

So the fix is pretty simple, just switch to ```=``` instead of ```==``` so as to make the script POSIX compliant to fix #977. 