### PR TITLE
Fix letsencrypt-compatibility-test

### DIFF
--- a/letsencrypt-compatibility-test/letsencrypt_compatibility_test/util.py
+++ b/letsencrypt-compatibility-test/letsencrypt_compatibility_test/util.py
@@ -34,6 +34,8 @@ def create_le_config(parent_dir):
     os.mkdir(config["work_dir"])
     os.mkdir(config["logs_dir"])
 
+    config["domains"] = None
+
     return argparse.Namespace(**config)  # pylint: disable=star-args
 
 

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -898,8 +898,9 @@ def prepare_and_parse_args(plugins, args):
         "testing", "--tls-sni-01-port", type=int,
         default=flag_default("tls_sni_01_port"),
         help=config_help("tls_sni_01_port"))
-    helpful.add("testing", "--http-01-port", dest="http01_port", type=int,
-                help=config_help("http01_port"))
+    helpful.add(
+        "testing", "--http-01-port", type=int, dest="http01_port",
+        default=flag_default("http01_port"), help=config_help("http01_port"))
 
     helpful.add_group(
         "security", description="Security parameters & server settings")

--- a/letsencrypt/configuration.py
+++ b/letsencrypt/configuration.py
@@ -5,8 +5,6 @@ import re
 
 import zope.interface
 
-from acme import challenges
-
 from letsencrypt import constants
 from letsencrypt import errors
 from letsencrypt import interfaces
@@ -79,13 +77,6 @@ class NamespaceConfig(object):
     def temp_checkpoint_dir(self):  # pylint: disable=missing-docstring
         return os.path.join(
             self.namespace.work_dir, constants.TEMP_CHECKPOINT_DIR)
-
-    @property
-    def http01_port(self):  # pylint: disable=missing-docstring
-        if self.namespace.http01_port is not None:
-            return self.namespace.http01_port
-        else:
-            return challenges.HTTP01Response.PORT
 
 
 class RenewerConfiguration(object):

--- a/letsencrypt/constants.py
+++ b/letsencrypt/constants.py
@@ -23,6 +23,7 @@ CLI_DEFAULTS = dict(
     work_dir="/var/lib/letsencrypt",
     logs_dir="/var/log/letsencrypt",
     no_verify_ssl=False,
+    http01_port=challenges.HTTP01Response.PORT,
     tls_sni_01_port=challenges.TLSSNI01Response.PORT,
 
     auth_cert_path="./cert.pem",

--- a/letsencrypt/tests/configuration_test.py
+++ b/letsencrypt/tests/configuration_test.py
@@ -54,11 +54,6 @@ class NamespaceConfigTest(unittest.TestCase):
         self.assertEqual(self.config.key_dir, '/tmp/config/keys')
         self.assertEqual(self.config.temp_checkpoint_dir, '/tmp/foo/t')
 
-    def test_http01_port(self):
-        self.assertEqual(4321, self.config.http01_port)
-        self.namespace.http01_port = None
-        self.assertEqual(80, self.config.http01_port)
-
     def test_absolute_paths(self):
         from letsencrypt.configuration import NamespaceConfig
 


### PR DESCRIPTION
Fixes issues between `letsencrypt-compatibility-test` and `configuration.py`. Made fixes now to test #1582.