### PR TITLE
Fixes failed Redhat bootstrapping

### DIFF
--- a/bootstrap/_rpm_common.sh
+++ b/bootstrap/_rpm_common.sh
@@ -16,16 +16,20 @@ else
 fi
 
 # "git-core" seems to be an alias for "git" in CentOS 7 (yum search fails)
+DEPS="git-core
+    python
+    python-devel
+    python-virtualenv
+    gcc
+    dialog
+    augeas-libs
+    openssl-devel
+    libffi-devel
+    ca-certificates "
+
 # Amazon Linux 2015.03 needs python27-virtualenv rather than python-virtualenv
-$tool install -y \
-  git-core \
-  python \
-  python-devel \
-  python27-virtualenv \
-  python-virtualenv \
-  gcc \
-  dialog \
-  augeas-libs \
-  openssl-devel \
-  libffi-devel \
-  ca-certificates \
+if grep -iq "Amazon Linux" /etc/issue ; then
+    DEPS+=python27-virtualenv
+fi
+
+$tool install -y $DEPS

--- a/bootstrap/_rpm_common.sh
+++ b/bootstrap/_rpm_common.sh
@@ -4,12 +4,12 @@
 #   - Fedora 22 (x64)
 #   - Centos 7 (x64: on AWS EC2 t2.micro, DigitalOcean droplet)
 
-if type yum 2>/dev/null
-then
-  tool=yum
-elif type dnf 2>/dev/null
+if type dnf 2>/dev/null
 then
   tool=dnf
+elif type yum 2>/dev/null
+then
+  tool=yum
 else
   echo "Neither yum nor dnf found. Aborting bootstrap!"
   exit 1


### PR DESCRIPTION
Currently on Fedora systems, the bootstrap will fail with the error message `No package python27-virtualenv available`. This patch tests whether the system is an Amazon system before appending the problem package to the dependency list. Additionally, there is a commit which changes the yum/dnf testing order as dnf is the new standard, and if it's available it should be the preference over yum (which in Fedora 22 currently is just a warning that yum is deprecated and that you should be using dnf).