### PR TITLE
Updated TODOs

### DIFF
--- a/letsencrypt/auth_handler.py
+++ b/letsencrypt/auth_handler.py
@@ -153,10 +153,8 @@ class AuthHandler(object):
         """
         active_achalls = []
         for achall, resp in itertools.izip(achalls, resps):
-            # XXX: make sure that all achalls, including those
-            # corresponding to None or False returned from
-            # Authenticator are removed from the queue and thus avoid
-            # infinite loop
+            # This line needs to be outside of the if block below to
+            # ensure failed challenges are cleaned up correctly
             active_achalls.append(achall)
 
             # Don't send challenges for None and False authenticator responses

--- a/letsencrypt/client.py
+++ b/letsencrypt/client.py
@@ -329,8 +329,6 @@ class Client(object):
 
         with error_handler.ErrorHandler(self.installer.recovery_routine):
             for dom in domains:
-                # TODO: Provide a fullchain reference for installers like
-                #       nginx that want it
                 self.installer.deploy_cert(
                     domain=dom, cert_path=os.path.abspath(cert_path),
                     key_path=os.path.abspath(privkey_path),

--- a/letsencrypt/renewer.py
+++ b/letsencrypt/renewer.py
@@ -95,7 +95,7 @@ def renew(cert, old_version):
         sans = crypto_util.get_sans_from_cert(f.read())
     new_certr, new_chain, new_key, _ = le_client.obtain_certificate(sans)
     if new_chain:
-        # XXX: Assumes that there was no key change.  We need logic
+        # XXX: Assumes that there was a key change.  We need logic
         #      for figuring out whether there was or not.  Probably
         #      best is to have obtain_certificate return None for
         #      new_key if the old key is to be used (since save_successor
@@ -180,7 +180,6 @@ def main(config=None, cli_args=sys.argv[1:]):
         rc_config = configobj.ConfigObj(cli_config.renewer_config_file)
         rc_config.merge(configobj.ConfigObj(
             os.path.join(cli_config.renewal_configs_dir, i)))
-        # TODO: this is a dirty hack!
         rc_config.filename = os.path.join(cli_config.renewal_configs_dir, i)
         try:
             # TODO: Before trying to initialize the RenewableCert object,


### PR DESCRIPTION
* Fixes #1033. Turns out that `XXX` comment was outdated. All challenges are properly removed in `_cleanup_challenges`.
* The full chain is now included in `deploy_cert` so that comment can also be removed.
* The comment in `renewer.py` was incorrect. By passing the key to `save_successor`, the code actually assumes there was a key change. This behavior is fine.
* Assigning to `rc_config.filename` is not a dirty hack. It's [documented](https://configobj.readthedocs.org/en/latest/configobj.html#writing-a-config-file) functionality of a `configobj.ConfigObj`.