### PR TITLE
Simple fix to hanging standalone

### DIFF
--- a/acme/acme/standalone.py
+++ b/acme/acme/standalone.py
@@ -64,7 +64,7 @@ class ACMEServerMixin:  # pylint: disable=old-style-class
         """Shutdown server loop from `serve_forever2`."""
         self._stopped = True
 
-        # dummy request to terminate last server_forever2.handle_request()
+        # dummy request to terminate last serve_forever2.handle_request()
         sock = socket.socket()
         try:
             sock.connect(self.socket.getsockname())

--- a/acme/acme/standalone.py
+++ b/acme/acme/standalone.py
@@ -51,6 +51,7 @@ class ACMEServerMixin:  # pylint: disable=old-style-class
     allow_reuse_address = True
 
     def __init__(self):
+        self.timeout = 3
         self._stopped = False
 
     def serve_forever2(self):


### PR DESCRIPTION
I was able to recreate this problem a couple times locally today, but I wasn't able to track down the interleaving of events that caused the issue. With that said, I believe this is a simple fix to the problem.

In `ACMEServerMixin`, [self.timeout](https://docs.python.org/2/library/socketserver.html#SocketServer.BaseServer.timeout) gives us away to have `handle_request` return after `self.timeout` seconds if it has not received a request. If `shutdown2` has not been called, `handle_request` will be called again, but this allows the code to break out of the `handle_request` function and to check the value of `self._stopped`.

@kuba, I defer to you here as you know more about this code than I do, but I believe this is a trivial fix to the problem.