### PR TITLE
Fix DST caused 1 hour offset in parse_time_interval() function

### DIFF
--- a/letsencrypt/storage.py
+++ b/letsencrypt/storage.py
@@ -1,4 +1,5 @@
 """Renewable certificates storage."""
+import calendar
 import datetime
 import os
 import re
@@ -40,8 +41,8 @@ def parse_time_interval(interval, textparser=parsedatetime.Calendar()):
 
     if interval.strip().isdigit():
         interval += " days"
-    return datetime.timedelta(0, time.mktime(textparser.parse(
-        interval, time.localtime(0))[0]))
+    return datetime.timedelta(0, calendar.timegm(textparser.parse(
+        interval, time.gmtime(0))[0]))
 
 
 class RenewableCert(object):  # pylint: disable=too-many-instance-attributes


### PR DESCRIPTION
The `parse_time_interval()` function was using `time.localtime()` and `time.mktime()` functions, which will use local time zone and DST settings, in some circumstances it will result in 1 hour offset.

This PR will fix this bug by using GMT (aka UTC) time instead of local time.