### PR TITLE
Fixed nits with plugin choice

### DIFF
--- a/letsencrypt/display/ops.py
+++ b/letsencrypt/display/ops.py
@@ -74,7 +74,7 @@ def pick_plugin(config, default, plugins, question, ifaces):
 
     if len(prepared) > 1:
         logger.debug("Multiple candidate plugins: %s", prepared)
-        plugin_ep = choose_plugin(prepared.values(), question)
+        plugin_ep = choose_plugin(prepared.values()[::-1], question)
         if plugin_ep is None:
             return None
         else:

--- a/letsencrypt/display/ops.py
+++ b/letsencrypt/display/ops.py
@@ -74,7 +74,7 @@ def pick_plugin(config, default, plugins, question, ifaces):
 
     if len(prepared) > 1:
         logger.debug("Multiple candidate plugins: %s", prepared)
-        plugin_ep = choose_plugin(prepared.values()[::-1], question)
+        plugin_ep = choose_plugin(prepared.values(), question)
         if plugin_ep is None:
             return None
         else:

--- a/letsencrypt/plugins/disco_test.py
+++ b/letsencrypt/plugins/disco_test.py
@@ -50,7 +50,9 @@ class PluginEntryPointTest(unittest.TestCase):
                 name, PluginEntryPoint.entry_point_to_plugin_name(entry_point))
 
     def test_description(self):
-        self.assertEqual("LE Will Automatically Test Your Domain", self.plugin_ep.description)
+        self.assertEqual(
+                "Run A Standalone Webserver To Prove That You Control Domains",
+                self.plugin_ep.description)
 
     def test_description_with_name(self):
         self.plugin_ep.plugin_cls = mock.MagicMock(description="Desc")

--- a/letsencrypt/plugins/disco_test.py
+++ b/letsencrypt/plugins/disco_test.py
@@ -50,7 +50,7 @@ class PluginEntryPointTest(unittest.TestCase):
                 name, PluginEntryPoint.entry_point_to_plugin_name(entry_point))
 
     def test_description(self):
-        self.assertEqual("Standalone Authenticator", self.plugin_ep.description)
+        self.assertEqual("LE Will Automatically Test Your Domain", self.plugin_ep.description)
 
     def test_description_with_name(self):
         self.plugin_ep.plugin_cls = mock.MagicMock(description="Desc")

--- a/letsencrypt/plugins/disco_test.py
+++ b/letsencrypt/plugins/disco_test.py
@@ -51,7 +51,7 @@ class PluginEntryPointTest(unittest.TestCase):
 
     def test_description(self):
         self.assertEqual(
-                "Run A Standalone Webserver To Prove That You Control Domains",
+                "Automatically configure and run a simple webserver",
                 self.plugin_ep.description)
 
     def test_description_with_name(self):

--- a/letsencrypt/plugins/manual.py
+++ b/letsencrypt/plugins/manual.py
@@ -32,7 +32,7 @@ class Authenticator(common.Plugin):
     zope.interface.implements(interfaces.IAuthenticator)
     zope.interface.classProvides(interfaces.IPluginFactory)
 
-    description = "Manual Authenticator"
+    description = "Manually Edit Your Configuration"
 
     MESSAGE_TEMPLATE = """\
 Make sure your web server displays the following content at
@@ -82,10 +82,10 @@ s.serve_forever()" """
     def more_info(self):  # pylint: disable=missing-docstring,no-self-use
         return """\
 This plugin requires user's manual intervention in setting up a HTTP
-server for solving SimpleHTTP challenges and thus does not need to be
-run as a privilidged process. Alternatively shows instructions on how
-to use Python's built-in HTTP server and, in case of HTTPS, openssl
-binary for temporary key/certificate generation.""".replace("\n", "")
+ server for solving SimpleHTTP challenges and thus does not need to be
+ run as a privilidged process. Alternatively shows instructions on how
+ to use Python's built-in HTTP server and, in case of HTTPS, openssl
+ binary for temporary key/certificate generation.""".replace("\n", "")
 
     def get_chall_pref(self, domain):
         # pylint: disable=missing-docstring,no-self-use,unused-argument

--- a/letsencrypt/plugins/manual.py
+++ b/letsencrypt/plugins/manual.py
@@ -26,17 +26,13 @@ logger = logging.getLogger(__name__)
 class Authenticator(common.Plugin):
     """Manual Authenticator.
 
