### PR TITLE
Add FreeBSD port/package to documentation (Usage)

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -86,8 +86,15 @@ in ``/etc/letsencrypt/live`` on the host.
 .. _`install Docker`: https://docs.docker.com/userguide/
 
 
-Distro packages
----------------
+Operating System Packages
+--------------------------
+
+**FreeBSD**
+
+  * Port: ``cd /usr/ports/security/py-letsencrypt && make install clean``
+  * Package: ``pkg install py27-letsencrypt``
+
+**Other Operating Systems**
 
 Unfortunately, this is an ongoing effort. If you'd like to package
 Let's Encrypt client for your distribution of choice please have a


### PR DESCRIPTION
The FreeBSD port for letsencrypt was [recently committed](https://svnweb.freebsd.org/changeset/ports/400885).

Update the letsencrypt documentation (usage page) with user instructions for how to install it via ports or packages.

* Rename "Distro's" to "Operating Systems"
* Add instructions for FreeBSD port and package installation
* Add "Other Operating System" header for the instructions to create packages