### PR TITLE
Implemented useragent debugging code for #1397

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -615,7 +615,6 @@ class ClientNetwork(object):
         else:
             raise errors.MissingNonce(response)
 
-
     def _get_nonce(self, url):
         if not self._nonces:
             logging.debug('Requesting fresh nonce')
@@ -629,11 +628,12 @@ class ClientNetwork(object):
         self._add_nonce(response)
         return self._check_response(response, content_type=content_type)
 
-    def _parse_user_agent_object(self):
+    def set_user_agent(self, keyval_map):
         """
         Update self.user_agent from data in self.user_agent_object
         """
 
+        self.user_agent_object = keyval_map
         uao = self.user_agent_object
 
         client_name = 'LetsEncryptPythonClient'
@@ -657,18 +657,7 @@ class ClientNetwork(object):
             dist_version
         )
 
-        for kv_pair in uao.iteritems(): user_agent += ' %s/%s' % kv_pair
+        for kv_pair in uao.iteritems():
+            user_agent += ' %s/%s' % kv_pair
+
         self.user_agent = user_agent
-
-    def update_user_agent(self, keyval_map=None):
-        """
-        Parse keyval_map and call _parse_user_agent_object to update
-        self.user_agent
-        """
-
-        # Allows self.user_agent_object to be modified externally & updated
-        if keyval_map is not None:
-            for key, value in keyval_map.iteritems():
-                self.user_agent_object[key] = value
-
-        self._parse_user_agent_object()

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -615,6 +615,7 @@ class ClientNetwork(object):
         else:
             raise errors.MissingNonce(response)
 
+
     def _get_nonce(self, url):
         if not self._nonces:
             logging.debug('Requesting fresh nonce')
@@ -629,14 +630,45 @@ class ClientNetwork(object):
         return self._check_response(response, content_type=content_type)
 
     def _parse_user_agent_object(self):
-        user_agent = ''
+        """
+        Update self.user_agent from data in self.user_agent_object
+        """
 
-        for kv_pair in self.user_agent_object.iteritems(): user_agent += '%s:%s ' % kv_pair
+        uao = self.user_agent_object
 
+        client_name = 'LetsEncryptPythonClient'
+        if 'client_name' in uao:
+            client_name = uao['client_name']
+            del uao['client_name']
+
+        le_version = ''
+        if 'le_version' in uao:
+            le_version = uao['le_version']
+            del uao['le_version']
+
+        dist_version = ''
+        if 'dist_version' in uao:
+            dist_version = uao['dist_version']
+            del uao['dist_version']
+
+        user_agent = '%s/%s (%s)' % (
+            client_name,
+            le_version,
+            dist_version
+        )
+
+        for kv_pair in uao.iteritems(): user_agent += ' %s/%s' % kv_pair
         self.user_agent = user_agent
 
-    def update_user_agent(self, keyval_map):
-        for key, value in keyval_map.iteritems():
-            self.user_agent_object[key] = value
+    def update_user_agent(self, keyval_map=None):
+        """
+        Parse keyval_map and call _parse_user_agent_object to update
+        self.user_agent
+        """
+
+        # Allows self.user_agent_object to be modified externally & updated
+        if keyval_map is not None:
+            for key, value in keyval_map.iteritems():
+                self.user_agent_object[key] = value
 
         self._parse_user_agent_object()

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -633,31 +633,37 @@ class ClientNetwork(object):
         Update self.user_agent from data in self.user_agent_object
         """
 
-        self.user_agent_object = keyval_map
-        uao = self.user_agent_object
+        if keyval_map['user_agent'] is None:
+            del keyval_map['user_agent']
 
-        client_name = 'LetsEncryptPythonClient'
-        if 'client_name' in uao:
-            client_name = uao['client_name']
-            del uao['client_name']
+            self.user_agent_object = keyval_map
+            uao = self.user_agent_object
 
-        le_version = ''
-        if 'le_version' in uao:
-            le_version = uao['le_version']
-            del uao['le_version']
+            client_name = 'LetsEncryptPythonClient'
+            if 'client_name' in uao:
+                client_name = uao['client_name']
+                del uao['client_name']
 
-        dist_version = ''
-        if 'dist_version' in uao:
-            dist_version = uao['dist_version']
-            del uao['dist_version']
+            le_version = ''
+            if 'le_version' in uao:
+                le_version = uao['le_version']
+                del uao['le_version']
 
-        user_agent = '%s/%s (%s)' % (
-            client_name,
-            le_version,
-            dist_version
-        )
+            dist_version = ''
+            if 'dist_version' in uao:
+                dist_version = uao['dist_version']
+                del uao['dist_version']
 
-        for kv_pair in uao.iteritems():
-            user_agent += ' %s/%s' % kv_pair
+            user_agent = '%s/%s (%s)' % (
+                client_name,
+                le_version,
+                dist_version
+            )
 
-        self.user_agent = user_agent
+            for kv_pair in uao.iteritems():
+                user_agent += ' %s/%s' % kv_pair
+
+            self.user_agent = user_agent
+
+        else:
+            self.user_agent = keyval_map['user_agent']

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -488,6 +488,7 @@ class ClientNetwork(object):
         self.verify_ssl = verify_ssl
         self._nonces = set()
         self.user_agent = user_agent
+        self.user_agent_object = dict()
 
     def _wrap_in_jws(self, obj, nonce):
         """Wrap `JSONDeSerializable` object in JWS.
