### PR TITLE
New verbs && plugin help changes if the plugins are not installed.

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -377,7 +377,7 @@ def choose_configurator_plugins(args, config, plugins, verb):
 
     # Which plugins do we need?
     need_inst = need_auth = (verb == "run")
-    if verb in ("auth","certonly"):
+    if verb in ("auth", "certonly"):
         need_auth = True
     if verb == "install":
         need_inst = True
@@ -669,7 +669,12 @@ class HelpfulArgumentParser(object):
 
         for i, token in enumerate(self.args):
             if token in self.VERBS:
-                self.verb = token
+                verb = token
+                if verb == "certonly":
+                    verb = "auth"
+                if verb == "everything":
+                    verb = "run"
+                self.verb = verb
                 self.args.pop(i)
                 return
 

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -622,7 +622,8 @@ class HelpfulArgumentParser(object):
     """
 
     # Maps verbs/subcommands to the functions that implement them
-    VERBS = {"auth": obtaincert, "certonly": obtaincert, "config_changes": config_changes,
+    VERBS = {"auth": obtaincert, "certonly": obtaincert,
+             "config_changes": config_changes, "everything": run,
              "install": install, "plugins": plugins_cmd,
              "revoke": revoke, "rollback": rollback, "run": run}
 

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -69,6 +69,11 @@ if "nginx" in plugins:
     nginx_doc = "--nginx           Use the Nginx plugin for authentication & installation"
 else:
     nginx_doc = "(nginx support is experimental, buggy, and not installed by default)"
+if "apache" in plugins:
+    apache_doc = "--apache          Use the Apache plugin for authentication & installation"
+else:
+    apache_doc = "(the apache plugin is not installed)"
+
 
 
 # This is the short help for letsencrypt --help, where we disable argparse

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -377,7 +377,7 @@ def choose_configurator_plugins(args, config, plugins, verb):
 
     # Which plugins do we need?
     need_inst = need_auth = (verb == "run")
-    if verb in ("auth", "certonly"):
+    if verb == "auth":
         need_auth = True
     if verb == "install":
         need_inst = True
@@ -457,7 +457,7 @@ def auth(args, config, plugins):
 
     try:
         # installers are used in auth mode to determine domain names
-        installer, authenticator = choose_configurator_plugins(args, config, plugins, "certonly")
+        installer, authenticator = choose_configurator_plugins(args, config, plugins, "auth")
     except PluginSelectionError, e:
         return e.message
 
@@ -481,7 +481,7 @@ def install(args, config, plugins):
     # XXX: Update for renewer/RenewableCert
 
     try:
-        installer, _ = choose_configurator_plugins(args, config, plugins, "certonly")
+        installer, _ = choose_configurator_plugins(args, config, plugins, "auth")
     except PluginSelectionError, e:
         return e.message
 
@@ -899,7 +899,7 @@ def _paths_parser(helpful):
         "paths", description="Arguments changing execution paths & servers")
 
     cph = "Path to where cert is saved (with auth), installed (with install --csr) or revoked."
-    if verb in ("auth", "certonly"):
+    if verb == "auth":
         add("paths", "--cert-path", default=flag_default("auth_cert_path"), help=cph)
     elif verb == "revoke":
         add("paths", "--cert-path", type=read_file, required=True, help=cph)
@@ -912,7 +912,7 @@ def _paths_parser(helpful):
         help="Path to private key for cert creation or revocation (if account key is missing)")
 
     default_cp = None
-    if verb in ("auth", "certonly"):
+    if verb == "auth":
         default_cp = flag_default("auth_chain_path")
     add("paths", "--fullchain-path", default=default_cp,
         help="Accompanying path to a full certificate chain (cert plus chain).")

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -64,18 +64,24 @@ the cert. Major SUBCOMMANDS are:
 
 """
 
+plugins = plugins_disco.PluginsRegistry.find_all()
+if "nginx" in plugins:
+    nginx_doc = "--nginx           Use the Nginx plugin for authentication & installation"
+else:
+    nginx_doc = "(nginx support is experimental, buggy, and not installed by default)"
+
 
 # This is the short help for letsencrypt --help, where we disable argparse
 # altogether
 USAGE = SHORT_USAGE + """Choice of server plugins for obtaining and installing cert:
 
   --apache          Use the Apache plugin for authentication & installation
-  --nginx           Use the Nginx plugin for authentication & installation
   --standalone      Run a standalone webserver for authentication
+  %s
 
 OR use different servers to obtain (authenticate) the cert and then install it:
 
-  --authenticator standalone --installer nginx
+  --authenticator standalone --installer apache
 
 More detailed help:
 
@@ -84,7 +90,7 @@ More detailed help:
 
    all, automation, paths, security, testing, or any of the subcommands or
    plugins (certonly, install, nginx, apache, standalone, etc)
-"""
+""" % nginx_doc
 
 
 def _find_domains(args, installer):
@@ -1061,7 +1067,7 @@ def main(cli_args=sys.argv[1:]):
     sys.excepthook = functools.partial(_handle_exception, args=None)
 
     # note: arg parser internally handles --help (and exits afterwards)
-    plugins = plugins_disco.PluginsRegistry.find_all()
+    global plugins
     args = prepare_and_parse_args(plugins, cli_args)
     config = configuration.NamespaceConfig(args)
     zope.component.provideUtility(config)

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -56,7 +56,7 @@ default, it will attempt to use a webserver both for obtaining and installing
 the cert. Major SUBCOMMANDS are:
 
   (default) run        Obtain & install a cert in your current webserver
-  certonly             Aka "auth": obtain cert, but do not install it
+  certonly             Obtain cert, but do not install it (aka "auth")
   install              Install a previously obtained cert in a server
   revoke               Revoke a previously obtained certificate
   rollback             Rollback server configuration changes made during install
@@ -67,12 +67,14 @@ the cert. Major SUBCOMMANDS are:
 
 # This is the short help for letsencrypt --help, where we disable argparse
 # altogether
-USAGE = SHORT_USAGE + """Choice of server for authentication/installation:
+USAGE = SHORT_USAGE + """Choice of server plugins for obtaining and installing cert:
 
   --apache          Use the Apache plugin for authentication & installation
   --nginx           Use the Nginx plugin for authentication & installation
   --standalone      Run a standalone webserver for authentication
-  OR:
+
+OR use different servers to obtain (authenticate) the cert and then install it:
+
   --authenticator standalone --installer nginx
 
 More detailed help:
@@ -80,8 +82,8 @@ More detailed help:
   -h, --help [topic]    print this message, or detailed help on a topic;
                         the available topics are:
 
-   all, apache, automation, manual, nginx, paths, security, testing, or any of
-   the subcommands
+   all, automation, paths, security, testing, or any of the subcommands or
+   plugins (certonly, install, nginx, apache, standalone, etc)
 """
 
 
