### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /opt/letsencrypt
 # If <dest> doesn't exist, it is created along with all missing
 # directories in its path.
 
-COPY bootstrap/ubuntu.sh /opt/letsencrypt/src/
+COPY bootstrap/ubuntu.sh /opt/letsencrypt/src/ubuntu.sh
 RUN /opt/letsencrypt/src/ubuntu.sh && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
On docker 1.9, the copy of the ubuntu.sh file fails if the full path of destination is not specified