### PR TITLE
Fix BOOTSTRAP path.

### DIFF
--- a/bootstrap/install-deps.sh
+++ b/bootstrap/install-deps.sh
@@ -9,7 +9,7 @@ else
   SUDO=
 fi
 
-BOOTSTRAP=`dirname $0`/bootstrap
+BOOTSTRAP=`dirname $0`/../bootstrap
 if [ ! -f $BOOTSTRAP/debian.sh ] ; then
   echo "Cannot find the letsencrypt bootstrap scripts in $BOOTSTRAP"
   exit 1


### PR DESCRIPTION
Running ./bootstrap/install-deps.sh returns error:
Cannot find the letsencrypt bootstrap scripts in ./bootstrap/bootstrap