### PR TITLE
Add gitattributes file to mark bat file as CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto eol=lf
+
+# special files
+*.bat text eol=crlf
+*.jpeg binary
+*.jpg binary
+*.png binary


### PR DESCRIPTION
Gitattributes files can be used to mark files as crlf, which is useful for the `.bat` files in case people use eol=lf in their git config.