### PR TITLE
Report expiration when using a CSR

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -377,9 +377,9 @@ def auth(args, config, plugins):
     if args.csr is not None:
         certr, chain = le_client.obtain_certificate_from_csr(le_util.CSR(
             file=args.csr[0], data=args.csr[1], form="der"))
-        le_client.save_certificate(
+        cert_path, _ = le_client.save_certificate(
             certr, chain, args.cert_path, args.chain_path)
-        _report_new_cert(args.cert_path)
+        _report_new_cert(cert_path)
     else:
         domains = _find_domains(args, installer)
         _auth_from_domains(le_client, config, domains, plugins)

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -269,9 +269,13 @@ def _treat_as_renewal(config, domains):
 
 def _report_new_cert(cert_path):
     """Reports the creation of a new certificate to the user."""
+    expiry = crypto_util.notAfter(cert_path).date()
     reporter_util = zope.component.getUtility(interfaces.IReporter)
     reporter_util.add_message("Congratulations! Your certificate has been "
-                              "saved at {0}.".format(cert_path),
+                              "saved at {0} and will expire on {1}. To obtain "
+                              "a new version of the certificate in the "
+                              "future, simply run Let's Encrypt again.".format(
+                                  cert_path, expiry),
                               reporter_util.MEDIUM_PRIORITY)
 
 
@@ -301,12 +305,6 @@ def _auth_from_domains(le_client, config, domains, plugins):
             raise errors.Error("Certificate could not be obtained")
 
     _report_new_cert(lineage.cert)
-    reporter_util = zope.component.getUtility(interfaces.IReporter)
-    reporter_util.add_message(
-        "Your certificate will expire on {0}. To obtain a new version of the "
-        "certificate in the future, simply run this client again.".format(
-            lineage.notafter().date()),
-        reporter_util.MEDIUM_PRIORITY)
 
     return lineage
 

--- a/letsencrypt/crypto_util.py
+++ b/letsencrypt/crypto_util.py
@@ -8,6 +8,7 @@ import logging
 import os
 
 import OpenSSL
+import pyrfc3339
 import zope.component
 
 from acme import crypto_util as acme_crypto_util
@@ -276,3 +277,48 @@ def dump_pyopenssl_chain(chain, filetype=OpenSSL.crypto.FILETYPE_PEM):
     # assumes that OpenSSL.crypto.dump_certificate includes ending
     # newline character
     return "".join(_dump_cert(cert) for cert in chain)
+
+
+def notBefore(cert_path):
+    """When does the cert at cert_path start being valid?
+
+    :param str cert_path: path to a cert in PEM format
+
+    :returns: the notBefore value from the cert at cert_path
+    :rtype: :class:`datetime.datetime`
+
+    """
+    return _notAfterBefore(cert_path, OpenSSL.crypto.X509.get_notBefore)
+
+
+def notAfter(cert_path):
+    """When does the cert at cert_path stop being valid?
+
+    :param str cert_path: path to a cert in PEM format
+
+    :returns: the notAfter value from the cert at cert_path
+    :rtype: :class:`datetime.datetime`
+
+    """
+    return _notAfterBefore(cert_path, OpenSSL.crypto.X509.get_notAfter)
+
+
+def _notAfterBefore(cert_path, method):
+    """Internal helper function for finding notbefore/notafter.
+
+    :param str cert_path: path to a cert in PEM format
+    :param function method: one of ``OpenSSL.crypto.X509.get_notBefore``
+        or ``OpenSSL.crypto.X509.get_notAfter``
+
+    :returns: the notBefore value from the cert at cert_path
+    :rtype: :class:`datetime.datetime`
+
+    """
+    with open(cert_path) as f:
+        x509 = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM,
+                                               f.read())
+    timestamp = method(x509)
+    reformatted_timestamp = [timestamp[0:4], "-", timestamp[4:6], "-",
+                             timestamp[6:8], "T", timestamp[8:10], ":",
+                             timestamp[10:12], ":", timestamp[12:]]
+    return pyrfc3339.parse("".join(reformatted_timestamp))

