### PR TITLE
Add -t to apache2ctl -D DUMP_RUN_CFG

### DIFF
--- a/letsencrypt-apache/letsencrypt_apache/parser.py
+++ b/letsencrypt-apache/letsencrypt_apache/parser.py
@@ -122,7 +122,7 @@ class ApacheParser(object):
         """
         try:
             proc = subprocess.Popen(
-                [ctl, "-D", "DUMP_RUN_CFG"],
+                [ctl, "-t", "-D", "DUMP_RUN_CFG"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE)
             stdout, stderr = proc.communicate()


### PR DESCRIPTION
Calling apache2ctl -D DUMP_RUN_CFG on Debian Wheezy (Apache 2.2) will
open a socket which breaks standalone auth. letsencrypt still won’t
work with apache 2.2 because it only returns „Syntax OK“.
Apache 2.4 works the same with or without -t.

(Checked with Apache 2.4 on Debian Jessie)