### PR TITLE
Integration tests: force le3.wtf over DVSNI.

### DIFF
--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -29,14 +29,22 @@ common() {
 
 # TODO: boulder#985
 common_dvsni() {
-    common --dvsni-port 5001 --simple-http-port 0 "$@"
+    common \
+        --standalone-supported-challenges dvsni \
+        --dvsni-port 5001 \
+        --simple-http-port 0 \
+        "$@"
 }
 common_http() {
-    common --dvsni-port 0 --simple-http-port ${SIMPLE_HTTP_PORT:-5001} "$@"
+    common \
+        --standalone-supported-challenges simpleHttp \
+        --dvsni-port 0 \
+        --simple-http-port ${SIMPLE_HTTP_PORT:-5001} \
+        "$@"
 }
 
-common_dvsni --domains le1.wtf --standalone-supported-challenges dvsni auth
-common_http --domains le2.wtf --standalone-supported-challenges simpleHttp run
+common_dvsni --domains le1.wtf auth
+common_http --domains le2.wtf run
 common_http -a manual -d le.wtf auth
 
 export CSR_PATH="${root}/csr.der" KEY_PATH="${root}/key.pem" \


### PR DESCRIPTION
Becuse of https://github.com/letsencrypt/boulder/issues/985, we need to force standalone to one particular type of challenge at a time. #895 didn't fix it properly - it forgot about issuance of le3.wtf (CSR-initiated), which results in Travis builds failing 50% of a time, e.g. https://travis-ci.org/letsencrypt/letsencrypt/jobs/85875483#L3318.

Please merge before anything else to reduce number of failed builds :)