### PR TITLE
Appropriately set and update Apache certificate directives

### DIFF
--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -214,7 +214,8 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
                      ".".join(str(i) for i in self.version))
 
         if self.version < (2, 4, 8) or (chain_path and not fullchain_path):
-            # install SSLCertificateFile, SSLCertificateKeyFile, and SSLCertificateChainFile directives
+            # install SSLCertificateFile, SSLCertificateKeyFile,
+            # and SSLCertificateChainFile directives
             set_cert_path = cert_path
             self.aug.set(path["cert_path"][-1], cert_path)
             self.aug.set(path["cert_key"][-1], key_path)
@@ -660,7 +661,8 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
 
         return ssl_addrs
 
-    def _remove_existing_ssl_directives(self, vh_path, minus={}):
+    def _remove_existing_ssl_directives(self, vh_path, minus=None):
+        minus = minus or {}
         directives_to_remove = list({"SSLCertificateKeyFile", "SSLCertificateChainFile",
                                      "SSLCertificateFile"} - set(minus))
         for directive in directives_to_remove:

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -265,6 +265,12 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         # Try to find a reasonable vhost
         vhost = self._find_best_vhost(target_name)
         if vhost is not None:
+            if vhost.ssl:
+                # remove existing SSL directives (minus the ones we'll use anyway,
+                # since we want to preserve order)
+                self._remove_existing_ssl_directives(
+                    vhost,
+                    minus=['SSLCertificatePath', 'SSLCertificateKeyFile'])
             if not vhost.ssl:
                 vhost = self.make_vhost_ssl(vhost)
 

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -652,9 +652,10 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
 
         return ssl_addrs
 
-    def _remove_existing_ssl_directives(self, vh_path):
-        for directive in ["SSLCertificateKeyFile", "SSLCertificateChainFile",
-                          "SSLCertificateFile"]:
+    def _remove_existing_ssl_directives(self, vh_path, minus={}):
+        directives_to_remove = list({"SSLCertificateKeyFile", "SSLCertificateChainFile",
+                                     "SSLCertificateFile"} - set(minus))
+        for directive in directives_to_remove:
             logger.debug("Trying to delete directive '%s'", directive)
             directive_tree = self.parser.find_dir(directive, None, vh_path)
             logger.debug("Parser found %s", directive_tree)

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -212,13 +212,13 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         logger.info("Deploying Certificate to VirtualHost %s", vhost.filep)
 
         # Assign the final directives; order is maintained in find_dir
-        if self.version >= (2, 4, 8):
+        if self.version >= (2, 4, 8) and fullchain_path is not None:
             logger.debug("Apache version (%s) is >= 2.4.8",
                          ".".join(str(i) for i in self.version))
             set_cert_path = fullchain_path
             self.aug.set(path["cert_path"][-1], fullchain_path)
             self.aug.set(path["cert_key"][-1], key_path)
-        elif self.version < (2, 4, 8):
+        else: # fall back to old SSL cert method
             logger.debug("Apache version (%s) is < 2.4.8",
                          ".".join(str(i) for i in self.version))
             set_cert_path = cert_path

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -584,10 +584,6 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         # Update Addresses
         self._update_ssl_vhosts_addrs(vh_p)
 
-        # Remove existing SSL directives
-        logger.info("Removing existing SSL directives")
-        self._remove_existing_ssl_directives(vh_p)
-
         # Add directives
         self._add_dummy_ssl_directives(vh_p)
 

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -214,13 +214,13 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         # Assign the final directives; order is maintained in find_dir
         if self.version >= (2, 4, 8):
             logger.debug("Apache version (%s) is >= 2.4.8",
-                         ".".join(map(str,self.version)))
+                         ".".join(str(i) for i in self.version))
             set_cert_path = fullchain_path
             self.aug.set(path["cert_path"][-1], fullchain_path)
             self.aug.set(path["cert_key"][-1], key_path)
         elif self.version < (2, 4, 8):
             logger.debug("Apache version (%s) is < 2.4.8",
-                         ".".join(map(str,self.version)))
+                         ".".join(str(i) for i in self.version))
             set_cert_path = cert_path
             self.aug.set(path["cert_path"][-1], cert_path)
             self.aug.set(path["cert_key"][-1], key_path)
