### PR TITLE
Fix misplaced verbosity from pip

### DIFF
--- a/letsencrypt-auto
+++ b/letsencrypt-auto
@@ -158,7 +158,7 @@ else
   $VENV_BIN/pip install -U pip > /dev/null
   printf .
   # nginx is buggy / disabled for now...
-  $VENV_BIN/pip install -r py26reqs.txt
+  $VENV_BIN/pip install -r py26reqs.txt > /dev/null
   printf .
   $VENV_BIN/pip install -U letsencrypt > /dev/null
   printf .


### PR DESCRIPTION
When configargparse is [not] being upgraded, `letsencrypt-auto` prints a bunch of ugly messages about it. 