-    This plugin requires user's manual intervention in setting up a HTTP
-    server for solving SimpleHTTP challenges and thus does not need to be
-    run as a privilidged process. Alternatively shows instructions on how
-    to use Python's built-in HTTP server and, in case of HTTPS, openssl
-    binary for temporary key/certificate generation.
+    .. todo:: Support for `~.challenges.DVSNI`.
     """
     zope.interface.implements(interfaces.IAuthenticator)
     zope.interface.classProvides(interfaces.IPluginFactory)
-#    hidden = True
+    hidden = True
 
-    description = "Manually Edit Your Configuration"
+    description = "Manually Configure And Run A Simple Python Webserver"
 
     MESSAGE_TEMPLATE = """\
 Make sure your web server displays the following content at
@@ -84,7 +80,11 @@ s.serve_forever()" """
         pass  # pragma: no cover
 
     def more_info(self):  # pylint: disable=missing-docstring,no-self-use
-        return self.__doc__.replace("\n    ", " ")
+        return ("This plugin requires user's manual intervention in setting "
+                "up a HTTP server for solving SimpleHTTP challenges and thus "
+                "does not need to be run as a privilidged process. "
+                "Alternatively shows instructions on how to use Python's "
+                "built-in HTTP server.")
 
     def get_chall_pref(self, domain):
         # pylint: disable=missing-docstring,no-self-use,unused-argument

--- a/letsencrypt/plugins/manual.py
+++ b/letsencrypt/plugins/manual.py
@@ -26,13 +26,18 @@ logger = logging.getLogger(__name__)
 class Authenticator(common.Plugin):
     """Manual Authenticator.
 
+       This plugin requires user's manual intervention in setting up a HTTP
+       server for solving SimpleHTTP challenges and thus does not need to be
+       run as a privilidged process. Alternatively shows instructions on how
+       to use Python's built-in HTTP server.
+
     .. todo:: Support for `~.challenges.DVSNI`.
     """
     zope.interface.implements(interfaces.IAuthenticator)
     zope.interface.classProvides(interfaces.IPluginFactory)
     hidden = True
 
-    description = "Manually Configure And Run A Simple Python Webserver"
+    description = "Manually configure and run a simple Python webserver"
 
     MESSAGE_TEMPLATE = """\
 Make sure your web server displays the following content at

--- a/letsencrypt/plugins/manual.py
+++ b/letsencrypt/plugins/manual.py
@@ -26,12 +26,15 @@ logger = logging.getLogger(__name__)
 class Authenticator(common.Plugin):
     """Manual Authenticator.
 
-    .. todo:: Support for `~.challenges.DVSNI`.
-
+    This plugin requires user's manual intervention in setting up a HTTP
+    server for solving SimpleHTTP challenges and thus does not need to be
+    run as a privilidged process. Alternatively shows instructions on how
+    to use Python's built-in HTTP server and, in case of HTTPS, openssl
+    binary for temporary key/certificate generation.
     """
     zope.interface.implements(interfaces.IAuthenticator)
     zope.interface.classProvides(interfaces.IPluginFactory)
-    hidden = True
+#    hidden = True
 
     description = "Manually Edit Your Configuration"
 
@@ -81,12 +84,7 @@ s.serve_forever()" """
         pass  # pragma: no cover
 
     def more_info(self):  # pylint: disable=missing-docstring,no-self-use
-        return """\
-This plugin requires user's manual intervention in setting up a HTTP
- server for solving SimpleHTTP challenges and thus does not need to be
- run as a privilidged process. Alternatively shows instructions on how
- to use Python's built-in HTTP server and, in case of HTTPS, openssl
- binary for temporary key/certificate generation.""".replace("\n", "")
+        return self.__doc__.replace("\n    ", " ")
 
     def get_chall_pref(self, domain):
         # pylint: disable=missing-docstring,no-self-use,unused-argument

--- a/letsencrypt/plugins/manual.py
+++ b/letsencrypt/plugins/manual.py
@@ -31,6 +31,7 @@ class Authenticator(common.Plugin):
     """
     zope.interface.implements(interfaces.IAuthenticator)
     zope.interface.classProvides(interfaces.IPluginFactory)
+    hidden = True
 
     description = "Manually Edit Your Configuration"
 

--- a/letsencrypt/plugins/standalone.py
+++ b/letsencrypt/plugins/standalone.py
@@ -134,8 +134,13 @@ def supported_challenges_validator(data):
 
 
 class Authenticator(common.Plugin):
-    """Standalone Authenticator."""
+    """Standalone Authenticator.
 