--- a/letsencrypt/crypto_util.py
+++ b/letsencrypt/crypto_util.py
@@ -310,7 +310,7 @@ def _notAfterBefore(cert_path, method):
     :param function method: one of ``OpenSSL.crypto.X509.get_notBefore``
         or ``OpenSSL.crypto.X509.get_notAfter``
 
-    :returns: the notBefore value from the cert at cert_path
+    :returns: the notBefore or notAfter value from the cert at cert_path
     :rtype: :class:`datetime.datetime`
 
     """

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -187,6 +187,7 @@ class CLITest(unittest.TestCase):
         mock_client = mock.MagicMock()
         mock_client.obtain_certificate_from_csr.return_value = ('certr',
                                                                 'chain')
+        mock_client.save_certificate.return_value = cert_path, None
         mock_init.return_value = mock_client
 
         installer = 'installer'

--- a/letsencrypt/tests/crypto_util_test.py
+++ b/letsencrypt/tests/crypto_util_test.py
@@ -15,6 +15,7 @@ from letsencrypt.tests import test_util
 
 RSA256_KEY = test_util.load_vector('rsa256_key.pem')
 RSA512_KEY = test_util.load_vector('rsa512_key.pem')
+CERT_PATH = test_util.vector_path('cert.pem')
 CERT = test_util.load_vector('cert.pem')
 SAN_CERT = test_util.load_vector('cert-san.pem')
 
@@ -230,6 +231,24 @@ class CertLoaderTest(unittest.TestCase):
 
         with self.assertRaises(errors.Error):
             pyopenssl_load_certificate(bad_cert_data)
+
+
+class NotBeforeTest(unittest.TestCase):
+    """Tests for letsencrypt.crypto_util.notBefore"""
+
+    def test_notBefore(self):
+        from letsencrypt.crypto_util import notBefore
+        self.assertEqual(notBefore(CERT_PATH).isoformat(),
+                         '2014-12-11T22:34:45+00:00')
+
+
+class NotAfterTest(unittest.TestCase):
+    """Tests for letsencrypt.crypto_util.notAfter"""
+
+    def test_notAfter(self):
+        from letsencrypt.crypto_util import notAfter
+        self.assertEqual(notAfter(CERT_PATH).isoformat(),
+                         '2014-12-18T22:34:45+00:00')
 
 
 if __name__ == '__main__':

--- a/letsencrypt/tests/renewer_test.py
+++ b/letsencrypt/tests/renewer_test.py
@@ -7,7 +7,6 @@ import unittest
 
 import configobj
 import mock
-import pytz
 
 from letsencrypt import configuration
 from letsencrypt import errors
@@ -348,26 +347,6 @@ class RenewableCertTests(BaseRenewableCertTest):
             f.write(test_cert)
         self.assertEqual(self.test_rc.names(12),
                          ["example.com", "www.example.com"])
-
-    def _test_notafterbefore(self, function, timestamp):
-        test_cert = test_util.load_vector("cert.pem")
-        os.symlink(os.path.join("..", "..", "archive", "example.org",
-                                "cert12.pem"), self.test_rc.cert)
-        with open(self.test_rc.cert, "w") as f:
-            f.write(test_cert)
-        desired_time = datetime.datetime.utcfromtimestamp(timestamp)
-        desired_time = desired_time.replace(tzinfo=pytz.UTC)
-        for result in (function(), function(12)):
-            self.assertEqual(result, desired_time)
-            self.assertEqual(result.utcoffset(), datetime.timedelta(0))
-
-    def test_notbefore(self):
-        self._test_notafterbefore(self.test_rc.notbefore, 1418337285)
-        # 2014-12-11 22:34:45+00:00 = Unix time 1418337285
-
-    def test_notafter(self):
-        self._test_notafterbefore(self.test_rc.notafter, 1418942085)
-        # 2014-12-18 22:34:45+00:00 = Unix time 1418942085
 
     @mock.patch("letsencrypt.storage.datetime")
     def test_time_interval_judgments(self, mock_datetime):


### PR DESCRIPTION
As noted in #983, cert expiration was not reported when using a user specified CSR. This fixes that.