### PR TITLE
Point out required dependencies

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -25,6 +25,12 @@ above method instead.
 Installation and Usage
 ======================
 
+Make sure you have the following dependencies installed on your system:
+
+- virtualenv
+- python2-libaugeas
+- dialog
+
 To install and run the client you just need to type:
 
 .. code-block:: shell
@@ -35,19 +41,15 @@ To install and run the client you just need to type:
 ``letsencrypt``.  ``letsencrypt-auto`` is a wrapper which installs virtualized
 dependencies and provides automated updates during the beta program)
 
+.. warning:: Please do **not** use ``python setup.py install`` or ``sudo pip install`.
+             Those mode of operation might corrupt your operating system and is
+             **not supported** by the Let's Encrypt team!
+
 The ``letsencrypt`` commandline tool has a builtin help:
 
 .. code-block:: shell
 
    ./letsencrypt-auto --help
-
-.. warning:: Please do **not** use ``python setup.py install`` or
-   ``python pip install .``. Please do **not** attempt the
-   installation commands as superuser/root and/or without virtual
-   environment, e.g. ``sudo python setup.py install``, ``sudo pip
-   install``, ``sudo ./venv/bin/...``. These modes of operation might
-   corrupt your operating system and are **not supported** by the
-   Let's Encrypt team!
 
 
 Configuration file


### PR DESCRIPTION
Since this is used in the beta-program only, a short hint in the documentation should be sufficient.
Otherwise the dependencies should be checked by the script.