### PR TITLE
Fix for issue #1030

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -805,7 +805,6 @@ def create_parser(plugins, args):
     helpful.add(
         "security", "-B", "--rsa-key-size", type=int, metavar="N",
         default=flag_default("rsa_key_size"), help=config_help("rsa_key_size"))
-    # TODO: resolve - assumes binary logic while client.py assumes ternary.
     helpful.add(
         "security", "-r", "--redirect", action="store_true",
         help="Automatically redirect all HTTP traffic to HTTPS for the newly "
@@ -1107,3 +1106,4 @@ if __name__ == "__main__":
     if err_string:
         logger.warn("Exiting with message %s", err_string)
     sys.exit(err_string)  # pragma: no cover
+v

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -436,6 +436,7 @@ def run(args, config, plugins):  # pylint: disable=too-many-branches,too-many-lo
     le_client.deploy_certificate(
         domains, lineage.privkey, lineage.cert,
         lineage.chain, lineage.fullchain)
+
     le_client.enhance_config(domains, args.redirect)
 
     if len(lineage.available_versions("cert")) == 1:
@@ -808,7 +809,11 @@ def create_parser(plugins, args):
     helpful.add(
         "security", "-r", "--redirect", action="store_true",
         help="Automatically redirect all HTTP traffic to HTTPS for the newly "
-             "authenticated vhost.")
+             "authenticated vhost.", dest="redirect", default=None)
+    helpful.add(
+        "security", "-n", "--no-redirect", action="store_false",
+        help="Do not automatically redirect all HTTP traffic to HTTPS for the newly "
+             "authenticated vhost.", dest="redirect", default=None)
     helpful.add(
         "security", "--strict-permissions", action="store_true",
         help="Require that all configuration files are owned by the current "

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -1106,4 +1106,3 @@ if __name__ == "__main__":
     if err_string:
         logger.warn("Exiting with message %s", err_string)
     sys.exit(err_string)  # pragma: no cover
-v

--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -20,6 +20,7 @@ letsencrypt_test () {
         --manual-test-mode \
         $store_flags \
         --text \
+        --redirect \
         --agree-dev-preview \
         --agree-tos \
         --email "" \

--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -20,7 +20,7 @@ letsencrypt_test () {
         --manual-test-mode \
         $store_flags \
         --text \
-        -r \
+        --no-redirect \
         --agree-dev-preview \
         --agree-tos \
         --email "" \

--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -20,7 +20,7 @@ letsencrypt_test () {
         --manual-test-mode \
         $store_flags \
         --text \
-        --redirect \
+        -r \
         --agree-dev-preview \
         --agree-tos \
         --email "" \


### PR DESCRIPTION
Fixes the argparse flag issue in which the '-r, --redirect' flag was set as a binary value, yet was assumed to be ternary in client.py.