### PR TITLE
fix bug in letsencrypt-auto on OSX

### DIFF
--- a/letsencrypt-auto
+++ b/letsencrypt-auto
@@ -33,7 +33,11 @@ ExperimentalBootstrap() {
   if [ "$DEBUG" = 1 ] ; then
     if [ "$2" != "" ]  ; then
       echo "Bootstrapping dependencies for $1..."
-      "$3" "$BOOTSTRAP/$2"
+      if [ "$3" != "" ]  ; then
+        "$3" "$BOOTSTRAP/$2"
+      else
+        "$BOOTSTRAP/$2"
+      fi
     fi
   else
     echo "WARNING: $1 support is very experimental at present..."


### PR DESCRIPTION
Fixes bug on OSX:

    $ ./letsencrypt-auto --debug bash
    Bootstrapping dependencies for Mac OS X...
    ./letsencrypt-auto: line 36: : command not found