### PR TITLE
Clean up after simplehttp port change to 5002.

### DIFF
--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -27,30 +27,14 @@ common() {
         "$@"
 }
 
-# TODO: boulder#985
-common_dvsni() {
-    common \
-        --standalone-supported-challenges dvsni \
-        --dvsni-port 5001 \
-        --simple-http-port 0 \
-        "$@"
-}
-common_http() {
-    common \
-        --standalone-supported-challenges simpleHttp \
-        --dvsni-port 0 \
-        --simple-http-port ${SIMPLE_HTTP_PORT:-5001} \
-        "$@"
-}
-
-common_dvsni --domains le1.wtf auth
-common_http --domains le2.wtf run
-common_http -a manual -d le.wtf auth
+common --domains le1.wtf --standalone-supported-challenges dvsni auth
+common --domains le2.wtf --standalone-supported-challenges simpleHttp run
+common -a manual -d le.wtf auth
 
 export CSR_PATH="${root}/csr.der" KEY_PATH="${root}/key.pem" \
        OPENSSL_CNF=examples/openssl.cnf
 ./examples/generate-csr.sh le3.wtf
-common_dvsni auth --csr "$CSR_PATH" \
+common auth --csr "$CSR_PATH" \
        --cert-path "${root}/csr/cert.pem" \
        --chain-path "${root}/csr/chain.pem"
 openssl x509 -in "${root}/csr/0000_cert.pem" -text


### PR DESCRIPTION
Now, when https://github.com/letsencrypt/boulder/pull/998 is in, we can remove all quick fixes for https://github.com/letsencrypt/boulder/issues/985.

@jsha, please merge to green Travis :)