### PR TITLE
Misconfigured selection was misconfigured (fixes #990)

### DIFF
--- a/letsencrypt/display/ops.py
+++ b/letsencrypt/display/ops.py
@@ -34,14 +34,15 @@ def choose_plugin(prepared, question):
             question, opts, help_label="More Info")
 
         if code == display_util.OK:
+            plugin_ep = prepared[index]
             if plugin_ep.misconfigured:
                 util(interfaces.IDisplay).notification(
                     "The selected plugin encountered an error while parsing "
                     "your server configuration and cannot be used. The error "
-                    "was: {0}".format(prepared[index].prepare()),
+                    "was: {0}".format(plugin_ep.prepare()),
                     height=display_util.HEIGHT)
             else:
-                return prepared[index]
+                return plugin_ep
         elif code == display_util.HELP:
             if prepared[index].misconfigured:
                 msg = "Reported Error: %s" % prepared[index].prepare()

--- a/letsencrypt/display/ops.py
+++ b/letsencrypt/display/ops.py
@@ -40,7 +40,7 @@ def choose_plugin(prepared, question):
                     "The selected plugin encountered an error while parsing "
                     "your server configuration and cannot be used. The error "
                     "was:\n\n{0}".format(plugin_ep.prepare()),
-                    height=display_util.HEIGHT)
+                    height=display_util.HEIGHT, pause=False)
             else:
                 return plugin_ep
         elif code == display_util.HELP:

--- a/letsencrypt/display/ops.py
+++ b/letsencrypt/display/ops.py
@@ -39,7 +39,7 @@ def choose_plugin(prepared, question):
                 util(interfaces.IDisplay).notification(
                     "The selected plugin encountered an error while parsing "
                     "your server configuration and cannot be used. The error "
-                    "was: {0}".format(plugin_ep.prepare()),
+                    "was:\n\n{0}".format(plugin_ep.prepare()),
                     height=display_util.HEIGHT)
             else:
                 return plugin_ep

--- a/letsencrypt/display/ops.py
+++ b/letsencrypt/display/ops.py
@@ -34,7 +34,14 @@ def choose_plugin(prepared, question):
             question, opts, help_label="More Info")
 
         if code == display_util.OK:
-            return prepared[index]
+            if plugin_ep.misconfigured:
+                util(interfaces.IDisplay).notification(
+                    "The selected plugin encountered an error while parsing "
+                    "your server configuration and cannot be used. The error "
+                    "was: {0}".format(prepared[index].prepare())
+                    height=display_util.HEIGHT)
+            else:
+                return prepared[index]
         elif code == display_util.HELP:
             if prepared[index].misconfigured:
                 msg = "Reported Error: %s" % prepared[index].prepare()

--- a/letsencrypt/display/ops.py
+++ b/letsencrypt/display/ops.py
@@ -38,7 +38,7 @@ def choose_plugin(prepared, question):
                 util(interfaces.IDisplay).notification(
                     "The selected plugin encountered an error while parsing "
                     "your server configuration and cannot be used. The error "
-                    "was: {0}".format(prepared[index].prepare())
+                    "was: {0}".format(prepared[index].prepare()),
                     height=display_util.HEIGHT)
             else:
                 return prepared[index]

--- a/letsencrypt/tests/display/ops_test.py
+++ b/letsencrypt/tests/display/ops_test.py
@@ -41,9 +41,11 @@ class ChoosePluginTest(unittest.TestCase):
         return choose_plugin(self.plugins, "Question?")
 
     @mock.patch("letsencrypt.display.ops.util")
-    def test_successful_choice(self, mock_util):
-        mock_util().menu.return_value = (display_util.OK, 0)
-        self.assertEqual(self.mock_apache, self._call())
+    def test_selection(self, mock_util):
+        mock_util().menu.side_effect = [(display_util.OK, 0),
+                                        (display_util.OK, 1)]
+        self.assertEqual(self.mock_stand, self._call())
+        self.assertEqual(mock_util().notification.call_count, 1)
 
     @mock.patch("letsencrypt.display.ops.util")
     def test_more_info(self, mock_util):


### PR DESCRIPTION
New behavior is:
```
# letsencrypt --agree-dev-preview --agree-tos --email "" -t certonly
2015-11-19 22:36:17,393:ERROR:letsencrypt.le_util:Error while running apache2ctl configtest.
Action 'configtest' failed.
The Apache error log may have more information.

AH00526: Syntax error on line 12 of /etc/apache2/sites-enabled/pickupapp.me.conf:
Invalid command 'DcumentRoot', perhaps misspelled or defined by a module not included in the server configuration


How would you like to authenticate with the Let's Encrypt CA?
-------------------------------------------------------------------------------
1: Apache Web Server - Alpha (apache) [Misconfigured]
2: Automatically use a temporary webserver (standalone)
-------------------------------------------------------------------------------
Select the appropriate number [1-2] then [enter] (press 'c' to cancel): 1

-------------------------------------------------------------------------------
The selected plugin encountered an error while parsing your server configuration
and cannot be used. The error was:

Error while running apache2ctl configtest.
Action 'configtest' failed.
The Apache error log may have more information.

AH00526: Syntax error on line 12 of /etc/apache2/sites-
enabled/pickupapp.me.conf:
Invalid command 'DcumentRoot', perhaps misspelled or defined by a module not
included in the server configuration
-------------------------------------------------------------------------------

How would you like to authenticate with the Let's Encrypt CA?
-------------------------------------------------------------------------------
1: Apache Web Server - Alpha (apache) [Misconfigured]
2: Automatically use a temporary webserver (standalone)
-------------------------------------------------------------------------------
Select the appropriate number [1-2] then [enter] (press 'c' to cancel): 2
Please enter in your domain name(s) (comma and/or space separated)  (Enter 'c'
to cancel):
```