### PR TITLE
Do not reinstall what's already installed

### DIFF
--- a/bootstrap/archlinux.sh
+++ b/bootstrap/archlinux.sh
@@ -3,7 +3,7 @@
 # "python-virtualenv" is Python3, but "python2-virtualenv" provides
 # only "virtualenv2" binary, not "virtualenv" necessary in
 # ./bootstrap/dev/_common_venv.sh
-pacman -S \
+pacman -S --needed \
   git \
   python2 \
   python-virtualenv \


### PR DESCRIPTION
There's no need to reinstall all packages. Few of  them are quite heavy (gcc) and most  of the time, when it comes to developers, already available. You need git, for instance, to clone the repository itself, that's going to be there and configured already too.

Please consider this change so that bootstrapping is going to be even faster. Best Regards