@@ -626,3 +627,16 @@ class ClientNetwork(object):
         response = self._send_request('POST', url, data=data, **kwargs)
         self._add_nonce(response)
         return self._check_response(response, content_type=content_type)
+
+    def _parse_user_agent_object(self):
+        user_agent = ''
+
+        for kv_pair in self.user_agent_object.iteritems(): user_agent += '%s:%s ' % kv_pair
+
+        self.user_agent = user_agent
+
+    def update_user_agent(self, keyval_map):
+        for key, value in keyval_map.iteritems():
+            self.user_agent_object[key] = value
+
+        self._parse_user_agent_object()

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -550,11 +550,19 @@ def obtaincert(args, config, plugins):
     # TODO: Handle errors from _init_le_client?
     le_client = _init_le_client(args, config, authenticator, installer)
 
+    auth_name = 'None'
+    if authenticator is not None:
+        auth_name = authenticator.name
+
+    inst_name = 'None'
+    if installer is not None:
+        inst_name = installer.name
+
     update_useragent(
-        args.opt_out_statistics,
+        args.user_agent,
         le_client,
-        (authenticator.name,
-         installer.name)
+        (auth_name,
+         inst_name)
     )
 
     # This is a special case; cert and chain are simply saved
@@ -583,11 +591,15 @@ def install(args, config, plugins):
     le_client = _init_le_client(
         args, config, authenticator=None, installer=installer)
 
+    inst_name = 'None'
+    if installer is not None:
+        inst_name = installer.name
+
     update_useragent(
-        args.opt_out_statistics,
+        args.user_agent,
         le_client,
         ('None',
-         installer.name)
+         inst_name)
     )
 
     assert args.cert_path is not None  # required=True in the subparser

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -481,6 +481,7 @@ def update_useragent(user_agent, le_client, names):
         'client_name': 'LetsEncryptPythonClient',
         'le_version': letsencrypt.__version__,
         'dist_version': os_info,
+        'user_agent': user_agent,
 
         'Authenticator': auth_name,
         'Installer': inst_name
