### PR TITLE
Remove serve_forever2/shutdown2 (reduces probability of #1085).

### DIFF
--- a/letsencrypt/plugins/standalone.py
+++ b/letsencrypt/plugins/standalone.py
@@ -72,7 +72,9 @@ class ServerManager(object):
         except socket.error as error:
             raise errors.StandaloneBindError(error, port)
 
-        thread = threading.Thread(target=server.serve_forever2)
+        thread = threading.Thread(
+            # pylint: disable=no-member
+            target=server.serve_forever)
         thread.start()
 
         # if port == 0, then random free port on OS is taken
@@ -90,7 +92,7 @@ class ServerManager(object):
         instance = self._instances[port]
         logger.debug("Stopping server at %s:%d...",
                      *instance.server.socket.getsockname()[:2])
-        instance.server.shutdown2()
+        instance.server.shutdown()
         instance.thread.join()
         del self._instances[port]
 


### PR DESCRIPTION
I'm not even sure why `serve_forever2` and `shutdown2` were introduced in the first place... It probably follows from my misconception about the SocketServer module. After having studied the module again, I come to the conclusion that we can get rid of my crap, simultaneously reducing probability of #1085 (hopefully down to 0)!

`server_forever` is used throughout tests instead of `handle_request`, because `shutdown`, following docs, "must be called while serve_forever() is running in another thread, or it will deadlock", and our `probe_sni` HTTP request is already enough to kill single `handle_request`.

We don't need to use any busy waiting block or `sleep` between serve and shutdown; studying CPython source code leads to the conclusion that the following construction is non-deadlocking:

```python
import threading, SocketServer
s = SocketServer.TCPServer(("", 0), None)
t = threading.Thread(target=s.shutdown)
t.start()
s.serve_forever()  # returns immediately
t.join()  # returns immediately
```