### PR TITLE
Fix for TLDs greater than 6 characters in length

### DIFF
--- a/letsencrypt/configuration.py
+++ b/letsencrypt/configuration.py
@@ -155,8 +155,8 @@ def _check_config_domain_sanity(domains):
             "Punycode domains are not supported")
     # FQDN checks from
     # http://www.mkyong.com/regular-expressions/domain-name-regular-expression-example/
-    #  Characters used, domain parts < 63 chars, tld > 1 < 13 chars
+    #  Characters used, domain parts < 63 chars, tld > 1 char
     #  first and last char is not "-"
-    fqdn = re.compile("^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,12}$")
+    fqdn = re.compile("^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,}$")
     if any(True for d in domains if not fqdn.match(d)):
         raise errors.ConfigurationError("Requested domain is not a FQDN")

--- a/letsencrypt/configuration.py
+++ b/letsencrypt/configuration.py
@@ -157,6 +157,6 @@ def _check_config_domain_sanity(domains):
     # http://www.mkyong.com/regular-expressions/domain-name-regular-expression-example/
     #  Characters used, domain parts < 63 chars, tld > 1 < 7 chars
     #  first and last char is not "-"
-    fqdn = re.compile("^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,6}$")
+    fqdn = re.compile("^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,12}$")
     if any(True for d in domains if not fqdn.match(d)):
         raise errors.ConfigurationError("Requested domain is not a FQDN")

--- a/letsencrypt/configuration.py
+++ b/letsencrypt/configuration.py
@@ -155,8 +155,8 @@ def _check_config_domain_sanity(domains):
             "Punycode domains are not supported")
     # FQDN checks from
     # http://www.mkyong.com/regular-expressions/domain-name-regular-expression-example/
-    #  Characters used, domain parts < 63 chars, tld > 1 char
+    #  Characters used, domain parts < 63 chars, tld > 1 < 64 chars
     #  first and last char is not "-"
-    fqdn = re.compile("^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,}$")
+    fqdn = re.compile("^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,63}$")
     if any(True for d in domains if not fqdn.match(d)):
         raise errors.ConfigurationError("Requested domain is not a FQDN")


### PR DESCRIPTION
Following bug https://github.com/letsencrypt/letsencrypt/issues/1529 which does not recognise .digital and .graphics, which are both TLDs which I use, I have increased the TLD length to 12 to encapsulate most of the new TLDs.