### PR TITLE
Respect pre-installed gcc package on Arch Linux

### DIFF
--- a/bootstrap/_arch_common.sh
+++ b/bootstrap/_arch_common.sh
@@ -4,6 +4,15 @@
 #   - Manjaro 15.09 (x86_64)
 #   - ArchLinux (x86_64)
 
+# Both "gcc-multilib" and "gcc" packages provide gcc. If user already has
+# "gcc-multilib" installed, let's stick to their choice
+if pacman -Qc gcc-multilib &>/dev/null
+then
+	GCC_PACKAGE="gcc-multilib";
+else
+	GCC_PACKAGE="gcc";
+fi
+
 # "python-virtualenv" is Python3, but "python2-virtualenv" provides
 # only "virtualenv2" binary, not "virtualenv" necessary in
 # ./bootstrap/dev/_common_venv.sh
@@ -11,7 +20,7 @@ pacman -S --needed \
   git \
   python2 \
   python-virtualenv \
-  gcc \
+  "$GCC_PACKAGE" \
   dialog \
   augeas \
   openssl \


### PR DESCRIPTION
Both `gcc-multilib` and `gcc` packages provide 64-bit gcc on x86_64 installations, so there is no harm if `gcc-multilib` is already installed. Making pacman install `gcc` when `gcc-multilib` is already installed prompts pacman to ask and uninstall `gcc-multilib` so it can be replaced by `gcc`.