### PR TITLE
Vagrantfile: use recommended bootstrap scripts for provisioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,14 +4,11 @@
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
-# Setup instructions from docs/using.rst
+# Setup instructions from docs/contributing.rst
 $ubuntu_setup_script = <<SETUP_SCRIPT
 cd /vagrant
-sudo ./bootstrap/ubuntu.sh
-if [ ! -d "venv" ]; then
-  virtualenv --no-site-packages -p python2 venv
-  ./venv/bin/pip install -r requirements.txt -e acme -e .[dev,docs,testing] -e letsencrypt-apache -e letsencrypt-nginx
-fi
+./bootstrap/install-deps.sh
+./bootstrap/dev/venv.sh
 SETUP_SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -312,7 +312,6 @@ synced to ``/vagrant``, so you can get started with:
 
   vagrant ssh
   cd /vagrant
-  ./venv/bin/pip install -r requirements.txt .[dev,docs,testing]
   sudo ./venv/bin/letsencrypt
 
 Support for other Linux distributions coming soon.


### PR DESCRIPTION
Also remove an incorrect and unnecessary (requirements are installed during Vagrant provisioning) command from the Vagrant instructions in `docs/contributing.rst`.