### PR TITLE
Bootstrap CentOS 6 Compatibility Improvement

### DIFF
--- a/bootstrap/_rpm_common.sh
+++ b/bootstrap/_rpm_common.sh
@@ -20,11 +20,15 @@ $tool install -y \
   git-core \
   python \
   python-devel \
-  python-virtualenv \
-  python-devel \
+  python-setuptools \
   gcc \
   dialog \
   augeas-libs \
   openssl-devel \
   libffi-devel \
   ca-certificates \
+
+if ! $tool install -y python-virtualenv ; then
+    easy_install pip
+    pip install virtualenv
+fi


### PR DESCRIPTION
Fix #1204 missing `virtualenv` issue, now the bootstrap will try to install `python-virtualenv` via `yum` or `dnf` first, and then try to use `pip install virtualenv` if previous attempt failed.

Also removed duplicates `python-devel`. Have two `python-devel` in the `yum install` or `dnf install` packages list make no sense.