### PR TITLE
 platform support for debian gnukfreebsd

### DIFF
--- a/letsencrypt/plugins/util.py
+++ b/letsencrypt/plugins/util.py
@@ -2,7 +2,14 @@
 import logging
 import socket
 
-import psutil
+try:
+    import psutil
+    psutil__net_connections = psutil.net_connections
+except ImportError:
+    def psutil__net_connections():
+        "When psutil is not available, returns no connection information"
+        return []
+
 import zope.component
 
 from letsencrypt import interfaces
@@ -25,7 +32,7 @@ def already_listening(port):
 
     """
     try:
-        net_connections = psutil.net_connections()
+        net_connections = psutil__net_connections()
     except psutil.AccessDenied as error:
         logger.info("Access denied when trying to list network "
                     "connections: %s. Are you root?", error)

--- a/letsencrypt/plugins/util_test.py
+++ b/letsencrypt/plugins/util_test.py
@@ -2,9 +2,12 @@
 import unittest
 
 import mock
-import psutil
+try:
+    import psutil
+except ImportError:
+    psutil = None
 
-
+@unittest.skipIf(psutil is None, "psutil not available")
 class AlreadyListeningTest(unittest.TestCase):
     """Tests for letsencrypt.plugins.already_listening."""
     def _call(self, *args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ install_requires = [
     'configobj',
     'cryptography>=0.7',  # load_pem_x509_certificate
     'parsedatetime',
-    'psutil>=2.1.0',  # net_connections introduced in 2.1.0
     'PyOpenSSL',
     'pyrfc3339',
     'python2-pythondialog>=3.2.2rc1',  # Debian squeeze support, cf. #280
@@ -47,6 +46,11 @@ install_requires = [
     'zope.component',
     'zope.interface',
 ]
+
+if 'gnukfreebsd' not in sys.platform:
+    install_requires.append(
+    'psutil>=2.1.0',  # net_connections introduced in 2.1.0
+    )
 
 # env markers in extras_require cause problems with older pip: #517
 if sys.version_info < (2, 7):


### PR DESCRIPTION
'psutil' is not available on debian kfreebsd.  Therefore, do not
require it there and deal gracefully when it is missing at runtime.
Apparently, this only prevents letsencrypt from diagnosing certain
"port already in use" type errors.

Note: I did run nox, but only on debian gnukfreebsd, not GNU/Linux.

Signed-off-by: Jeff Epler <jepler@unpythonic.net>