### PR TITLE
bootstrap: use a proper dependency test for Arch

### DIFF
--- a/bootstrap/_arch_common.sh
+++ b/bootstrap/_arch_common.sh
@@ -1,29 +1,27 @@
 #!/bin/sh
 
 # Tested with:
-#   - Manjaro 15.09 (x86_64)
 #   - ArchLinux (x86_64)
-
-# Both "gcc-multilib" and "gcc" packages provide gcc. If user already has
-# "gcc-multilib" installed, let's stick to their choice
-if pacman -Qc gcc-multilib &>/dev/null
-then
-	GCC_PACKAGE="gcc-multilib";
-else
-	GCC_PACKAGE="gcc";
-fi
-
+#
 # "python-virtualenv" is Python3, but "python2-virtualenv" provides
 # only "virtualenv2" binary, not "virtualenv" necessary in
 # ./bootstrap/dev/_common_venv.sh
-pacman -S --needed \
-  git \
-  python2 \
-  python-virtualenv \
-  "$GCC_PACKAGE" \
-  dialog \
-  augeas \
-  openssl \
-  libffi \
-  ca-certificates \
-  pkg-config \
+
+deps="
+  git
+  python2
+  python-virtualenv
+  gcc
+  dialog
+  augeas
+  openssl
+  libffi
+  ca-certificates
+  pkg-config
+"
+
+missing=$(pacman -T $deps)
+
+if [ "$missing" ]; then
+  pacman -S --needed $missing
+fi


### PR DESCRIPTION
`pacman -T` exists for this exact purpose; it respects provides without having to manually code them into the script.