@@ -961,7 +962,7 @@ def prepare_and_parse_args(plugins, args):
         help="Require that all configuration files are owned by the current "
              "user; only needed if your config is somewhere unsafe like /tmp/")
     helpful.add(
-        "security", "--user-agent", type=str, default="",
+        "security", "--user-agent", type=str, default=None,
         help="Set a custom user agent string for the client. User agent strings allow "
              "the CA to collect high level statistics about success rates by OS and "
              "plugin. If you wish to hide your server OS version from the Let's "

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -1246,7 +1246,6 @@ def main(cli_args=sys.argv[1:]):
 
     return args.func(args, config, plugins)
 
-
 if __name__ == "__main__":
     err_string = main()
     if err_string:

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -470,10 +470,8 @@ def update_useragent(user_agent, le_client, names):
     Update the ACME HTTP request's useragent to include
     information pertaining to plugins and modules
     """
-
     if user_agent == '':
         return
-
     auth_name, inst_name = names
     os_info = ' '.join(get_os_info())
 
@@ -516,8 +514,7 @@ def run(args, config, plugins):  # pylint: disable=too-many-branches,too-many-lo
     update_useragent(
         args.user_agent,
         le_client,
-        (auth_name,
-         inst_name)
+        (auth_name, inst_name)
     )
 
     lineage = _auth_from_domains(le_client, config, domains, plugins)
@@ -562,8 +559,7 @@ def obtaincert(args, config, plugins):
     update_useragent(
         args.user_agent,
         le_client,
-        (auth_name,
-         inst_name)
+        (auth_name, inst_name)
     )
 
     # This is a special case; cert and chain are simply saved
@@ -599,8 +595,7 @@ def install(args, config, plugins):
     update_useragent(
         args.user_agent,
         le_client,
-        ('None',
-         inst_name)
+        ('None', inst_name)
     )
 
     assert args.cert_path is not None  # required=True in the subparser
@@ -1243,7 +1238,6 @@ def main(cli_args=sys.argv[1:]):
         #return (
         #    "{0}Root is required to run letsencrypt.  Please use sudo.{0}"
         #    .format(os.linesep))
-
     return args.func(args, config, plugins)
 
 if __name__ == "__main__":

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -460,18 +460,18 @@ def get_os_info():
         ).communicate()[0]
 
     else:
-        os_ver = 'X'
+        os_ver = ''
 
     return os_type, os_ver
 
 
-def update_useragent(opt_out, le_client, names):
+def update_useragent(user_agent, le_client, names):
     """
     Update the ACME HTTP request's useragent to include
     information pertaining to plugins and modules
     """
 
-    if opt_out:
+    if user_agent == '':
         return
 
     auth_name, inst_name = names
@@ -486,7 +486,7 @@ def update_useragent(opt_out, le_client, names):
         'Installer': inst_name
     }
 
-    le_client.acme.net.update_user_agent(useragent_args)
+    le_client.acme.net.set_user_agent(useragent_args)
 
 
 # TODO: Make run as close to auth + install as possible
@@ -512,9 +512,9 @@ def run(args, config, plugins):  # pylint: disable=too-many-branches,too-many-lo
         inst_name = installer.name
 
     update_useragent(
-        args.opt_out_statistics,
+        args.user_agent,
         le_client,
-        (auth_name, 
+        (auth_name,
          inst_name)
     )
 
@@ -585,7 +585,7 @@ def install(args, config, plugins):
     update_useragent(
         args.opt_out_statistics,
         le_client,
-        (authenticator.name,
+        ('None',
          installer.name)
     )
 
@@ -961,8 +961,11 @@ def prepare_and_parse_args(plugins, args):
         help="Require that all configuration files are owned by the current "
              "user; only needed if your config is somewhere unsafe like /tmp/")
     helpful.add(
-        "security", "--opt-out-statistics", action="store_true",
-        help="Do not send statistical data back to LetsEncrypt via ACME"
+        "security", "--user-agent", type=str, default="",
+        help="Set a custom user agent string for the client. User agent strings allow "
+             "the CA to collect high level statistics about success rates by OS and "
+             "plugin. If you wish to hide your server OS version from the Let's "
+             "Encrypt server, set this to \"\"."
     )
 
     _create_subparsers(helpful)

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -487,7 +487,8 @@ def update_useragent(user_agent, le_client, names):
         'Installer': inst_name
     }
 
-    le_client.acme.net.set_user_agent(useragent_args)
+    if hasattr(le_client.acme, 'net'):
+        le_client.acme.net.set_user_agent(useragent_args)
 
 
 # TODO: Make run as close to auth + install as possible

--- a/letsencrypt/client.py
+++ b/letsencrypt/client.py
@@ -124,6 +124,8 @@ class Client(object):
         self.dv_auth = dv_auth
         self.installer = installer
 
+        # Add in User Agent code
+
         # Initialize ACME if account is provided
         if acme is None and self.account is not None:
             acme = _acme_from_config_key(config, self.account.key)

--- a/letsencrypt/client.py
+++ b/letsencrypt/client.py
@@ -124,8 +124,6 @@ class Client(object):
         self.dv_auth = dv_auth
         self.installer = installer
 
-        # Add in User Agent code
-
         # Initialize ACME if account is provided
         if acme is None and self.account is not None:
             acme = _acme_from_config_key(config, self.account.key)

--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -21,6 +21,7 @@ letsencrypt_test () {
         $store_flags \
         --text \
         --no-redirect \
+        --user-agent "" \
         --agree-dev-preview \
         --agree-tos \
         --email "" \


### PR DESCRIPTION
Information regarding the Authenticator and Installer, as well as basic Operating System info (OS / Dist + version) is now sent in the ACME HTTP request, via the useragent. New flag has been added (--user-agent), which allows for both the customization of the user agent, and the disabling of data collection via the user agent by Let's Encrypt's servers.