### PR TITLE
Remove AAAA record check suggestion

### DIFF
--- a/letsencrypt/auth_handler.py
+++ b/letsencrypt/auth_handler.py
@@ -486,7 +486,7 @@ def is_preferred(offered_challb, satisfied,
 
 _ERROR_HELP_COMMON = (
     "To fix these errors, please make sure that your domain name was entered "
-    "correctly and the DNS A/AAAA record(s) for that domain contains the "
+    "correctly and the DNS A record(s) for that domain contains the "
     "right IP address.")
 
 


### PR DESCRIPTION
Boulder doesn't support ipv6 validation, so don't confuse people
by asking them to check their AAAA record(s). Fixes #1134.