### PR TITLE
Help text for -d flag, and refactoring the long name from plural to singular form

### DIFF
--- a/letsencrypt-nginx/tests/boulder-integration.sh
+++ b/letsencrypt-nginx/tests/boulder-integration.sh
@@ -18,7 +18,7 @@ letsencrypt_test_nginx () {
         "$@"
 }
 
-letsencrypt_test_nginx --domains nginx.wtf run
+letsencrypt_test_nginx --domain nginx.wtf run
 echo | openssl s_client -connect localhost:5001 \
     | openssl x509 -out $root/nginx.pem
 diff -q $root/nginx.pem $root/conf/live/nginx.wtf/cert.pem

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -811,7 +811,9 @@ def prepare_and_parse_args(plugins, args):
     # --domains is useful, because it can be stored in config
     #for subparser in parser_run, parser_auth, parser_install:
     #    subparser.add_argument("domains", nargs="*", metavar="domain")
-    helpful.add(None, "-d", "--domains", metavar="DOMAIN", action="append")
+    helpful.add(None, "-d", "--domains", metavar="DOMAIN", action="append",
+                help="Domain names to apply. Use multiple -d flags if you want "
+                "to specify multiple domains")
     helpful.add(
         None, "--duplicate", dest="duplicate", action="store_true",
         help="Allow getting a certificate that duplicates an existing one")

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -106,7 +106,7 @@ def _find_domains(args, installer):
         domains = args.domains
 
     if not domains:
-        raise errors.Error("Please specify --domains, or --installer that "
+        raise errors.Error("Please specify --domain, or --installer that "
                            "will help in domain names autodiscovery")
 
     return domains
@@ -465,9 +465,9 @@ def obtaincert(args, config, plugins):
     """Authenticate & obtain cert, but do not install it."""
 
     if args.domains is not None and args.csr is not None:
-        # TODO: --csr could have a priority, when --domains is
+        # TODO: --csr could have a priority, when --domain is
         # supplied, check if CSR matches given domains?
-        return "--domains and --csr are mutually exclusive"
+        return "--domain and --csr are mutually exclusive"
 
     try:
         # installers are used in auth mode to determine domain names
@@ -807,11 +807,12 @@ def prepare_and_parse_args(plugins, args):
         None, "-t", "--text", dest="text_mode", action="store_true",
         help="Use the text output instead of the curses UI.")
     helpful.add(None, "-m", "--email", help=config_help("email"))
-    # positional arg shadows --domains, instead of appending, and
-    # --domains is useful, because it can be stored in config
+    # positional arg shadows --domain, instead of appending, and
+    # --domain is useful, because it can be stored in config
     #for subparser in parser_run, parser_auth, parser_install:
     #    subparser.add_argument("domains", nargs="*", metavar="domain")
-    helpful.add(None, "-d", "--domains", metavar="DOMAIN", action="append",
+    helpful.add(None, "-d", "--domain", dest="domains",
+                metavar="DOMAIN", action="append",
                 help="Domain names to apply. Use multiple -d flags if you want "
                 "to specify multiple domains")
     helpful.add(

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -170,7 +170,7 @@ class CLITest(unittest.TestCase):
 
     def test_certonly_bad_args(self):
         ret, _, _, _ = self._call(['-d', 'foo.bar', 'certonly', '--csr', CSR])
-        self.assertEqual(ret, '--domains and --csr are mutually exclusive')
+        self.assertEqual(ret, '--domain and --csr are mutually exclusive')
 
         ret, _, _, _ = self._call(['-a', 'bad_auth', 'certonly'])
         self.assertEqual(ret, 'The requested bad_auth plugin does not appear to be installed')

--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -27,8 +27,8 @@ common() {
         "$@"
 }
 
-common --domains le1.wtf --standalone-supported-challenges tls-sni-01 auth
-common --domains le2.wtf --standalone-supported-challenges http-01 run
+common --domain le1.wtf --standalone-supported-challenges tls-sni-01 auth
+common --domain le2.wtf --standalone-supported-challenges http-01 run
 common -a manual -d le.wtf auth
 
 export CSR_PATH="${root}/csr.der" KEY_PATH="${root}/key.pem" \


### PR DESCRIPTION
* Added help text for -d flag
* Refactored the long name --domains to --domain to be semantically correct

Fixes #1442 

Still uses the old key "domains" in the internal code, to not to break existing configuration files etc.