### PR TITLE
Fixes 2 lines of code that could cause IndexError in the nginx plugin

### DIFF
--- a/letsencrypt-nginx/letsencrypt_nginx/parser.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/parser.py
@@ -246,7 +246,7 @@ class NginxParser(object):
                 # Can't be a server block
                 return False
 
-            if item[0] == 'server_name':
+            if len(item) > 0 and item[0] == 'server_name':
                 server_names.update(_get_servernames(item[1]))
 
         return server_names == names
@@ -425,7 +425,7 @@ def _is_include_directive(entry):
 
     """
     return (isinstance(entry, list) and
-            entry[0] == 'include' and len(entry) == 2 and
+            len(entry) == 2 and entry[0] == 'include' and
             isinstance(entry[1], str))
 
 


### PR DESCRIPTION
Check the length of the list before do `list_object[0]`.

Fixes the following exceptions:
```
2015-11-07 15:47:21,721:DEBUG:letsencrypt.cli:Exiting abnormally:
Traceback (most recent call last):
  File "/home/user/.local/share/letsencrypt/bin/letsencrypt", line 11, in <module>
    sys.exit(main())
......
  File "/home/user/.local/share/letsencrypt/lib/python2.7/site-packages/letsencrypt_nginx/parser.py", line 324, in _do_for_subarray
    _do_for_subarray(item, condition, func)
  File "/home/user/.local/share/letsencrypt/lib/python2.7/site-packages/letsencrypt_nginx/parser.py", line 324, in _do_for_subarray
    _do_for_subarray(item, condition, func)
  File "/home/user/.local/share/letsencrypt/lib/python2.7/site-packages/letsencrypt_nginx/parser.py", line 324, in _do_for_subarray
    _do_for_subarray(item, condition, func)
  File "/home/user/.local/share/letsencrypt/lib/python2.7/site-packages/letsencrypt_nginx/parser.py", line 324, in _do_for_subarray
    _do_for_subarray(item, condition, func)
  File "/home/user/.local/share/letsencrypt/lib/python2.7/site-packages/letsencrypt_nginx/parser.py", line 320, in _do_for_subarray
    if condition(entry):
  File "/home/user/.local/share/letsencrypt/lib/python2.7/site-packages/letsencrypt_nginx/parser.py", line 271, in <lambda>
    lambda x: self._has_server_names(x, names),
  File "/home/user/.local/share/letsencrypt/lib/python2.7/site-packages/letsencrypt_nginx/parser.py", line 249, in _has_server_names
    if item[0] == 'server_name':
IndexError: list index out of range
```

And:
```
2015-11-07 16:05:34,482:DEBUG:letsencrypt.cli:Exiting abnormally:
Traceback (most recent call last):
  File "/home/user/.local/share/letsencrypt/bin/letsencrypt", line 11, in <module>
    sys.exit(main())
......
  File "/home/user/.local/share/letsencrypt/lib/python2.7/site-packages/letsencrypt_nginx/parser.py", line 324, in _do_for_subarray
    _do_for_subarray(item, condition, func)
  File "/home/user/.local/share/letsencrypt/lib/python2.7/site-packages/letsencrypt_nginx/parser.py", line 324, in _do_for_subarray
    _do_for_subarray(item, condition, func)
  File "/home/user/.local/share/letsencrypt/lib/python2.7/site-packages/letsencrypt_nginx/parser.py", line 324, in _do_for_subarray
    _do_for_subarray(item, condition, func)
  File "/home/user/.local/share/letsencrypt/lib/python2.7/site-packages/letsencrypt_nginx/parser.py", line 320, in _do_for_subarray
    if condition(entry):
  File "/home/user/.local/share/letsencrypt/lib/python2.7/site-packages/letsencrypt_nginx/parser.py", line 271, in <lambda>
    lambda x: self._has_server_names(x, names),
  File "/home/user/.local/share/letsencrypt/lib/python2.7/site-packages/letsencrypt_nginx/parser.py", line 242, in _has_server_names
    new_entry = self._get_included_directives(entry)
  File "/home/user/.local/share/letsencrypt/lib/python2.7/site-packages/letsencrypt_nginx/parser.py", line 137, in _get_included_directives
    if _is_include_directive(directive):
  File "/home/user/.local/share/letsencrypt/lib/python2.7/site-packages/letsencrypt_nginx/parser.py", line 428, in _is_include_directive
    entry[0] == 'include' and len(entry) == 2 and
IndexError: list index out of range
```