### PR TITLE
Update letsencrypt-auto with CentOS6 SCL for python 2.7

### DIFF
--- a/bootstrap/centos.sh
+++ b/bootstrap/centos.sh
@@ -1,1 +1,27 @@
-_rpm_common.sh
+#!/bin/sh
+
+# Tested with:
+# - CentOS 6.7 (x64)
+
+
+if [ `lsb_release -rs | cut -f1 -d.` -eq 6 ]
+then
+	# Setup SCL Repo - https://wiki.centos.org/AdditionalResources/Repositories/SCL
+	yum -y install centos-release-SCL
+
+	# Now install Deps
+	yum -y install \
+		git-core \
+		python27 \
+		python27-python-devel \
+		python27-python-virtualenv  \
+		gcc \
+		dialog \
+		augeas-libs \
+		openssl-devel \
+		libffi-devel \
+		ca-certificates
+
+else
+	source $BOOTSTRAP/_rpm_common.sh
+fi

--- a/bootstrap/centos.sh
+++ b/bootstrap/centos.sh
@@ -6,22 +6,29 @@
 
 if [ `lsb_release -rs | cut -f1 -d.` -eq 6 ]
 then
-	# Setup SCL Repo - https://wiki.centos.org/AdditionalResources/Repositories/SCL
-	yum -y install centos-release-SCL
-
-	# Now install Deps
-	yum -y install \
-		git-core \
-		python27 \
-		python27-python-devel \
-		python27-python-virtualenv  \
-		gcc \
-		dialog \
-		augeas-libs \
-		openssl-devel \
-		libffi-devel \
-		ca-certificates
-
-else
-	source $BOOTSTRAP/_rpm_common.sh
+    
+    if [[ ! -f /etc/yum.repos.d/ius.repo || ! -f /usr/bin/python2.7 ]] ; then
+    
+        # Setup SCL Repo - https://wiki.centos.org/AdditionalResources/Repositories/SCL	
+        yum -y install centos-release-SCL
+		# Disable SCL
+        sed -i 's/enabled=1/enabled=0/g' /etc/yum.repos.d/CentOS-SCL.repo
+    	
+        # Install Python 2.7
+        yum -y --enablerepo=scl install \
+            python27 \
+            python27-python-devel \
+            python27-python-virtualenv
+    fi 
+        # Now install Deps
+    yum -y install \
+        git-core \
+        gcc \
+        dialog \
+        augeas-libs \
+        openssl-devel \
+        libffi-devel \
+        ca-certificates
+    else
+    source $BOOTSTRAP/_rpm_common.sh
 fi

--- a/letsencrypt-auto
+++ b/letsencrypt-auto
@@ -12,6 +12,7 @@ XDG_DATA_HOME=${XDG_DATA_HOME:-~/.local/share}
 VENV_NAME="letsencrypt"
 VENV_PATH=${VENV_PATH:-"$XDG_DATA_HOME/$VENV_NAME"}
 VENV_BIN=${VENV_PATH}/bin
+PYTHON_VER="python2"
 
 if test "`id -u`" -ne "0" ; then
   SUDO=sudo
@@ -46,7 +47,16 @@ then
     $SUDO $BOOTSTRAP/manjaro.sh
   elif [ -f /etc/redhat-release ] ; then
     echo "Bootstrapping dependencies for RedHat-based OSes..."
-    $SUDO $BOOTSTRAP/_rpm_common.sh
+    if [ `lsb_release -is` == "CentOS" ]; then
+        $SUDO $BOOTSTRAP/centos.sh
+	if [ `lsb_release -rs | cut -f1 -d.` -eq 6 ]; then
+		source /opt/rh/python27/enable
+		PYTHON_VER="python2.7"
+		SCL="scl enable python27 "
+	fi
+    else
+        $SUDO $BOOTSTRAP/_rpm_common.sh
+    fi
   elif uname | grep -iq FreeBSD ; then
     echo "Bootstrapping dependencies for FreeBSD..."
     $SUDO $BOOTSTRAP/freebsd.sh
@@ -62,11 +72,12 @@ then
     echo "for more info"
   fi
 
-  echo "Creating virtual environment..."
+
+  echo "Creating virtual environment...$VENV_PATH"
   if [ "$VERBOSE" = 1 ] ; then
-    virtualenv --no-site-packages --python python2 $VENV_PATH
+    virtualenv --no-site-packages --python $PYTHON_VER $VENV_PATH
   else
-    virtualenv --no-site-packages --python python2 $VENV_PATH > /dev/null
+    virtualenv --no-site-packages --python $PYTHON_VER $VENV_PATH > /dev/null
   fi
 fi
 
@@ -99,5 +110,9 @@ fi
 
 # Explain what's about to happen, for the benefit of those getting sudo
 # password prompts...
-echo "Running with virtualenv:" $SUDO $VENV_BIN/letsencrypt "$@"
-$SUDO $VENV_BIN/letsencrypt "$@"
+if [ -z "$SCL" ] ; then
+    echo "Running with virtualenv:" $SUDO $VENV_BIN/letsencrypt "$@"
+    $SUDO $VENV_BIN/letsencrypt "$@"
+else
+    echo "Now run: $SUDO $SCL \"$VENV_BIN/letsencrypt $@\""
+fi

--- a/letsencrypt-auto
+++ b/letsencrypt-auto
@@ -49,12 +49,15 @@ then
     echo "Bootstrapping dependencies for RedHat-based OSes..."
     if [ `lsb_release -is` == "CentOS" ]; then
         $SUDO $BOOTSTRAP/centos.sh
-	if [ `lsb_release -rs | cut -f1 -d.` -eq 6 ]; then
+	if [[ `lsb_release -rs | cut -f1 -d.` -eq 6 ]] && [[ ! -f /etc/yum.repos.d/ius.repo || ! -f /usr/bin/python2.7 ]] ; then
 		source /opt/rh/python27/enable
 		PYTHON_VER="python2.7"
 		SCL="scl enable python27 "
 	fi
     else
+        if [[ `lsb_release -rs | cut -f1 -d.` -eq 6 ]] && [[ -f /usr/bin/python2.7 ]]; then
+            PYTHON_VER="python2.7"
+        fi
         $SUDO $BOOTSTRAP/_rpm_common.sh
     fi
   elif uname | grep -iq FreeBSD ; then


### PR DESCRIPTION
The attached PR fixes #1046 for CentOS 6 users by setting up python 2.7 using the Software Collection Library that is part of CentOS. (Therefore not relying on 3rd party repo's to upgrade python)

Feedback/comments/suggestions welcome.