### PR TITLE
Additional hint on cmd vs copy&paste

### DIFF
--- a/letsencrypt/plugins/manual.py
+++ b/letsencrypt/plugins/manual.py
@@ -47,6 +47,7 @@ Make sure your web server displays the following content at
 {validation}
 
 Content-Type header MUST be set to {ct}.
+It is recommended to use the printf command provided below to make sure line endings are set correctly.
 
 If you don't have HTTP server configured, you can run the following
 command on the target server (as root):


### PR DESCRIPTION
I spent a lot of time figuring out why the challenge failed - my file was 86 bytes (pasting to vim) instead of 87 when created with the printf

So to make users aware of issue when pasting only the text, this might help others spending that time again