### PR TITLE
use more accurate method to calculate time interval

### DIFF
--- a/letsencrypt/tests/renewer_test.py
+++ b/letsencrypt/tests/renewer_test.py
@@ -1,5 +1,6 @@
 """Tests for letsencrypt.renewer."""
 import datetime
+import pytz
 import os
 import tempfile
 import shutil
@@ -622,18 +623,47 @@ class RenewableCertTests(BaseRenewableCertTest):
         #      OCSP server to test against.
         self.assertFalse(self.test_rc.ocsp_revoked())
 
-    def test_parse_time_interval(self):
+    def test_add_time_interval(self):
         from letsencrypt import storage
-        # XXX: I'm not sure if intervals related to years and months
-        #      take account of the current date (if so, some of these
-        #      may fail in the future, like in leap years or even in
-        #      months of different lengths!)
-        intended = {"": 0, "17 days": 17, "23": 23, "1 month": 31,
-                    "7 weeks": 49, "1 year 1 day": 366, "1 year-1 day": 364,
-                    "4 years": 1461}
-        for time in intended:
-            self.assertEqual(storage.parse_time_interval(time),
-                             datetime.timedelta(intended[time]))
+
+        # this month has 30 days, and the next year is a leap year
+        time_1 = pytz.UTC.fromutc(datetime.datetime(2003, 11, 20, 11, 59, 21))
+
+        # this month has 31 days, and the next year is not a leap year
+        time_2 = pytz.UTC.fromutc(datetime.datetime(2012, 10, 18, 21, 31, 16))
+
+        # in different time zone (GMT+8)
+        time_3 = pytz.timezone('Asia/Shanghai').fromutc(
+            datetime.datetime(2015, 10, 26, 22, 25, 41))
+
+        intended = {
+            (time_1, ""): time_1,
+            (time_2, ""): time_2,
+            (time_3, ""): time_3,
+            (time_1, "17 days"): time_1 + datetime.timedelta(17),
+            (time_2, "17 days"): time_2 + datetime.timedelta(17),
+            (time_1, "30"): time_1 + datetime.timedelta(30),
+            (time_2, "30"): time_2 + datetime.timedelta(30),
+            (time_1, "7 weeks"): time_1 + datetime.timedelta(49),
+            (time_2, "7 weeks"): time_2 + datetime.timedelta(49),
+            # 1 month is always 30 days, no matter which month it is
+            (time_1, "1 month"): time_1 + datetime.timedelta(30),
+            (time_2, "1 month"): time_2 + datetime.timedelta(31),
+            # 1 year could be 365 or 366 days, depends on the year
+            (time_1, "1 year"): time_1 + datetime.timedelta(366),
+            (time_2, "1 year"): time_2 + datetime.timedelta(365),
+            (time_1, "1 year 1 day"): time_1 + datetime.timedelta(367),
+            (time_2, "1 year 1 day"): time_2 + datetime.timedelta(366),
+            (time_1, "1 year-1 day"): time_1 + datetime.timedelta(365),
+            (time_2, "1 year-1 day"): time_2 + datetime.timedelta(364),
+            (time_1, "4 years"): time_1 + datetime.timedelta(1461),
+            (time_2, "4 years"): time_2 + datetime.timedelta(1461),
+        }
+
+        for parameters, excepted in intended.items():
+            base_time, interval = parameters
+            self.assertEqual(storage.add_time_interval(base_time, interval),
+                             excepted)
 
     @mock.patch("letsencrypt.renewer.plugins_disco")
     @mock.patch("letsencrypt.account.AccountFileStorage")


### PR DESCRIPTION
Change the `should_autodeploy()` function and `should_autorenew()` function to use more accurate method to calculate time interval, considering of timezone, DST, leap year, and different month lengths, etc.

This PR replaces #1120 