### PR TITLE
Better UI when asking for email

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -139,7 +139,7 @@ def _determine_account(args, config):
         elif len(accounts) == 1:
             acc = accounts[0]
         else:  # no account registered yet
-            if args.email is None and not args.allow_unsafe_registration:
+            if args.email is None and not args.register_unsafely_without_email:
                 args.email = display_ops.get_email()
             else:
                 args.email = None
@@ -843,7 +843,7 @@ def prepare_and_parse_args(plugins, args):
         None, "-t", "--text", dest="text_mode", action="store_true",
         help="Use the text output instead of the curses UI.")
     helpful.add(
-        None, "--allow-unsafe-registration", action="store_true",
+        None, "--register-unsafely-without-email", action="store_true",
         help="Specifying this flag enables registering an account with no "
              "email address. This is strongly discouraged, because in the "
              "event of key loss or account compromise you will irrevocably "

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -141,8 +141,6 @@ def _determine_account(args, config):
         else:  # no account registered yet
             if args.email is None and not args.register_unsafely_without_email:
                 args.email = display_ops.get_email()
-            else:
-                args.email = None
 
             def _tos_cb(regr):
                 if args.tos:

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -139,9 +139,9 @@ def _determine_account(args, config):
         elif len(accounts) == 1:
             acc = accounts[0]
         else:  # no account registered yet
-            if args.email is None:
+            if args.email is None and not args.allow_unsafe_registration:
                 args.email = display_ops.get_email()
-            if not args.email:  # get_email might return ""
+            else:
                 args.email = None
 
             def _tos_cb(regr):
@@ -842,6 +842,16 @@ def prepare_and_parse_args(plugins, args):
     helpful.add(
         None, "-t", "--text", dest="text_mode", action="store_true",
         help="Use the text output instead of the curses UI.")
+    helpful.add(
+        None, "--allow-unsafe-registration", action="store_true",
+        help="Specifying this flag enables registering an account with no "
+             "email address. This is strongly discouraged, because in the "
+             "event of key loss or account compromise you will irrevocably "
+             "lose access to your account. You will also be unable to receive "
+             "notice about impending expiration of revocation of your "
+             "certificates. Updates to the Subscriber Agreement will still "
+             "affect you, and will be effective N days after posting an "
+             "update to the web site.")
     helpful.add(None, "-m", "--email", help=config_help("email"))
     # positional arg shadows --domains, instead of appending, and
     # --domains is useful, because it can be stored in config

--- a/letsencrypt/client.py
+++ b/letsencrypt/client.py
@@ -140,7 +140,8 @@ def perform_registration(acme, config):
     try:
         return acme.register(messages.NewRegistration.from_data(email=config.email))
     except messages.Error, e:
-        if "MX record" in repr(e):
+        err = repr(e)
+        if "MX record" in err or "Validation of contact mailto" in err:
             config.namespace.email = display_ops.get_email(more=True, invalid=True)
             return perform_registration(acme, config)
         else:

--- a/letsencrypt/client.py
+++ b/letsencrypt/client.py
@@ -135,7 +135,13 @@ def perform_registration(acme, config):
     Actually register new account, trying repeatedly if there are email
     problems
 
-    :returns: the same value as acme.register
+    :param .IConfig config: Client configuration.
+    :param acme.client.Client client: ACME client object.
+
+    :returns: Registration Resource.
+    :rtype: `acme.messages.RegistrationResource`
+
+    :raises .UnexpectedUpdate:
     """
     try:
         return acme.register(messages.NewRegistration.from_data(email=config.email))

--- a/letsencrypt/client.py
+++ b/letsencrypt/client.py
@@ -138,7 +138,7 @@ def perform_registration(acme, config):
     :returns: the same value as acme.register
     """
     try:
-        regr = acme.register(messages.NewRegistration.from_data(email=config.email))
+        return acme.register(messages.NewRegistration.from_data(email=config.email))
     except messages.Error, e:
         if "MX record" in repr(e):
             config.namespace.email = display_ops.get_email(more=True, invalid=True)

--- a/letsencrypt/client.py
+++ b/letsencrypt/client.py
@@ -100,6 +100,11 @@ def register(config, account_storage, tos_cb=None):
     if account_storage.find_all():
         logger.info("There are already existing accounts for %s", config.server)
     if config.email is None:
+        if not config.register_unsafely_without_email:
+            msg = ("No email was provided and "
+                   "--register-unsafely-without-email was not present.")
+            logger.warn(msg)
+            raise errors.Error(msg)
         logger.warn("Registering without email!")
 
     # Each new registration shall use a fresh new key

--- a/letsencrypt/client.py
+++ b/letsencrypt/client.py
@@ -130,6 +130,7 @@ def register(config, account_storage, tos_cb=None):
 
     return acc, acme
 
+
 def perform_registration(acme, config):
     """
     Actually register new account, trying repeatedly if there are email
@@ -152,6 +153,7 @@ def perform_registration(acme, config):
             return perform_registration(acme, config)
         else:
             raise
+
 
 class Client(object):
     """ACME protocol client.

--- a/letsencrypt/display/ops.py
+++ b/letsencrypt/display/ops.py
@@ -124,9 +124,10 @@ def get_email():
     """
     while True:
         code, email = zope.component.getUtility(interfaces.IDisplay).input(
-            "Enter email address (mandatory since no "
-            "--allow-unsafe-registration was provided)"
-            "(used for urgent notices and lost key recovery)")
+            "Enter email address "
+            "(used for urgent notices and lost key recovery)\n\n"
+            "If you really want to skip this, run the client with "
+            "--register-unsafely-without-email")
 
         if code == display_util.OK:
             if le_util.safe_email(email):

--- a/letsencrypt/display/ops.py
+++ b/letsencrypt/display/ops.py
@@ -124,7 +124,9 @@ def get_email():
     """
     while True:
         code, email = zope.component.getUtility(interfaces.IDisplay).input(
-            "Enter email address (used for urgent notices and lost key recovery)")
+            "Enter email address (mandatory since no "
+            "--allow-unsafe-registration was provided)"
+            "(used for urgent notices and lost key recovery)")
 
         if code == display_util.OK:
             if le_util.safe_email(email):

