### PR TITLE
Check for python2.7 before python2 in letsencrypt-auto

### DIFF
--- a/letsencrypt-auto
+++ b/letsencrypt-auto
@@ -83,10 +83,10 @@ ExperimentalBootstrap() {
 }
 
 DeterminePythonVersion() {
-  if command -v python2 > /dev/null ; then
-    export LE_PYTHON=${LE_PYTHON:-python2}
-  elif command -v python2.7 > /dev/null ; then
+  if command -v python2.7 > /dev/null ; then
     export LE_PYTHON=${LE_PYTHON:-python2.7}
+  elif command -v python2 > /dev/null ; then
+    export LE_PYTHON=${LE_PYTHON:-python2}
   elif command -v python > /dev/null ; then
     export LE_PYTHON=${LE_PYTHON:-python}
   else


### PR DESCRIPTION
There are cases where more than one version of python2 is installed, and where
the default is not 2.7. For example in CentOS 6, it is common for both 2.6 and
2.7 to be installed, as yum requires 2.6 apparently for some reason.