### PR TITLE
Fix dev release script: don't install from PyPI in tests

### DIFF
--- a/tools/dev-release.sh
+++ b/tools/dev-release.sh
@@ -74,9 +74,10 @@ python -m SimpleHTTPServer $PORT &
 # installed from local PyPI rather than current directory (repo root)
 virtualenv --no-site-packages ../venv
 . ../venv/bin/activate
-# Now, use our local PyPI. --pre allows installation of pre-release (incl. dev)
+pip install -U setuptools
+pip install -U pip
+# Now, use our local PyPI
 pip install \
-  --pre \
   --extra-index-url http://localhost:$PORT \
   letsencrypt $SUBPKGS
 # stop local PyPI

--- a/tools/dev-release.sh
+++ b/tools/dev-release.sh
@@ -28,9 +28,10 @@ virtualenv --no-site-packages $tmpvenv
 # update setuptools/pip just like in other places in the repo
 pip install -U setuptools
 pip install -U pip  # latest pip => no --pre for dev releases
-pip install -U wheel  # setup.py bdist_wheel newer versions of
-# virtualenv inherit setuptools/pip/wheel versions from current env
-# when creating a child env
+pip install -U wheel  # setup.py bdist_wheel
+
+# newer versions of virtualenv inherit setuptools/pip/wheel versions
+# from current env when creating a child env
 pip install -U virtualenv
 
 root="$(mktemp -d -t le.$version.XXX)"

--- a/tools/dev-release.sh
+++ b/tools/dev-release.sh
@@ -22,6 +22,15 @@ tag="v$version"
 mv "dist.$version" "dist.$version.$(date +%s).bak" || true
 git tag --delete "$tag" || true
 
+tmpvenv=$(mktemp -d)
+virtualenv --no-site-packages $tmpvenv
+. $tmpvenv/bin/activate
+pip install -U setuptools
+pip install -U pip
+pip install -U wheel
+# updating virtualenv does some crazy stuff...
+pip install -U virtualenv
+
 root="$(mktemp -d -t le.$version.XXX)"
 echo "Cloning into fresh copy at $root"  # clean repo = no artificats
 git clone . $root

--- a/tools/dev-release.sh
+++ b/tools/dev-release.sh
@@ -10,8 +10,8 @@ RELEASE_GPG_KEY="${RELEASE_GPG_KEY:-148C30F6F7E429337A72D992B00B9CC82D7ADF2C}"
 PORT=${PORT:-1234}
 
 # subpackages to be released
-SUBPKGS=${SUBPKGS:-"acme letsencrypt_apache letsencrypt_nginx letshelp_letsencrypt"}
-subpkgs_dirs="$(echo $SUBPKGS | sed s/_/-/g)"
+SUBPKGS=${SUBPKGS:-"acme letsencrypt-apache letsencrypt-nginx letshelp-letsencrypt"}
+subpkgs_modules="$(echo $SUBPKGS | sed s/-/_/g)"
 # letsencrypt_compatibility_test is not packaged because:
 # - it is not meant to be used by anyone else than Let's Encrypt devs
 # - it causes problems when running nosetests - the latter tries to
@@ -29,7 +29,7 @@ cd $root
 git branch -f "$DEV_RELEASE_BRANCH"
 git checkout "$DEV_RELEASE_BRANCH"
 
-for pkg_dir in $subpkgs_dirs
+for pkg_dir in $SUBPKGS
 do
   sed -i $x "s/^version.*/version = '$version'/" $pkg_dir/setup.py
 done
@@ -41,7 +41,7 @@ git tag --local-user "$RELEASE_GPG_KEY" \
     --sign --message "Release $version" "$tag"
 
 echo "Preparing sdists and wheels"
-for pkg_dir in . $subpkgs_dirs
+for pkg_dir in . $SUBPKGS
 do
   cd $pkg_dir
 
@@ -61,7 +61,7 @@ done
 
 mkdir "dist.$version"
 mv dist "dist.$version/letsencrypt"
-for pkg_dir in $subpkgs_dirs
+for pkg_dir in $SUBPKGS
 do
   mv $pkg_dir/dist "dist.$version/$pkg_dir/"
 done
@@ -89,7 +89,7 @@ mkdir ../kgs
 kgs="../kgs/$version"
 pip freeze | tee $kgs
 pip install nose
-nosetests letsencrypt $SUBPKGS
+nosetests letsencrypt $subpkgs_modules
 
 echo "New root: $root"
 echo "KGS is at $root/kgs"

--- a/tools/dev-release.sh
+++ b/tools/dev-release.sh
@@ -25,10 +25,12 @@ git tag --delete "$tag" || true
 tmpvenv=$(mktemp -d)
 virtualenv --no-site-packages $tmpvenv
 . $tmpvenv/bin/activate
+# update setuptools/pip just like in other places in the repo
 pip install -U setuptools
-pip install -U pip
-pip install -U wheel
-# updating virtualenv does some crazy stuff...
+pip install -U pip  # latest pip => no --pre for dev releases
+pip install -U wheel  # setup.py bdist_wheel newer versions of
+# virtualenv inherit setuptools/pip/wheel versions from current env
+# when creating a child env
 pip install -U virtualenv
 
 root="$(mktemp -d -t le.$version.XXX)"

--- a/tools/dev-release.sh
+++ b/tools/dev-release.sh
@@ -25,6 +25,7 @@ git tag --delete "$tag" || true
 root="$(mktemp -d -t le.$version.XXX)"
 echo "Cloning into fresh copy at $root"  # clean repo = no artificats
 git clone . $root
+git rev-parse HEAD
 cd $root
 git branch -f "$DEV_RELEASE_BRANCH"
 git checkout "$DEV_RELEASE_BRANCH"


### PR DESCRIPTION
There are a couple of fixes addressed by this PR:

1. updating `pip`/`setuptools` to latest: this matches rest of our codebase and lets us drop archaic `--pre`; just this change would also fix (2) below due to way newer versions of `pip` work...

2. script was confusing package names (with hyphens) and module names (with underscores): we were calling `pip instal letsencrypt_apache`, which failed to be found in the temporary index created by `python -m SimpleHTTPServer 1234`, but PyPI happily converted the name to correct `letsencrypt-apache` and served `0.0.0.dev20151008` instead of the locally created `0.0.0.dev20151017`

3. creating `virtualenv` for the dev-release: this installs necessary `wheel` and... `virtualenv` (!) - this is to make sure that virtualenv created later inherits latest versions of `pip`/`setuptools`/`wheel` (this achieves the same affect as (1), but caused a hell of confusion during last release)

This PR blocks next dev release.