### PR TITLE
Fix Dockerfile copying ubuntu.sh bootstrap file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /opt/letsencrypt
 # If <dest> doesn't exist, it is created along with all missing
 # directories in its path.
 
-COPY bootstrap/ubuntu.sh /opt/letsencrypt/src/
+COPY bootstrap/ubuntu.sh /opt/letsencrypt/src/ubuntu.sh
 RUN /opt/letsencrypt/src/ubuntu.sh && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
When trying to build the docker image for letsencrypt, I was unable to since the COPY statement did not work until I specified the full destination path.