### PR TITLE
Use PEM for Account.id generation.

### DIFF
--- a/letsencrypt/account.py
+++ b/letsencrypt/account.py
@@ -56,7 +56,7 @@ class Account(object):  # pylint: disable=too-few-public-methods
 
         self.id = hashlib.md5(
             self.key.key.public_key().public_bytes(
-                encoding=serialization.Encoding.DER,
+                encoding=serialization.Encoding.PEM,
                 format=serialization.PublicFormat.SubjectPublicKeyInfo)
         ).hexdigest()
         # Implementation note: Email? Multiple accounts can have the

--- a/letsencrypt/tests/account_test.py
+++ b/letsencrypt/tests/account_test.py
@@ -45,16 +45,16 @@ class AccountTest(unittest.TestCase):
 
     def test_id(self):
         self.assertEqual(
-            self.acc.id, "2ba35a3bdf380ed76a5ac9e740568395")
+            self.acc.id, "bca5889f66457d5b62fbba7b25f9ab6f")
 
     def test_slug(self):
         self.assertEqual(
-            self.acc.slug, "test.letsencrypt.org@2015-07-04T14:04:10Z (2ba3)")
+            self.acc.slug, "test.letsencrypt.org@2015-07-04T14:04:10Z (bca5)")
 
     def test_repr(self):
         self.assertEqual(
             repr(self.acc),
-            "<Account(2ba35a3bdf380ed76a5ac9e740568395)>")
+            "<Account(bca5889f66457d5b62fbba7b25f9ab6f)>")
 
 
 class ReportNewAccountTest(unittest.TestCase):


### PR DESCRIPTION
This is a breaking change, already existing /etc/letsencrypt/accounts will cause the client raise `errors.AccountStorageError` ("Account ids mismatch ..."). Simple fix: start over by `rm -rf /etc/letsencrypt`. In a long run it's a better solution that bumping to `cryptography>=0.9`...

@pde, this is one of the examples that shows problem in sharing `/etc/letsencrypt` between our package and e.g. Debian packaging. Even if we had a migration script, if user went back to `letsencrypt` provided by Debian, they would have a really hard time.

Fixes #1012