### PR TITLE
Use git instead of git-core in bootstrapping on Debian and friends

### DIFF
--- a/bootstrap/_deb_common.sh
+++ b/bootstrap/_deb_common.sh
@@ -33,7 +33,7 @@ if apt-cache show python-virtualenv > /dev/null ; then
 fi
 
 apt-get install -y --no-install-recommends \
-  git-core \
+  git \
   python \
   python-dev \
   $virtualenv \


### PR DESCRIPTION
Fixes #1179 (bootstrap script installs transitional package git-core)