### PR TITLE
Add missing RPM requirement

### DIFF
--- a/bootstrap/_rpm_common.sh
+++ b/bootstrap/_rpm_common.sh
@@ -40,6 +40,7 @@ if ! $tool install -y \
        augeas-libs \
        openssl-devel \
        libffi-devel \
+       redhat-rpm-config \
        ca-certificates
 then
     echo "Could not install additional dependencies. Aborting bootstrap!"


### PR DESCRIPTION
`redhat-rpm-config` provides the required `/usr/lib/rpm/redhat/redhat-hardened-cc1`.

At least available in Fedora and CentOS. No idea about other RPM distros in this case.