### PR TITLE
use boulder's integration-test.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,7 @@ addons:
     - rsyslog
 
 install: "travis_retry pip install tox coveralls"
-before_script: '[ "xxx$BOULDER_INTEGRATION" = "xxx" ] || ./tests/boulder-start.sh'
-script: 'travis_retry tox && ([ "xxx$BOULDER_INTEGRATION" = "xxx" ] || (source .tox/$TOXENV/bin/activate && ./tests/boulder-integration.sh))'
+script: 'travis_retry tox && ([ "xxx$BOULDER_INTEGRATION" = "xxx" ] || ./tests/travis-integration.sh)'
 
 after_success: '[ "$TOXENV" == "cover" ] && coveralls'
 

--- a/tests/boulder-fetch.sh
+++ b/tests/boulder-fetch.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Download and run Boulder instance for integration testing
+
+# ugh, go version output is like:
+# go version go1.4.2 linux/amd64
+GOVER=`go version | cut -d" " -f3 | cut -do -f2`
+
+# version comparison
+function verlte {
+  #OS X doesn't support version sorting; emulate with sed
+  if [ `uname` == 'Darwin' ]; then
+    [ "$1" = "`echo -e \"$1\n$2\" |  sed 's/\b\([0-9]\)\b/0\1/g' \
+      | sort | sed 's/\b0\([0-9]\)/\1/g' | head -n1`" ]
+  else
+    [  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
+  fi
+}
+
+if ! verlte 1.5 "$GOVER" ; then
+  echo "We require go version 1.5 or later; you have... $GOVER"
+  exit 1
+fi
+
+set -xe
+
+# `/...` avoids `no buildable Go source files` errors, for more info
+# see `go help packages`
+go get -d github.com/letsencrypt/boulder/...
+cd $GOPATH/src/github.com/letsencrypt/boulder
+# goose is needed for ./test/create_db.sh
+wget https://github.com/jsha/boulder-tools/raw/master/goose.gz && \
+  mkdir $GOPATH/bin && \
+  zcat goose.gz > $GOPATH/bin/goose && \
+  chmod +x $GOPATH/bin/goose
+./test/create_db.sh
+# listenbuddy is needed for ./start.py
+go get github.com/jsha/listenbuddy
+cd -
+

--- a/tests/boulder-start.sh
+++ b/tests/boulder-start.sh
@@ -1,43 +1,9 @@
 #!/bin/bash
-# Download and run Boulder instance for integration testing
-
-
-# ugh, go version output is like:
-# go version go1.4.2 linux/amd64
-GOVER=`go version | cut -d" " -f3 | cut -do -f2`
-
-# version comparison
-function verlte {
-  #OS X doesn't support version sorting; emulate with sed
-  if [ `uname` == 'Darwin' ]; then
-    [ "$1" = "`echo -e \"$1\n$2\" |  sed 's/\b\([0-9]\)\b/0\1/g' \
-      | sort | sed 's/\b0\([0-9]\)/\1/g' | head -n1`" ]
-  else
-    [  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
-  fi
-}
-
-if ! verlte 1.5 "$GOVER" ; then
-  echo "We require go version 1.5 or later; you have... $GOVER"
-  exit 1
-fi
-
-set -xe
 
 export GOPATH="${GOPATH:-/tmp/go}"
 export PATH="$GOPATH/bin:$PATH"
 
-# `/...` avoids `no buildable Go source files` errors, for more info
-# see `go help packages`
-go get -d github.com/letsencrypt/boulder/...
+./tests/boulder-fetch.sh
+
 cd $GOPATH/src/github.com/letsencrypt/boulder
-# goose is needed for ./test/create_db.sh
-wget https://github.com/jsha/boulder-tools/raw/master/goose.gz && \
-  mkdir $GOPATH/bin && \
-  zcat goose.gz > $GOPATH/bin/goose && \
-  chmod +x $GOPATH/bin/goose
-./test/create_db.sh
-# listenbuddy is needed for ./start.py
-go get github.com/jsha/listenbuddy
-./start.py &
-# Hopefully start.py bootstraps before integration test is started...
+./start.py

--- a/tests/travis-integration.sh
+++ b/tests/travis-integration.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -o errexit
+
+./tests/boulder-fetch.sh
+
+source .tox/$TOXENV/bin/activate
+
+export LETSENCRYPT_PATH=`pwd`
+
+cd $GOPATH/src/github.com/letsencrypt/boulder/
+
+# boulder's integration-test.py has code that knows to start and wait for the
+# boulder processes to start reliably and then will run the letsencrypt
+# boulder-interation.sh on its own. The --letsencrypt flag says to run only the
+# letsencrypt tests (instead of any other client tests it might run). We're
+# going to want to define a more robust interaction point between the boulder
+# and letsencrypt tests, but that will be better built off of this.
+python test/integration-test.py --letsencrypt


### PR DESCRIPTION
This prevents the integration tests from getting run before the boulder processes have finished booting in most cases. There's still some small races with debug ports going up before RPC ports, but this flushes the big ones (specifically, the WFE ports), and the boulder devs are going to fix the rest in integration-test.py over time.

This also makes boulder-start.sh a blocking operation. Now that the TravisCI integration tests no longer requires boulder-start.sh, we can let the other priority of being easier for users to control (that is, basically,
make it easy to Ctrl-C) take over. That plus the idea that self-daemonizing code is tricky to get right, especially over multiple platforms led me to not trying to get start.py to make itself asynchronous.

Most of this change is code movement in order to allow developers to run boulder-start.sh once and boulder-integration.sh many times while also not duplicating that code in order to run the tests in TravisCI.

I'm not a huge fan of both the letsencrypt's shell scripts and boulder's integration-test.py having hard-coded file dependencies in the other's repo.

This, however, seemed like the smallest path to code that would spuriously break less. All the designs I was able to come up that were maybe smaller changes either had the "starts tests before the servers are up" problem or with a "each repo uses another repo's test code file" problem. Those problem on top of the "it's a bigger change" problem led me here.