@@ -759,6 +761,10 @@ class HelpfulArgumentParser(object):
         """
         # topics maps each topic to whether it should be documented by
         # argparse on the command line
+        if chosen_topic == "certonly":
+            chosen_topic = "auth"
+        if chosen_topic == "everything":
+            chosen_topic = "run"
         if chosen_topic == "all":
             return dict([(t, True) for t in self.help_topics])
         elif not chosen_topic:

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -69,30 +69,42 @@ class CLITest(unittest.TestCase):
         self.assertRaises(SystemExit, self._call, ['--help', 'all'])
         output = StringIO.StringIO()
         with mock.patch('letsencrypt.cli.sys.stdout', new=output):
+            plugins = disco.PluginsRegistry.find_all()
             self.assertRaises(SystemExit, self._call_stdout, ['--help', 'all'])
             out = output.getvalue()
             self.assertTrue("--configurator" in out)
             self.assertTrue("how a cert is deployed" in out)
             self.assertTrue("--manual-test-mode" in out)
             output.truncate(0)
+
             self.assertRaises(SystemExit, self._call_stdout, ['-h', 'nginx'])
             out = output.getvalue()
-            if "nginx" in disco.PluginsRegistry.find_all():
+            if "nginx" in plugins:
                 # may be false while building distributions without plugins
                 self.assertTrue("--nginx-ctl" in out)
             self.assertTrue("--manual-test-mode" not in out)
             self.assertTrue("--checkpoints" not in out)
             output.truncate(0)
+
+            self.assertRaises(SystemExit, self._call_stdout, ['-h'])
+            out = output.getvalue()
+            if "nginx" in plugins:
+                self.assertTrue("Use the Nginx plugin" in out)
+            else:
+                self.assertTrue("(nginx support is experimental" in out)
+            output.truncate(0)
+
             self.assertRaises(SystemExit, self._call_stdout, ['--help', 'plugins'])
             out = output.getvalue()
             self.assertTrue("--manual-test-mode" not in out)
             self.assertTrue("--prepare" in out)
             self.assertTrue("Plugin options" in out)
             output.truncate(0)
+
             self.assertRaises(SystemExit, self._call_stdout, ['-h'])
             out = output.getvalue()
             from letsencrypt import cli
-            self.assertTrue(cli.USAGE in out)
+            self.assertTrue(cli.usage_strings(plugins)[0] in out)
 
     def test_configurator_selection(self):
         real_plugins = disco.PluginsRegistry.find_all()

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -116,6 +116,7 @@ class CLITest(unittest.TestCase):
             ret, _, _, _ = self._call(args)
             self.assertTrue("The nginx plugin is not working" in ret)
             self.assertTrue("Could not find configuration root" in ret)
+            self.assertTrue("NoInstallationError" in ret)
 
         with MockedVerb("auth") as mock_auth:
             from letsencrypt import cli

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -131,7 +131,6 @@ class CLITest(unittest.TestCase):
             self.assertTrue("NoInstallationError" in ret)
 
         with MockedVerb("auth") as mock_auth:
-            from letsencrypt import cli
             self._call(["certonly", "--standalone"])
             self.assertEqual(1, mock_auth.call_count)
 

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -132,7 +132,7 @@ class CLITest(unittest.TestCase):
 
         with MockedVerb("certonly") as mock_certonly:
             self._call(["auth", "--standalone"])
-            self.assertEqual(1, mock_auth.call_count)
+            self.assertEqual(1, mock_certonly.call_count)
 
     def test_rollback(self):
         _, _, _, client = self._call(['rollback'])

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -115,6 +115,12 @@ class CLITest(unittest.TestCase):
             # (we can only do that if letsencrypt-nginx is actually present)
             ret, _, _, _ = self._call(args)
             self.assertTrue("The nginx plugin is not working" in ret)
+            self.assertTrue("Could not find configuration root" in ret)
+
+        with MockedVerb("auth") as mock_auth:
+            from letsencrypt import cli
+            self._call(["certonly", "--standalone"])
+            self.assertEqual(1, mock_auth.call_count)
 
     def test_rollback(self):
         _, _, _, client = self._call(['rollback'])


### PR DESCRIPTION
In #657 UX researchers noted that the "auth" command is deeply confusing; systems administrators expected it to be some kind of login command rather than the verb that gets you a cert.  So this PR makes "certonly" an alias for it, and makes that form the one that is suggested to users in the help.