@@ -663,8 +663,8 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
             directive_tree = self.parser.find_dir(directive, None, vh_path)
             logger.debug("Parser found %s", directive_tree)
             if directive_tree:
-                    logger.debug("Removing directive %s", directive)
-                    self.aug.remove(re.sub(r"/\w*$", "", directive_tree[-1]))
+                logger.debug("Removing directive %s", directive)
+                self.aug.remove(re.sub(r"/\w*$", "", directive_tree[-1]))
 
     def _add_dummy_ssl_directives(self, vh_path):
         self.parser.add_dir(vh_path, "SSLCertificateFile",

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -213,7 +213,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         logger.debug("Apache version is %s",
                      ".".join(str(i) for i in self.version))
 
-        if self.version < (2, 4, 8) or (chain_path and not fullchain_path):
+        if self.version < (2, 4, 8):
             # install SSLCertificateFile, SSLCertificateKeyFile,
             # and SSLCertificateChainFile directives
             set_cert_path = cert_path

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -225,6 +225,8 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
                                         "SSLCertificateChainFile", chain_path)
                 else:
                     self.aug.set(path["chain_path"][-1], chain_path)
+            else:
+                raise errors.PluginError("--chain-path is required for your version of Apache")
         else:
             if not fullchain_path:
                 raise errors.PluginError("Please provide the --fullchain-path\

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -662,9 +662,9 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         return ssl_addrs
 
     def _remove_existing_ssl_directives(self, vh_path, minus=None):
-        minus = minus or {}
-        directives_to_remove = list({"SSLCertificateKeyFile", "SSLCertificateChainFile",
-                                     "SSLCertificateFile"} - set(minus))
+        minus = minus or set()
+        directives_to_remove = list(set(["SSLCertificateKeyFile", "SSLCertificateChainFile",
+                                     "SSLCertificateFile"]) - set(minus))
         for directive in directives_to_remove:
             logger.debug("Trying to delete directive '%s'", directive)
             directive_tree = self.parser.find_dir(directive, None, vh_path)

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -213,7 +213,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         logger.debug("Apache version is %s",
                      ".".join(str(i) for i in self.version))
 
-        if self.version < (2, 4, 8):
+        if self.version < (2, 4, 8) or (chain_path and not fullchain_path):
             # install SSLCertificateFile, SSLCertificateKeyFile,
             # and SSLCertificateChainFile directives
             set_cert_path = cert_path

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -183,6 +183,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
 
         """
         vhost = self.choose_vhost(domain)
+        self._clean_vhost(vhost)
 
         # This is done first so that ssl module is enabled and cert_path,
         # cert_key... can all be parsed appropriately
@@ -276,15 +277,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
             self.assoc[target_name] = vhost
             return vhost
 
-        vhost = self._choose_vhost_from_list(target_name)
-        if vhost.ssl:
-            # remove duplicated or conflicting ssl directives
-            self._deduplicate_directives(vhost.path,
-                ["SSLCertificateFile", "SSLCertificateKeyFile"])
-            # remove all problematic directives
-            self._remove_directives(vhost.path, ["SSLCertificateChainFile"])
-
-        return vhost
+        return self._choose_vhost_from_list(target_name)
 
     def _choose_vhost_from_list(self, target_name):
         # Select a vhost from a list
@@ -664,6 +657,13 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
             ssl_addrs.add(ssl_addr)
 
         return ssl_addrs
+
+    def _clean_vhost(self, vhost):
+        # remove duplicated or conflicting ssl directives
+        self._deduplicate_directives(vhost.path,
+            ["SSLCertificateFile", "SSLCertificateKeyFile"])
+        # remove all problematic directives
+        self._remove_directives(vhost.path, ["SSLCertificateChainFile"])
 
     def _deduplicate_directives(self, vh_path, directives):
         for directive in directives:

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -658,7 +658,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
 
     def _remove_existing_ssl_directives(self, vh_path):
         for directive in ["SSLCertificateKeyFile", "SSLCertificateChainFile",
-                          "SSLCACertificatePath", "SSLCertificateFile"]:
+                          "SSLCertificateFile"]:
             logger.debug("Trying to delete directive '%s'", directive)
             directive_tree = self.parser.find_dir(directive, None, vh_path)
             logger.debug("Parser found %s", directive_tree)

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -192,39 +192,51 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
 
         path["cert_path"] = self.parser.find_dir(
             "SSLCertificateFile", None, vhost.path)
-        path["cert_key"] = self.parser.find_dir(
-            "SSLCertificateKeyFile", None, vhost.path)
 
         # Only include if a certificate chain is specified
         if chain_path is not None:
             path["chain_path"] = self.parser.find_dir(
                 "SSLCertificateChainFile", None, vhost.path)
 
-        if not path["cert_path"] or not path["cert_key"]:
+        if not path["cert_path"]:
             # Throw some can't find all of the directives error"
             logger.warn(
-                "Cannot find a cert or key directive in %s. "
+                "Cannot find a cert directive in %s. "
                 "VirtualHost was not modified", vhost.path)
             # Presumably break here so that the virtualhost is not modified
             raise errors.PluginError(
-                "Unable to find cert and/or key directives")
+                "Unable to find cert directive")
 
         logger.info("Deploying Certificate to VirtualHost %s", vhost.filep)
 
         # Assign the final directives; order is maintained in find_dir
         if self.version >= (2, 4, 8):
+            logger.debug("Apache version (%s) is >= 2.4.8",
+                         ".".join(map(str,self.version)))
+            set_cert_path = fullchain_path
+            logger.debug(fullchain_path)
+            logger.debug(path["cert_path"][-1])
             self.aug.set(path["cert_path"][-1], fullchain_path)
         elif self.version < (2, 4, 8):
+            logger.debug("Apache version (%s) is < 2.4.8",
+                         ".".join(map(str,self.version)))
+            set_cert_path = cert_path
             self.aug.set(path["cert_path"][-1], cert_path)
-            self.aug.set(path["chain_path"][-1], chain_path)
+            if not path["chain_path"]:
+                self.parser.add_dir(vhost.path,
+                                    "SSLCertificateChainFile", chain_path)
+            else:
+                self.aug.set(path["chain_path"][-1], chain_path)
+
+        with open("%s/sites-available/%s" % (self.parser.root, os.path.basename(vhost.filep))) as f:
+            logger.debug(f.read())
 
         # Save notes about the transaction that took place
         self.save_notes += ("Changed vhost at %s with addresses of %s\n"
-                            "\tSSLCertificateFile %s\n"
-                            "\tSSLCertificateKeyFile %s\n" %
+                            "\tSSLCertificateFile %s\n" %
                             (vhost.filep,
                              ", ".join(str(addr) for addr in vhost.addrs),
-                             cert_path, key_path))
+                             set_cert_path))
         if chain_path is not None:
             self.save_notes += "\tSSLCertificateChainFile %s\n" % chain_path
 
@@ -573,7 +585,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         self._update_ssl_vhosts_addrs(vh_p)
 
         # Remove existing SSL directives
-        logging.info("Removing existing SSL directives")
+        logger.info("Removing existing SSL directives")
         self._remove_existing_ssl_directives(vh_p)
 
         # Add directives
@@ -657,8 +669,6 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
     def _add_dummy_ssl_directives(self, vh_path):
         self.parser.add_dir(vh_path, "SSLCertificateFile",
                             "insert_cert_file_path")
-        self.parser.add_dir(vh_path, "SSLCertificateKeyFile",
-                            "insert_key_file_path")
         self.parser.add_dir(vh_path, "Include", self.mod_ssl_conf)
 
     def _add_name_vhost_if_necessary(self, vhost):

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -221,11 +221,8 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
             self.aug.set(path["cert_path"][-1], cert_path)
             self.aug.set(path["cert_key"][-1], key_path)
             if chain_path is not None:
-                if not path["chain_path"]:
-                    self.parser.add_dir(vhost.path,
-                                        "SSLCertificateChainFile", chain_path)
-                else:
-                    self.aug.set(path["chain_path"][-1], chain_path)
+                self.parser.add_dir(vhost.path,
+                                    "SSLCertificateChainFile", chain_path)
             else:
                 raise errors.PluginError("--chain-path is required for your version of Apache")
         else:

--- a/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
+++ b/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
@@ -304,8 +304,7 @@ class TwoVhost80Test(util.ApacheTest):
         self.config.assoc["random.demo"] = self.vh_truth[1]
         self.assertRaises(errors.PluginError,
                           lambda: self.config.deploy_cert(
-                              "random.demo", "example/cert.pem", "example/key.pem",
-                              "example/cert_chain.pem"))
+                              "random.demo", "example/cert.pem", "example/key.pem"))
 
     def test_deploy_cert(self):
         self.config.parser.modules.add("ssl_module")

--- a/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
+++ b/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
@@ -306,6 +306,19 @@ class TwoVhost80Test(util.ApacheTest):
                           lambda: self.config.deploy_cert(
                               "random.demo", "example/cert.pem", "example/key.pem"))
 
+    def test_deploy_cert_old_apache_no_chain(self):
+        self.config = util.get_apache_configurator(
+            self.config_path, self.config_dir, self.work_dir, version=(2, 4, 7))
+
+        self.config.parser.modules.add("ssl_module")
+        self.config.parser.modules.add("mod_ssl.c")
+
+        # Get the default 443 vhost
+        self.config.assoc["random.demo"] = self.vh_truth[1]
+        self.assertRaises(errors.PluginError,
+                          lambda: self.config.deploy_cert(
+                              "random.demo", "example/cert.pem", "example/key.pem"))
+
     def test_deploy_cert(self):
         self.config.parser.modules.add("ssl_module")
         self.config.parser.modules.add("mod_ssl.c")

--- a/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
+++ b/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
@@ -381,8 +381,8 @@ class TwoVhost80Test(util.ApacheTest):
 
     def test_remove_existing_ssl_directives(self):
         # pylint: disable=protected-access
-        BOGUS_DIRECTIVES = ["SSLCertificateKeyFile", "SSLCertificateChainFile",
-                            "SSLCACertificatePath", "SSLCertificateFile"]
+        BOGUS_DIRECTIVES = ["SSLCertificateKeyFile",
+                            "SSLCertificateChainFile", "SSLCertificateFile"]
         for directive in BOGUS_DIRECTIVES:
             self.config.parser.add_dir(self.vh_truth[0].path, directive, ["bogus"])
         self.config.save()

--- a/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
+++ b/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
@@ -262,6 +262,20 @@ class TwoVhost80Test(util.ApacheTest):
         self.assertEqual(configurator.get_file_path(loc_key[0]),
                          self.vh_truth[1].filep)
 
+    def test_deploy_cert_newssl_no_fullchain(self):
+        self.config = util.get_apache_configurator(
+            self.config_path, self.config_dir, self.work_dir, version=(2, 4, 16))
+
+        self.config.parser.modules.add("ssl_module")
+        self.config.parser.modules.add("mod_ssl.c")
+
+        # Get the default 443 vhost
+        self.config.assoc["random.demo"] = self.vh_truth[1]
+        self.assertRaises(errors.PluginError,
+                          lambda: self.config.deploy_cert(
+                              "random.demo", "example/cert.pem", "example/key.pem",
+                              "example/cert_chain.pem"))
+
     def test_deploy_cert(self):
         self.config.parser.modules.add("ssl_module")
         self.config.parser.modules.add("mod_ssl.c")

--- a/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
+++ b/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
@@ -386,6 +386,7 @@ class TwoVhost80Test(util.ApacheTest):
         for directive in BOGUS_DIRECTIVES:
             self.config.parser.add_dir(self.vh_truth[0].path, directive, ["bogus"])
         self.config.save()
+
         self.config._remove_existing_ssl_directives(self.vh_truth[0].path)
         self.config.save()
 
@@ -393,6 +394,31 @@ class TwoVhost80Test(util.ApacheTest):
             self.assertEqual(
                 self.config.parser.find_dir(directive, None, self.vh_truth[0].path),
                 [])
+
+    def test_remove_existing_ssl_directives_minus_some(self):
+        # pylint: disable=protected-access
+        BOGUS_DIRECTIVES = ["SSLCertificateKeyFile",
+                            "SSLCertificateChainFile", "SSLCertificateFile"]
+        MINUS_DIRECTIVES = ["SSLCertificateKeyFile", "SSLCertificateFile"]
+        for directive in BOGUS_DIRECTIVES:
+            self.config.parser.add_dir(self.vh_truth[0].path, directive, ["bogus"])
+        self.config.save()
+
+        self.config._remove_existing_ssl_directives(self.vh_truth[0].path,
+                                                    minus=MINUS_DIRECTIVES)
+        self.config.save()
+
+        for directive in BOGUS_DIRECTIVES:
+            if directive not in MINUS_DIRECTIVES:
+                self.assertEqual(
+                    self.config.parser.find_dir(directive, None, self.vh_truth[0].path),
+                    [],
+                    msg="directive %s should have been removed" % directive)
+            else:
+                self.assertNotEqual(
+                    self.config.parser.find_dir(directive, None, self.vh_truth[0].path),
+                    [],
+                    msg="directive %s should still exist" % directive)
 
     def test_make_vhost_ssl_extra_vhs(self):
         self.config.aug.match = mock.Mock(return_value=["p1", "p2"])

--- a/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
+++ b/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
@@ -131,11 +131,8 @@ class TwoVhost80Test(util.ApacheTest):
         self.config.save()
         mock_select.return_value = self.vh_truth[1]
 
-        vhost = self.config.choose_vhost("none.com")
+        self.config.choose_vhost("none.com")
         self.config.save()
-
-        with open(vhost.filep) as f:
-            print f.read()
 
         loc_cert = self.config.parser.find_dir(
             'SSLCertificateFile', None, self.vh_truth[1].path, False)


### PR DESCRIPTION
Also use fullchain.pem on Apache versions that support it.  From this IRC log:
```
2015-11-02 16:31:29	@pdeee	for >= 2.4.8:
2015-11-02 16:32:23	@pdeee	add new SSLCertificateFile pointing to fullchain.pem
2015-11-02 16:33:10	@pdeee	remove all preexisting SSLCertificateFile, SSLCertificateChainFile, SSLCACertificatePath, and possibly other fields subject to careful research :)
2015-11-02 16:33:21	@pdeee	for < 2.4.8:
2015-11-02 16:34:03	@pdeee	add SSLCertificateFile pointing to cert.pem
2015-11-02 16:34:42	@pdeee	and SSLCertificateChainFile pointing to chain.pem
2015-11-02 16:34:50	xamnesiax	gotcha
2015-11-02 16:34:55	@pdeee	remove all preexisting/conflicting entries
2015-11-02 16:35:19	xamnesiax	Am I correct to assume that this can all be done from deploy_certs in the apache configurator?
2015-11-02 16:36:32	xamnesiax	deploy_cert *
2015-11-02 16:36:48	@pdeee	I think so
2015-11-02 16:36:59	@pdeee	again, jdkasten may wish to say more
```

Will fix #1213, hopefully will fix #1266.