### PR TITLE
Correct typo and whitespace issues

### DIFF
--- a/letsencrypt/plugins/manual.py
+++ b/letsencrypt/plugins/manual.py
@@ -90,10 +90,10 @@ s.serve_forever()" """
 
     def more_info(self):  # pylint: disable=missing-docstring,no-self-use
         return """\
-This plugin requires user's manual intervention in setting up a HTTP
-server for solving SimpleHTTP challenges and thus does not need to be
-run as a privilidged process. Alternatively shows instructions on how
-to use Python's built-in HTTP server and, in case of HTTPS, openssl
+This plugin requires user's manual intervention in setting up an HTTP 
+server for solving SimpleHTTP challenges and thus does not need to be 
+run as a privileged process. Alternatively shows instructions on how 
+to use Python's built-in HTTP server and, in case of HTTPS, openssl 
 binary for temporary key/certificate generation.""".replace("\n", "")
 
     def get_chall_pref(self, domain):


### PR DESCRIPTION
* s/privilidged/privileged/
* s/a HTTP/an HTTP/
* Add whitespace at the end of the lines to improve user experience

The lack of trailing whitespace on these entries causes Debian's debconf
interface to join the last word of a line with the first word of the
next line, with no space in between.