### PR TITLE
Add disclaimer about IP logging in the manual authentication plugin

### DIFF
--- a/letsencrypt/plugins/manual.py
+++ b/letsencrypt/plugins/manual.py
@@ -162,7 +162,7 @@ binary for temporary key/certificate generation.""".replace("\n", "")
         else:
             if not zope.component.getUtility(interfaces.IDisplay).yesno(
                     self.IP_DISCLAIMER, "Yes", "No"):
-                raise errors.Error("Must agree to IP logging to proceed")
+                raise errors.PluginError("Must agree to IP logging to proceed")
 
             self._notify_and_wait(self.MESSAGE_TEMPLATE.format(
                 validation=validation.json_dumps(), response=response,

--- a/letsencrypt/plugins/manual.py
+++ b/letsencrypt/plugins/manual.py
@@ -162,7 +162,7 @@ binary for temporary key/certificate generation.""".replace("\n", "")
         else:
             if not zope.component.getUtility(interfaces.IDisplay).yesno(
                     self.IP_DISCLAIMER, "Yes", "No"):
-                raise errors.Error("Must agree to proceed")
+                raise errors.Error("Must agree to IP logging to proceed")
 
             self._notify_and_wait(self.MESSAGE_TEMPLATE.format(
                 validation=validation.json_dumps(), response=response,

--- a/letsencrypt/plugins/manual.py
+++ b/letsencrypt/plugins/manual.py
@@ -161,7 +161,7 @@ binary for temporary key/certificate generation.""".replace("\n", "")
                 raise errors.Error("Couldn't execute manual command")
         else:
             if not zope.component.getUtility(interfaces.IDisplay).yesno(
-                self.IP_DISCLAIMER, "Yes", "No"):
+                    self.IP_DISCLAIMER, "Yes", "No"):
                 raise errors.Error("Must agree to proceed")
 
             self._notify_and_wait(self.MESSAGE_TEMPLATE.format(

--- a/letsencrypt/plugins/manual.py
+++ b/letsencrypt/plugins/manual.py
@@ -48,6 +48,15 @@ command on the target server (as root):
 {command}
 """
 
+    # a disclaimer about your current IP being transmitted to Let's Encrypt's servers.
+    IP_DISCLAIMER = """\
+NOTE: The IP of this machine will be publicly logged as having requested this certificate. \
+If you're running letsencrypt in manual mode on a machine that is not your server, \
+please ensure you're okay with that.
+
+Are you OK with your IP being logged?
+"""
+
     # "cd /tmp/letsencrypt" makes sure user doesn't serve /root,
     # separate "public_html" ensures that cert.pem/key.pem are not
     # served and makes it more obvious that Python command will serve
@@ -151,6 +160,10 @@ binary for temporary key/certificate generation.""".replace("\n", "")
             if self._httpd.poll() is not None:
                 raise errors.Error("Couldn't execute manual command")
         else:
+            if not zope.component.getUtility(interfaces.IDisplay).yesno(
+                self.IP_DISCLAIMER, "Yes", "No"):
+                raise errors.Error("Must agree to proceed")
+
             self._notify_and_wait(self.MESSAGE_TEMPLATE.format(
                 validation=validation.json_dumps(), response=response,
                 uri=response.uri(achall.domain, achall.challb.chall),

--- a/letsencrypt/plugins/manual_test.py
+++ b/letsencrypt/plugins/manual_test.py
@@ -110,11 +110,11 @@ class AuthenticatorTest(unittest.TestCase):
     @mock.patch("letsencrypt.plugins.manual.sys.stdout")
     @mock.patch("acme.challenges.SimpleHTTPResponse.simple_verify")
     @mock.patch("__builtin__.raw_input")
-    def test_disagree_with_ip_logging(self, mock_raw_input, mock_verify, mock_stdout, mock_interaction):
-        mock_verify.return_value = True
+    def test_disagree_with_ip_logging(self, mock_raw_input, mock_verify, mock_stdout,
+                                      mock_interaction):
+        # pylint: disable=unused-argument
         mock_interaction().yesno.return_value = False
 
-        resp = challenges.SimpleHTTPResponse(tls=False)
         with self.assertRaises(errors.PluginError):
             self.auth.perform(self.achalls)
 

--- a/letsencrypt/plugins/manual_test.py
+++ b/letsencrypt/plugins/manual_test.py
@@ -43,11 +43,11 @@ class AuthenticatorTest(unittest.TestCase):
     def test_perform_empty(self):
         self.assertEqual([], self.auth.perform([]))
 
-    @mock.patch("letsencrypt.proof_of_possession.zope.component.getUtility")
+    @mock.patch("letsencrypt.plugins.manual.zope.component.getUtility")
     @mock.patch("letsencrypt.plugins.manual.sys.stdout")
     @mock.patch("acme.challenges.SimpleHTTPResponse.simple_verify")
     @mock.patch("__builtin__.raw_input")
-    def test_perform(self, mock_raw_input, mock_verify, mock_stdout, mock_input, mock_interaction):
+    def test_perform(self, mock_raw_input, mock_verify, mock_stdout, mock_interaction):
         mock_verify.return_value = True
         mock_interaction.yesno.return_value = True
 

--- a/letsencrypt/plugins/manual_test.py
+++ b/letsencrypt/plugins/manual_test.py
@@ -67,7 +67,8 @@ class AuthenticatorTest(unittest.TestCase):
     @mock.patch("letsencrypt.plugins.manual.Authenticator._notify_and_wait")
     def test_disagree_with_ip_logging(self, mock_notify, mock_interaction):
         mock_interaction().yesno.return_value = False
-        mock_notify.side_effect = errors.Error("Exception not raised, continued execution even after disagreeing with IP logging")
+        mock_notify.side_effect = errors.Error("Exception not raised, \
+            continued execution even after disagreeing with IP logging")
 
         self.assertRaises(errors.PluginError, self.auth.perform, self.achalls)
 

--- a/letsencrypt/plugins/manual_test.py
+++ b/letsencrypt/plugins/manual_test.py
@@ -115,8 +115,7 @@ class AuthenticatorTest(unittest.TestCase):
         # pylint: disable=unused-argument
         mock_interaction().yesno.return_value = False
 
-        with self.assertRaises(errors.PluginError):
-            self.auth.perform(self.achalls)
+        self.assertRaises(errors.PluginError, self.auth.perform, self.achalls)
 
 
 if __name__ == "__main__":

--- a/letsencrypt/plugins/manual_test.py
+++ b/letsencrypt/plugins/manual_test.py
@@ -106,6 +106,18 @@ class AuthenticatorTest(unittest.TestCase):
         self.auth_test_mode.cleanup(self.achalls)
         mock_killpg.assert_called_once_with(1234, signal.SIGTERM)
 
+    @mock.patch("letsencrypt.plugins.manual.zope.component.getUtility")
+    @mock.patch("letsencrypt.plugins.manual.sys.stdout")
+    @mock.patch("acme.challenges.SimpleHTTPResponse.simple_verify")
+    @mock.patch("__builtin__.raw_input")
+    def test_disagree_with_ip_logging(self, mock_raw_input, mock_verify, mock_stdout, mock_interaction):
+        mock_verify.return_value = True
+        mock_interaction().yesno.return_value = False
+
+        resp = challenges.SimpleHTTPResponse(tls=False)
+        with self.assertRaises(errors.PluginError):
+            self.auth.perform(self.achalls)
+
 
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover

--- a/letsencrypt/plugins/manual_test.py
+++ b/letsencrypt/plugins/manual_test.py
@@ -49,7 +49,7 @@ class AuthenticatorTest(unittest.TestCase):
     @mock.patch("__builtin__.raw_input")
     def test_perform(self, mock_raw_input, mock_verify, mock_stdout, mock_interaction):
         mock_verify.return_value = True
-        mock_interaction.yesno.return_value = True
+        mock_interaction().yesno.return_value = True
 
         resp = challenges.SimpleHTTPResponse(tls=False)
         self.assertEqual([resp], self.auth.perform(self.achalls))

--- a/letsencrypt/plugins/manual_test.py
+++ b/letsencrypt/plugins/manual_test.py
@@ -63,6 +63,12 @@ class AuthenticatorTest(unittest.TestCase):
         mock_verify.return_value = False
         self.assertEqual([None], self.auth.perform(self.achalls))
 
+    @mock.patch("letsencrypt.plugins.manual.zope.component.getUtility")
+    def test_disagree_with_ip_logging(self, mock_interaction):
+        mock_interaction().yesno.return_value = False
+
+        self.assertRaises(errors.PluginError, self.auth.perform, self.achalls)
+
     @mock.patch("letsencrypt.plugins.manual.subprocess.Popen", autospec=True)
     def test_perform_test_command_oserror(self, mock_popen):
         mock_popen.side_effect = OSError
@@ -105,17 +111,6 @@ class AuthenticatorTest(unittest.TestCase):
         httpd.poll.return_value = None
         self.auth_test_mode.cleanup(self.achalls)
         mock_killpg.assert_called_once_with(1234, signal.SIGTERM)
-
-    @mock.patch("letsencrypt.plugins.manual.zope.component.getUtility")
-    @mock.patch("letsencrypt.plugins.manual.sys.stdout")
-    @mock.patch("acme.challenges.SimpleHTTPResponse.simple_verify")
-    @mock.patch("__builtin__.raw_input")
-    def test_disagree_with_ip_logging(self, mock_raw_input, mock_verify, mock_stdout,
-                                      mock_interaction):
-        # pylint: disable=unused-argument
-        mock_interaction().yesno.return_value = False
-
-        self.assertRaises(errors.PluginError, self.auth.perform, self.achalls)
 
 
 if __name__ == "__main__":

--- a/letsencrypt/plugins/manual_test.py
+++ b/letsencrypt/plugins/manual_test.py
@@ -43,11 +43,13 @@ class AuthenticatorTest(unittest.TestCase):
     def test_perform_empty(self):
         self.assertEqual([], self.auth.perform([]))
 
+    @mock.patch("letsencrypt.proof_of_possession.zope.component.getUtility")
     @mock.patch("letsencrypt.plugins.manual.sys.stdout")
     @mock.patch("acme.challenges.SimpleHTTPResponse.simple_verify")
     @mock.patch("__builtin__.raw_input")
-    def test_perform(self, mock_raw_input, mock_verify, mock_stdout):
+    def test_perform(self, mock_raw_input, mock_verify, mock_stdout, mock_input, mock_interaction):
         mock_verify.return_value = True
+        mock_interaction.yesno.return_value = True
 
         resp = challenges.SimpleHTTPResponse(tls=False)
         self.assertEqual([resp], self.auth.perform(self.achalls))

--- a/letsencrypt/plugins/manual_test.py
+++ b/letsencrypt/plugins/manual_test.py
@@ -64,8 +64,10 @@ class AuthenticatorTest(unittest.TestCase):
         self.assertEqual([None], self.auth.perform(self.achalls))
 
     @mock.patch("letsencrypt.plugins.manual.zope.component.getUtility")
-    def test_disagree_with_ip_logging(self, mock_interaction):
+    @mock.patch("letsencrypt.plugins.manual.Authenticator._notify_and_wait")
+    def test_disagree_with_ip_logging(self, mock_notify, mock_interaction):
         mock_interaction().yesno.return_value = False
+        mock_notify.side_effect = errors.Error("Exception not raised, continued execution even after disagreeing with IP logging")
 
         self.assertRaises(errors.PluginError, self.auth.perform, self.achalls)
 


### PR DESCRIPTION
Fixes #991.
![ip_logging_disclaimer](https://cloud.githubusercontent.com/assets/4635721/10713763/857a8e9c-7a96-11e5-8998-4e2c4f72931d.png)
Here's [a terminal recording](https://asciinema.org/a/2xmxfq43nxb9a9muiu3q290z7)!