### PR TITLE
Added pkg-config to Arch bootstrap (fixes #1147)

### DIFF
--- a/bootstrap/_arch_common.sh
+++ b/bootstrap/_arch_common.sh
@@ -17,3 +17,4 @@ pacman -S --needed \
   openssl \
   libffi \
   ca-certificates \
+  pkg-config \


### PR DESCRIPTION
As pointed out in #1147, `pkg-config` needs to be installed on Arch for `cffi` to work properly. This fixes that and has been tested successfully on a fresh Arch installation.