### PR TITLE
Test dnf before yum

### DIFF
--- a/bootstrap/_rpm_common.sh
+++ b/bootstrap/_rpm_common.sh
@@ -4,12 +4,13 @@
 #   - Fedora 22 (x64)
 #   - Centos 7 (x64: on AWS EC2 t2.micro, DigitalOcean droplet)
 
-if type yum 2>/dev/null
-then
-  tool=yum
-elif type dnf 2>/dev/null
+if type dnf 2>/dev/null
 then
   tool=dnf
+elif type yum 2>/dev/null
+then
+  tool=yum
+
 else
   echo "Neither yum nor dnf found. Aborting bootstrap!"
   exit 1


### PR DESCRIPTION
yum may still be installed (by default in recent Fedoras) and will display a deprecation and migration message. On the other hand, dnf either is or isn't installed and the test will proceed as intended. (dnf is the modern replacement for yum.)