### PR TITLE
docker: Use full filename when copying symlink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ WORKDIR /opt/letsencrypt
 # If <dest> doesn't exist, it is created along with all missing
 # directories in its path.
 
-COPY bootstrap/ubuntu.sh /opt/letsencrypt/src/
+
+COPY bootstrap/ubuntu.sh /opt/letsencrypt/src/ubuntu.sh
 RUN /opt/letsencrypt/src/ubuntu.sh && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -22,7 +22,7 @@ WORKDIR /opt/letsencrypt
 
 # TODO: Install non-default Python versions for tox.
 # TODO: Install Apache/Nginx for plugin development.
-COPY bootstrap/ubuntu.sh /opt/letsencrypt/src/
+COPY bootstrap/ubuntu.sh /opt/letsencrypt/src/ubuntu.sh
 RUN /opt/letsencrypt/src/ubuntu.sh && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
Works around an upstream bug in Docker:

https://github.com/docker/docker/issues/17730

Fixes #1374