### PR TITLE
Support more distros with different RPM names

### DIFF
--- a/bootstrap/_rpm_common.sh
+++ b/bootstrap/_rpm_common.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 # Tested with:
-#   - Fedora 22 (x64)
-#   - Centos 7 (x64: on AWS EC2 t2.micro, DigitalOcean droplet)
+#   - Fedora 22, 23 (x64)
+#   - Centos 7 (x64: onD igitalOcean droplet)
 
 if type yum 2>/dev/null
 then
@@ -15,17 +15,33 @@ else
   exit 1
 fi
 
+# Some distros and older versions of current distros use a "python27"
+# instead of "python" naming convention. Try both conventions.
+if ! $tool install -y \
+       python \
+       python-devel \
+       python-virtualenv
+then
+  if ! $tool install -y \
+         python27 \
+         python27-devel \
+         python27-virtualenv
+  then
+    echo "Could not install Python dependencies. Aborting bootstrap!"
+    exit 1
+  fi
+fi
+
 # "git-core" seems to be an alias for "git" in CentOS 7 (yum search fails)
-# Amazon Linux 2015.03 needs python27-virtualenv rather than python-virtualenv
-$tool install -y \
-  git-core \
-  python \
-  python-devel \
-  python27-virtualenv \
-  python-virtualenv \
-  gcc \
-  dialog \
-  augeas-libs \
-  openssl-devel \
-  libffi-devel \
-  ca-certificates \
+if ! $tool install -y \
+       git-core \
+       gcc \
+       dialog \
+       augeas-libs \
+       openssl-devel \
+       libffi-devel \
+       ca-certificates
+then
+    echo "Could not install additional dependencies. Aborting bootstrap!"
+    exit 1
+fi


### PR DESCRIPTION
* Support both python and python27 naming conventions (varies by distro)
* Test every install command and give feedback if they don't succeed

The new install structure also allows for future conflicts/package naming inconsistencies to be resolved in a similar way. Should allow for wider RPM distro support with more testing and feedback.