### PR TITLE
Remove CLI subparsers

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -655,7 +655,11 @@ class HelpfulArgumentParser(object):
         return parsed_args
 
     def determine_verb(self):
-        """Determines the verb/subcommand provided by the user."""
+        """Determines the verb/subcommand provided by the user.
+
+        This function works around some of the limitations of argparse.
+
+        """
         if "-h" in self.args or "--help" in self.args:
             # all verbs double as help arguments; don't get them confused
             self.verb = "help"
@@ -756,7 +760,7 @@ class HelpfulArgumentParser(object):
             return dict([(t, t == chosen_topic) for t in self.help_topics])
 
 
-def parse_args(plugins, args):
+def prepare_and_parse_args(plugins, args):
     """Returns parsed command line arguments.
 
     :param .PluginsRegistry plugins: available plugins
@@ -1040,7 +1044,7 @@ def main(cli_args=sys.argv[1:]):
 
     # note: arg parser internally handles --help (and exits afterwards)
     plugins = plugins_disco.PluginsRegistry.find_all()
-    args = parse_args(plugins, cli_args)
+    args = prepare_and_parse_args(plugins, cli_args)
     config = configuration.NamespaceConfig(args)
     zope.component.provideUtility(config)
 

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -341,7 +341,7 @@ def diagnose_configurator_problem(cfg_type, requested, plugins):
 
     :param str cfg_type: either "installer" or "authenticator"
     :param str requested: the plugin that was requested
-    :param PluginRegistry plugins: available plugins
+    :param .PluginsRegistry plugins: available plugins
 
     :raises error.PluginSelectionError: if there was a problem
     """

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -372,8 +372,13 @@ class MockedVerb(object):
     """Simple class that can be used for mocking out verbs/subcommands.
 
     Storing a dictionary of verbs and the functions that implement them
-    makes mocking much more complicated. This class can be used as a
-    simple context manager for mocking out verbs in CLI tests.
+    in letsencrypt.cli makes mocking much more complicated. This class
+    can be used as a simple context manager for mocking out verbs in CLI
+    tests. For example:
+
+    with MockedVerb("run") as mock_run:
+        self._call([])
+        self.assertEqual(1, mock_run.call_count)
 
     """
     def __init__(self, verb_name):


### PR DESCRIPTION
Subparsers in `cli.py` have been an unfortunate source of problems for us (most of which are due to problems upstream). This PR removes them completely and fixes #640 and #892.

cc @pde