### PR TITLE
do not use brew to install pip; use python instead

### DIFF
--- a/bootstrap/mac.sh
+++ b/bootstrap/mac.sh
@@ -8,11 +8,15 @@ brew install augeas
 brew install dialog
 
 if ! hash pip 2>/dev/null; then
-    echo "pip Not Installed\nInstalling python from Homebrew..."
-    brew install python
+    echo "pip Not Installed. Downloading..."
+    curl -so get-pip.py 'https://bootstrap.pypa.io/get-pip.py'
+    echo sudo python get-pip.py
+    sudo python get-pip.py
+    rm get-pip.py
 fi
 
 if ! hash virtualenv 2>/dev/null; then
     echo "virtualenv Not Installed\nInstalling with pip"
-    pip install virtualenv
+    echo sudo pip install virtualenv
+    sudo pip install virtualenv
 fi


### PR DESCRIPTION
Mac OS X already shipped python (2.7) with it at the most of time.
Use brew version python may cause a lot of other issues.

This PR needs #1415 merged first to be functional.