### PR TITLE
Ask for email unless --allow-unsafe-registration

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -127,7 +127,7 @@ def _determine_account(args, config):
         elif len(accounts) == 1:
             acc = accounts[0]
         else:  # no account registered yet
-            if args.email is None and not args.allow_unsafe_registration:
+            if args.email is None and not args.register_unsafely_without_email:
                 args.email = display_ops.get_email()
             else:
                 args.email = None
@@ -783,7 +783,7 @@ def prepare_and_parse_args(plugins, args):
         None, "-t", "--text", dest="text_mode", action="store_true",
         help="Use the text output instead of the curses UI.")
     helpful.add(
-        None, "--allow-unsafe-registration", action="store_true",
+        None, "--register-unsafely-without-email", action="store_true",
         help="Specifying this flag enables registering an account with no "
              "email address. This is strongly discouraged, because in the "
              "event of key loss or account compromise you will irrevocably "

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -127,9 +127,9 @@ def _determine_account(args, config):
         elif len(accounts) == 1:
             acc = accounts[0]
         else:  # no account registered yet
-            if args.email is None:
+            if args.email is None and not args.allow_unsafe_registration:
                 args.email = display_ops.get_email()
-            if not args.email:  # get_email might return ""
+            else:
                 args.email = None
 
             def _tos_cb(regr):
@@ -782,6 +782,16 @@ def prepare_and_parse_args(plugins, args):
     helpful.add(
         None, "-t", "--text", dest="text_mode", action="store_true",
         help="Use the text output instead of the curses UI.")
+    helpful.add(
+        None, "--allow-unsafe-registration", action="store_true",
+        help="Specifying this flag enables registering an account with no "
+             "email address. This is strongly discouraged, because in the "
+             "event of key loss or account compromise you will irrevocably "
+             "lose access to your account. You will also be unable to receive "
+             "notice about impending expiration of revocation of your "
+             "certificates. Updates to the Subscriber Agreement will still "
+             "affect you, and will be effective N days after posting an "
+             "update to the web site.")
     helpful.add(None, "-m", "--email", help=config_help("email"))
     # positional arg shadows --domains, instead of appending, and
     # --domains is useful, because it can be stored in config

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -129,7 +129,7 @@ def _determine_account(args, config):
         else:  # no account registered yet
             if args.email is None and not args.register_unsafely_without_email:
                 args.email = display_ops.get_email()
-            else:
+            if not args.email:  # get_email might return ""
                 args.email = None
 
             def _tos_cb(regr):

--- a/letsencrypt/client.py
+++ b/letsencrypt/client.py
@@ -76,6 +76,11 @@ def register(config, account_storage, tos_cb=None):
     if account_storage.find_all():
         logger.info("There are already existing accounts for %s", config.server)
     if config.email is None:
+        if not config.register_unsafely_without_email:
+            msg = ("No email was provided and "
+                   "--register-unsafely-without-email was not present.")
+            logger.warn(msg)
+            raise errors.Error(msg)
         logger.warn("Registering without email!")
 
     # Each new registration shall use a fresh new key

--- a/letsencrypt/display/ops.py
+++ b/letsencrypt/display/ops.py
@@ -124,9 +124,10 @@ def get_email():
     """
     while True:
         code, email = zope.component.getUtility(interfaces.IDisplay).input(
-            "Enter email address (mandatory since no "
-            "--allow-unsafe-registration was provided)"
-            "(used for urgent notices and lost key recovery)")
+            "Enter email address "
+            "(used for urgent notices and lost key recovery)\n\n"
+            "If you really want to skip this, run the client with "
+            "--register-unsafely-without-email")
 
         if code == display_util.OK:
             if le_util.safe_email(email):

--- a/letsencrypt/display/ops.py
+++ b/letsencrypt/display/ops.py
@@ -124,7 +124,9 @@ def get_email():
     """
     while True:
         code, email = zope.component.getUtility(interfaces.IDisplay).input(
-            "Enter email address (used for urgent notices and lost key recovery)")
+            "Enter email address (mandatory since no "
+            "--allow-unsafe-registration was provided)"
+            "(used for urgent notices and lost key recovery)")
 
         if code == display_util.OK:
             if le_util.safe_email(email):

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -307,6 +307,7 @@ class DetermineAccountTest(unittest.TestCase):
     @mock.patch('letsencrypt.client.display_ops.get_email')
     def test_no_accounts_no_email(self, mock_get_email):
         mock_get_email.return_value = 'foo@bar.baz'
+        self.args.register_unsafely_without_email = False
 
         with mock.patch('letsencrypt.cli.client') as client:
             client.register.return_value = (
@@ -320,12 +321,20 @@ class DetermineAccountTest(unittest.TestCase):
 
     def test_no_accounts_email(self):
         self.args.email = 'other email'
+        self.args.register_unsafely_without_email = False
         with mock.patch('letsencrypt.cli.client') as client:
             client.register.return_value = (self.accs[1], mock.sentinel.acme)
             self._call()
         self.assertEqual(self.accs[1].id, self.args.account)
         self.assertEqual('other email', self.args.email)
 
+    def test_no_accounts_no_email_unsafe(self):
+        self.args.register_unsafely_without_email = True
+        with mock.patch('letsencrypt.cli.client') as client:
+            client.register.return_value = (self.accs[1], mock.sentinel.acme)
+            self._call()
+        self.assertEqual(self.accs[1].id, self.args.account)
+        self.assertEqual(None, self.args.email)
 
 class DuplicativeCertsTest(renewer_test.BaseRenewableCertTest):
     """Test to avoid duplicate lineages."""


### PR DESCRIPTION
Add new option that explicitly allows to not provide an email.
Fixes #414