--- a/letsencrypt/display/ops.py
+++ b/letsencrypt/display/ops.py
@@ -117,9 +117,9 @@ def pick_configurator(
 def get_email(more=False, invalid=False):
     """Prompt for valid email address.
 
-    :param bool more: -- explain why the email is strongly advisable, but how to
+    :param bool more: explain why the email is strongly advisable, but how to
         skip it
-    "param bool invalid: -- true if the user just typed something, but it wasn't
+    :param bool invalid: true if the user just typed something, but it wasn't
         a valid-looking email
 
     :returns: Email or ``None`` if cancelled by user.

--- a/letsencrypt/display/util.py
+++ b/letsencrypt/display/util.py
@@ -114,7 +114,11 @@ class NcursesDisplay(object):
             `string` - input entered by the user
 
         """
-        return self.dialog.inputbox(message, width=self.width)
+        sections = message.split("\n")
+        # each section takes at least one line, plus extras if it's longer than self.width
+        wordlines = [1+(len(section)/self.width) for section in sections]
+        height = 6+ sum(wordlines) + len(sections)
+        return self.dialog.inputbox(message, width=self.width, height=height)
 
     def yesno(self, message, yes_label="Yes", no_label="No"):
         """Display a Yes/No dialog box.

--- a/letsencrypt/display/util.py
+++ b/letsencrypt/display/util.py
@@ -104,6 +104,7 @@ class NcursesDisplay(object):
 
             return code, int(tag) - 1
 
+
     def input(self, message):
         """Display an input box to the user.
 
@@ -116,9 +117,10 @@ class NcursesDisplay(object):
         """
         sections = message.split("\n")
         # each section takes at least one line, plus extras if it's longer than self.width
-        wordlines = [1+(len(section)/self.width) for section in sections]
-        height = 6+ sum(wordlines) + len(sections)
+        wordlines = [1 + (len(section)/self.width) for section in sections]
+        height = 6 + sum(wordlines) + len(sections)
         return self.dialog.inputbox(message, width=self.width, height=height)
+
 
     def yesno(self, message, yes_label="Yes", no_label="No"):
         """Display a Yes/No dialog box.

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -488,7 +488,8 @@ class DetermineAccountTest(unittest.TestCase):
     """Tests for letsencrypt.cli._determine_account."""
 
     def setUp(self):
-        self.args = mock.MagicMock(account=None, email=None)
+        self.args = mock.MagicMock(account=None, email=None,
+            register_unsafely_without_email=False)
         self.config = configuration.NamespaceConfig(self.args)
         self.accs = [mock.MagicMock(id='x'), mock.MagicMock(id='y')]
         self.account_storage = account.AccountMemoryStorage()

--- a/letsencrypt/tests/client_test.py
+++ b/letsencrypt/tests/client_test.py
@@ -24,7 +24,7 @@ class RegisterTest(unittest.TestCase):
     """Tests for letsencrypt.client.register."""
 
     def setUp(self):
-        self.config = mock.MagicMock(rsa_key_size=1024)
+        self.config = mock.MagicMock(rsa_key_size=1024, register_unsafely_without_email=False)
         self.account_storage = account.AccountMemoryStorage()
         self.tos_cb = mock.MagicMock()
 
@@ -61,6 +61,9 @@ class RegisterTest(unittest.TestCase):
             self._call()
             self.assertEqual(mock_get_email.call_count, 1)
 
+    def test_needs_email(self):
+        self.config.email = None
+        self.assertRaises(errors.Error, self._call)
 
 class ClientTest(unittest.TestCase):
     """Tests for letsencrypt.client.Client."""

--- a/letsencrypt/tests/client_test.py
+++ b/letsencrypt/tests/client_test.py
@@ -54,7 +54,7 @@ class RegisterTest(unittest.TestCase):
     @mock.patch("letsencrypt.client.display_ops.get_email")
     def test_email_retry(self, _rep, mock_get_email):
         from acme import messages
-        msg = "No MX record for domain ofijfoisjfs.com"
+        msg = "Validation of contact mailto:sousaphone@improbablylongggstring.tld failed"
         mx_err = messages.Error(detail=msg, typ="malformed", title="title")
         with mock.patch("letsencrypt.client.acme_client.Client") as mock_client:
             mock_client.register.side_effect = mx_err

--- a/letsencrypt/tests/client_test.py
+++ b/letsencrypt/tests/client_test.py
@@ -47,9 +47,19 @@ class RegisterTest(unittest.TestCase):
 
     def test_it(self):
         with mock.patch("letsencrypt.client.acme_client.Client"):
-            with mock.patch("letsencrypt.account."
-                            "report_new_account"):
+            with mock.patch("letsencrypt.account.report_new_account"):
                 self._call()
+
+    @mock.patch("letsencrypt.account.report_new_account")
+    @mock.patch("letsencrypt.client.display_ops.get_email")
+    def test_email_retry(self, _rep, mock_get_email):
+        from acme import messages
+        msg = "No MX record for domain ofijfoisjfs.com"
+        mx_err = messages.Error(detail=msg, typ="malformed", title="title")
+        with mock.patch("letsencrypt.client.acme_client.Client") as mock_client:
+            mock_client.register.side_effect = mx_err
+            self._call()
+            self.assertEqual(mock_get_email.call_count, 1)
 
 
 class ClientTest(unittest.TestCase):

--- a/letsencrypt/tests/client_test.py
+++ b/letsencrypt/tests/client_test.py
@@ -57,7 +57,7 @@ class RegisterTest(unittest.TestCase):
         msg = "Validation of contact mailto:sousaphone@improbablylongggstring.tld failed"
         mx_err = messages.Error(detail=msg, typ="malformed", title="title")
         with mock.patch("letsencrypt.client.acme_client.Client") as mock_client:
-            mock_client.register.side_effect = mx_err
+            mock_client().register.side_effect = [mx_err, mock.MagicMock()]
             self._call()
             self.assertEqual(mock_get_email.call_count, 1)
 

--- a/letsencrypt/tests/display/ops_test.py
+++ b/letsencrypt/tests/display/ops_test.py
@@ -168,9 +168,9 @@ class GetEmailTest(unittest.TestCase):
         zope.component.provideUtility(mock_display, interfaces.IDisplay)
 
     @classmethod
-    def _call(cls):
+    def _call(cls, **kwargs):
         from letsencrypt.display.ops import get_email
-        return get_email()
+        return get_email(**kwargs)
 
     def test_cancel_none(self):
         self.input.return_value = (display_util.CANCEL, "foo@bar.baz")
@@ -178,17 +178,37 @@ class GetEmailTest(unittest.TestCase):
 
     def test_ok_safe(self):
         self.input.return_value = (display_util.OK, "foo@bar.baz")
-        with mock.patch("letsencrypt.display.ops.le_util"
-                        ".safe_email") as mock_safe_email:
+        with mock.patch("letsencrypt.display.ops.le_util.safe_email") as mock_safe_email:
             mock_safe_email.return_value = True
             self.assertTrue(self._call() is "foo@bar.baz")
 
     def test_ok_not_safe(self):
         self.input.return_value = (display_util.OK, "foo@bar.baz")
-        with mock.patch("letsencrypt.display.ops.le_util"
-                        ".safe_email") as mock_safe_email:
+        with mock.patch("letsencrypt.display.ops.le_util.safe_email") as mock_safe_email:
             mock_safe_email.side_effect = [False, True]
             self.assertTrue(self._call() is "foo@bar.baz")
+
+    def test_more_and_invalid_flags(self):
+        more_txt = "--register-unsafely-without-email"
+        invalid_txt = "There seem to be problems"
+        base_txt = "Enter email"
+        self.input.return_value = (display_util.OK, "foo@bar.baz")
+        with mock.patch("letsencrypt.display.ops.le_util.safe_email") as mock_safe_email:
+            mock_safe_email.return_value = True
+            self._call()
+            msg = self.input.call_args[0][0]
+            self.assertTrue(more_txt not in msg)
+            self.assertTrue(invalid_txt not in msg)
+            self.assertTrue(base_txt in msg)
+            self._call(more=True)
+            msg = self.input.call_args[0][0]
+            self.assertTrue(more_txt in msg)
+            self.assertTrue(invalid_txt not in msg)
+            self._call(more=True, invalid=True)
+            msg = self.input.call_args[0][0]
+            self.assertTrue(more_txt in msg)
+            self.assertTrue(invalid_txt in msg)
+            self.assertTrue(base_txt in msg)
 
 
 class ChooseAccountTest(unittest.TestCase):

--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -23,7 +23,7 @@ letsencrypt_test () {
         --no-redirect \
         --agree-dev-preview \
         --agree-tos \
-        --email "" \
+        --register-unsafely-without-email \
         --renew-by-default \
         --debug \
         -vvvvvvv \


### PR DESCRIPTION
This finishes off @miquelruiz's branch  #1124.

* fixes a bug or two
* the note about `--register-unsafely-without-email` is only displayed if the user tries to give a blank email
* serverside email rejection produces a retry, not erroring out
* fix broken test cases
* add new ones

Closes: #414 