+    This authenticator creates its own ephemeral TCP listener on the
+    necessary port in order to respond to incoming DVSNI and SimpleHTTP
+    challenges from the certificate authority. Therefore, it does not
+    rely on any existing server program.
+    """
     zope.interface.implements(interfaces.IAuthenticator)
     zope.interface.classProvides(interfaces.IPluginFactory)
 
@@ -176,11 +181,7 @@ class Authenticator(common.Plugin):
                    self.conf("supported-challenges").split(","))
 
     def more_info(self):  # pylint: disable=missing-docstring
-        return """\
-This authenticator creates its own ephemeral TCP listener on the
- necessary port in order to respond to incoming DVSNI and SimpleHTTP
- challenges from the certificate authority. Therefore, it does not
- rely on any existing server program.""".replace("\n", "")
+        return self.__doc__.replace("\n    ", " ")
 
     def prepare(self):  # pylint: disable=missing-docstring
         pass

--- a/letsencrypt/plugins/standalone.py
+++ b/letsencrypt/plugins/standalone.py
@@ -134,18 +134,10 @@ def supported_challenges_validator(data):
 
 
 class Authenticator(common.Plugin):
-    """Standalone Authenticator.
-
-    This authenticator creates its own ephemeral TCP listener on the
-    necessary port in order to respond to incoming DVSNI and SimpleHTTP
-    challenges from the certificate authority. Therefore, it does not
-    rely on any existing server program.
-
-    """
     zope.interface.implements(interfaces.IAuthenticator)
     zope.interface.classProvides(interfaces.IPluginFactory)
 
-    description = "Standalone Authenticator"
+    description = "LE Will Automatically Test Your Domain"
 
     def __init__(self, *args, **kwargs):
         super(Authenticator, self).__init__(*args, **kwargs)
@@ -182,7 +174,11 @@ class Authenticator(common.Plugin):
                    self.conf("supported-challenges").split(","))
 
     def more_info(self):  # pylint: disable=missing-docstring
-        return self.__doc__
+        return """\
+This authenticator creates its own ephemeral TCP listener on the
+ necessary port in order to respond to incoming DVSNI and SimpleHTTP
+ challenges from the certificate authority. Therefore, it does not
+ rely on any existing server program.""".replace("\n","")
 
     def prepare(self):  # pylint: disable=missing-docstring
         pass

--- a/letsencrypt/plugins/standalone.py
+++ b/letsencrypt/plugins/standalone.py
@@ -144,7 +144,7 @@ class Authenticator(common.Plugin):
     zope.interface.implements(interfaces.IAuthenticator)
     zope.interface.classProvides(interfaces.IPluginFactory)
 
-    description = "LE Will Automatically Test Your Domain"
+    description = "Run A Standalone Webserver To Prove That You Control Domains"
 
     def __init__(self, *args, **kwargs):
         super(Authenticator, self).__init__(*args, **kwargs)
@@ -181,7 +181,10 @@ class Authenticator(common.Plugin):
                    self.conf("supported-challenges").split(","))
 
     def more_info(self):  # pylint: disable=missing-docstring
-        return self.__doc__.replace("\n    ", " ")
+        return("This authenticator creates its own ephemeral TCP listener "
+                "on the necessary port in order to respond to incoming DVSNI "
+                "and SimpleHTTP challenges from the certificate authority. "
+                "Therefore, it does not rely on any existing server program.")
 
     def prepare(self):  # pylint: disable=missing-docstring
         pass

--- a/letsencrypt/plugins/standalone.py
+++ b/letsencrypt/plugins/standalone.py
@@ -134,6 +134,8 @@ def supported_challenges_validator(data):
 
 
 class Authenticator(common.Plugin):
+    """Standalone Authenticator."""
+
     zope.interface.implements(interfaces.IAuthenticator)
     zope.interface.classProvides(interfaces.IPluginFactory)
 
@@ -178,7 +180,7 @@ class Authenticator(common.Plugin):
 This authenticator creates its own ephemeral TCP listener on the
  necessary port in order to respond to incoming DVSNI and SimpleHTTP
  challenges from the certificate authority. Therefore, it does not
- rely on any existing server program.""".replace("\n","")
+ rely on any existing server program.""".replace("\n", "")
 
     def prepare(self):  # pylint: disable=missing-docstring
         pass

--- a/letsencrypt/plugins/standalone.py
+++ b/letsencrypt/plugins/standalone.py
@@ -144,7 +144,7 @@ class Authenticator(common.Plugin):
     zope.interface.implements(interfaces.IAuthenticator)
     zope.interface.classProvides(interfaces.IPluginFactory)
 
-    description = "Run A Standalone Webserver To Prove That You Control Domains"
+    description = "Automatically configure and run a simple webserver"
 
     def __init__(self, *args, **kwargs):
         super(Authenticator, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Changed order of plugins listed - they'll now be reverse alphabetical
Made the descriptions of plugins not mimic their names
Made more_info for standalone work the same way as manual
Made more_info strings not have missing spaces due to stripped \n formatting by adding leading spaces