### PR TITLE
Remove another reference to simplehttp

### DIFF
--- a/letsencrypt/plugins/webroot.py
+++ b/letsencrypt/plugins/webroot.py
@@ -13,7 +13,7 @@ Apache2
    operating systems might use something very similar, but you might
    still need to readjust some commands.
 
-Create ``/etc/apache2/conf-available/letsencrypt-simplehttp.conf``, with
+Create ``/etc/apache2/conf-available/letsencrypt.conf``, with
 the following contents::
 
   <IfModule mod_headers.c>


### PR DESCRIPTION
Since the command `a2enconf letsencrypt` is listed on this page, make sure the config file is named accordingly.