### PR TITLE
bootstrap/_deb_common: add dependency to libssl-dev

### DIFF
--- a/bootstrap/_deb_common.sh
+++ b/bootstrap/_deb_common.sh
@@ -43,6 +43,7 @@ apt-get install -y --no-install-recommends \
   libssl-dev \
   libffi-dev \
   ca-certificates \
+  libssl-dev
 
 if ! which virtualenv > /dev/null ; then
   echo Failed to install a working \"virtualenv\" command, exiting


### PR DESCRIPTION
Otherwise virtualenv fails with:

    x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fno-strict-aliasing -D_FORTIFY_SOURCE=2 -g -fstack-protector-strong -Wformat -Werror=format-security -fPIC -I/usr/include/python2.7 -c build/temp.linux-x86_64-2.7/_openssl.c -o build/temp.linux-x86_64-2.7/build/temp.linux-x86_64-2.7/_openssl.o
    build/temp.linux-x86_64-2.7/_openssl.c:408:25: fatal error: openssl/aes.h: No such file or directory
    compilation terminated.
    error: command 'x86_64-linux-gnu-gcc' failed with exit status 1