### PR TITLE
removed extra path

### DIFF
--- a/bootstrap/install-deps.sh
+++ b/bootstrap/install-deps.sh
@@ -9,7 +9,7 @@ else
   SUDO=
 fi
 
-BOOTSTRAP=`dirname $0`/bootstrap
+BOOTSTRAP=`dirname $0`/
 if [ ! -f $BOOTSTRAP/debian.sh ] ; then
   echo "Cannot find the letsencrypt bootstrap scripts in $BOOTSTRAP"
   exit 1

--- a/bootstrap/install-deps.sh
+++ b/bootstrap/install-deps.sh
@@ -9,7 +9,7 @@ else
   SUDO=
 fi
 
-BOOTSTRAP=`dirname $0`/
+BOOTSTRAP=`dirname $0`
 if [ ! -f $BOOTSTRAP/debian.sh ] ; then
   echo "Cannot find the letsencrypt bootstrap scripts in $BOOTSTRAP"
   exit 1


### PR DESCRIPTION
```
root@localhost:~# cd letsencrypt/
root@localhost:~/letsencrypt# ./bootstrap/install-deps.sh 
Cannot find the letsencrypt bootstrap scripts in ./bootstrap/bootstrap

```

However, with the proposed change

```
root@localhost:~/letsencrypt# ./bootstrap/install-deps.sh 
Bootstrapping dependencies for Debian-based OSes...
Ign http://mirrors.linode.com jessie InRelease
Hit http://mirrors.linode.com jessie-updates InRelease  
```