### PR TITLE
Added comment about installer.save()

### DIFF
--- a/letsencrypt/client.py
+++ b/letsencrypt/client.py
@@ -326,7 +326,7 @@ class Client(object):
                     key_path=os.path.abspath(privkey_path),
                     chain_path=chain_path,
                     fullchain_path=fullchain_path)
-                self.installer.save()
+                self.installer.save()  # needed by the Apache plugin
 
             self.installer.save("Deployed Let's Encrypt Certificate")
             # sites may have been enabled / final cleanup


### PR DESCRIPTION
In response to #1226, I just wanted to add a comment about why the call to `installer.save()` is necessary so it's not arbitrarily deleted in the future.