### PR TITLE
Don't install all LE packages on Arch

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -103,7 +103,7 @@ Operating System Packages
 
 .. code-block:: shell
 
-   sudo pacman -S letsencrypt
+   sudo pacman -S letsencrypt letsencrypt-apache
 
 **Other Operating Systems**
 

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -103,8 +103,7 @@ Operating System Packages
 
 .. code-block:: shell
 
-   sudo pacman -S letsencrypt letsencrypt-nginx letsencrypt-apache \
-                  letshelp-letsencrypt
+   sudo pacman -S letsencrypt
 
 **Other Operating Systems**
 


### PR DESCRIPTION
@felixonmars, I believe we should only be instructing users to install the `letsencrypt` package on Arch, at least for the time being. My reasoning is as follows:

##### letsencrypt-nginx

This plugin is very experimental and should only be used extremely carefully if you're not a developer working on the plugin as it has the potential to break your Nginx configuration. References for this are [here](https://letsencrypt.readthedocs.org/en/latest/using.html#plugins), [here](https://github.com/letsencrypt/letsencrypt#current-features), and [here](https://github.com/letsencrypt/letsencrypt/issues?q=is%3Aopen+is%3Aissue+label%3Anginx).

##### letsencrypt-apache

Currently, the Apache plugin only works on Debian based systems. If you try to use the Apache plugin on Arch, `letsencrypt` will exit with the error message:
```
The apache plugin is not working; there may be problems with your existing configuration.
The error was: NoInstallationError()
```
The reason for this is the plugin is looking for Debian specific Apache binaries such as `a2enmod` and when it doesn't find them, assumes that Apache is not installed.

##### letshelp-letsencrypt

This script makes a copy of your Apache configuration with all sensitive information stripped out and puts them in a tarball. In the future, it will then submit this tarball to a server we set up where we can use the Apache configuration for debugging and testing. Currently, we're not instructing anyone to run this script so it certainly isn't a necessary package for most users.

Side note: On my laptop I see the following for the `letshelp-letsencrypt` package.
```
$ pacman -Ss letshelp-letsencrypt                                                                                                                                                        
community/letshelp-letsencrypt 0.0.0.dev20151114-1
    Apache plugin for Let’s Encrypt client
```
This description is not accurate.

Please do not merge this without a comment from @felixonmars, but I believe we shouldn't be instructing our users to install unnecessary/unstable packages.