### PR TITLE
Update tox.ini to run acme tests with Python 3.5

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 # acme and letsencrypt are not yet on pypi, so when Tox invokes
 # "install *.zip", it will not find deps
 skipsdist = true
-envlist = py26,py27,py33,py34,cover,lint
+envlist = py26,py27,py33,py34,py35,cover,lint
 
 # nosetest -v => more verbose output, allows to detect busy waiting
 # loops, especially on Travis
@@ -37,6 +37,11 @@ commands =
     nosetests -v acme
 
 [testenv:py34]
+commands =
+    pip install -e acme[testing]
+    nosetests -v acme
+
+[testenv:py35]
 commands =
     pip install -e acme[testing]
     nosetests -v acme


### PR DESCRIPTION
I somewhat confused GitHub and cannot reopen #1506. Sorry for the noise.