### PR TITLE
Support multiple webroot paths

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -1,5 +1,7 @@
 """Let's Encrypt CLI."""
 # TODO: Sanity check all input.  Be sure to avoid shell code etc...
+# pylint: disable=too-many-lines
+# (TODO: split this file into main.py and cli.py)
 import argparse
 import atexit
 import functools
@@ -384,7 +386,6 @@ def diagnose_configurator_problem(cfg_type, requested, plugins):
 def choose_configurator_plugins(args, config, plugins, verb):  # pylint: disable=too-many-branches
     """
     Figure out which configurator we're going to use
-
     :raises error.PluginSelectionError if there was a problem
     """
 
@@ -802,7 +803,6 @@ class HelpfulArgumentParser(object):
             return dict([(t, t == chosen_topic) for t in self.help_topics])
 
 
-
 def prepare_and_parse_args(plugins, args):
     """Returns parsed command line arguments.
 
@@ -946,8 +946,7 @@ def _create_subparsers(helpful):
         help="Set a custom user agent string for the client. User agent strings allow "
              "the CA to collect high level statistics about success rates by OS and "
              "plugin. If you wish to hide your server OS version from the Let's "
-             'Encrypt server, set this to "".'
-    )
+             'Encrypt server, set this to "".')
     helpful.add("certonly",
                 "--csr", type=read_file,
                 help="Path to a Certificate Signing Request (CSR) in DER"

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -1062,8 +1062,7 @@ class DomainFlagProcessor(argparse.Action): # pylint: disable=missing-docstring
         Process a new -d flag, helping the webroot plugin construct a map of
         {domain : webrootpath} if -w / --webroot-path is in use
         """
-        if not config.domains:
-            config.domains = []
+        if not config.domains: config.domains = []
         new_domains = [d.strip() for d in domain_arg.split(",")
                                   if d not in config.domains]
         config.domains.extend(new_domains)

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -1043,6 +1043,10 @@ def _plugins_parsing(helpful, plugins):
 
 
 class WebrootPathProcessor(argparse.Action): # pylint: disable=missing-docstring
+    def __init__(self, *args, **kwargs):
+        self.domain_before_webroot = False
+        argparse.Action.__init__(self, *args, **kwargs)
+
     def __call__(self, parser, config, webroot, option_string=None):
         """
         Keep a record of --webroot-path / -w flags during processing, so that
@@ -1055,8 +1059,12 @@ class WebrootPathProcessor(argparse.Action): # pylint: disable=missing-docstring
             # config.webroot_map are filled in by cli.DomainFlagProcessor
             if config.domains:
                 config.webroot_map = dict([(d, webroot) for d in config.domains])
+                self.domain_before_webroot = True
             else:
                 config.webroot_map = {}
+        elif self.domain_before_webroot:
+            raise errors.Error("If you specify multiple webroot paths, one of "
+                               "them must precede all domain flags")
         config.webroot_path.append(webroot)
 
 

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -1038,7 +1038,7 @@ def _plugins_parsing(helpful, plugins):
     helpful.add_plugin_args(plugins)
 
 
-class WebrootPathProcessor(argparse.Action):
+class WebrootPathProcessor(argparse.Action): # pylint: disable=missing-docstring
     def __call__(self, parser, config, webroot, option_string=None):
         """
         Keep a record of --webroot-path / -w flags during processing, so that
@@ -1056,13 +1056,14 @@ class WebrootPathProcessor(argparse.Action):
         config.webroot_path.append(webroot)
 
 
-class DomainFlagProcessor(argparse.Action):
+class DomainFlagProcessor(argparse.Action): # pylint: disable=missing-docstring
     def __call__(self, parser, config, domain_arg, option_string=None):
         """
         Process a new -d flag, helping the webroot plugin construct a map of
         {domain : webrootpath} if -w / --webroot-path is in use
         """
-        if not config.domains: config.domains = []
+        if not config.domains:
+            config.domains = []
         new_domains = [d.strip() for d in domain_arg.split(",")
                                   if d not in config.domains]
         config.domains.extend(new_domains)

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -1036,7 +1036,7 @@ def _plugins_parsing(helpful, plugins):
     # "webroot" topic
     helpful.add("webroot", "-w", "--webroot-path", action=WebrootPathProcessor,
                 help="public_html / webroot path")
-    parse_dict = lambda s : dict(json.loads(s))
+    parse_dict = lambda s: dict(json.loads(s))
     helpful.add("webroot", "--webroot-map", default={}, type=parse_dict,
                 help="Mapping from domains to webroot paths")
 
@@ -1068,7 +1068,7 @@ class DomainFlagProcessor(argparse.Action): # pylint: disable=missing-docstring
         if not config.domains:
             config.domains = []
 
-        for d in map(string.strip, domain_arg.split(",")):
+        for d in map(string.strip, domain_arg.split(",")): # pylint: disable=bad-builtin
             if d not in config.domains:
                 config.domains.append(d)
                 # Each domain has a webroot_path of the most recent -w flag

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -839,7 +839,7 @@ def prepare_and_parse_args(plugins, args):
     # --domains is useful, because it can be stored in config
     #for subparser in parser_run, parser_auth, parser_install:
     #    subparser.add_argument("domains", nargs="*", metavar="domain")
-    helpful.add(None, "-d", "--domains", dest="domains",
+    helpful.add(None, "-d", "--domains", "--domain", dest="domains",
                 metavar="DOMAIN", action=DomainFlagProcessor,
                 help="Domain names to apply. For multiple domains you can use "
                 "multiple -d flags or enter a comma separated list of domains "

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -1037,8 +1037,9 @@ def _plugins_parsing(helpful, plugins):
     helpful.add("webroot", "-w", "--webroot-path", action=WebrootPathProcessor,
                 help="public_html / webroot path")
     parse_dict = lambda s: dict(json.loads(s))
+    # --webroot-map still has some awkward properties, so it is undocumented
     helpful.add("webroot", "--webroot-map", default={}, type=parse_dict,
-                help="Mapping from domains to webroot paths")
+                help=argparse.SUPPRESS)
 
 
 class WebrootPathProcessor(argparse.Action): # pylint: disable=missing-docstring

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -1035,7 +1035,10 @@ def _plugins_parsing(helpful, plugins):
     # legibiility. helpful.add_plugin_ags must be called first to add the
     # "webroot" topic
     helpful.add("webroot", "-w", "--webroot-path", action=WebrootPathProcessor,
-                help="public_html / webroot path")
+                help="public_html / webroot path. This can be specified multiple times to "
+                     "handle different domains; each domain will have the webroot path that"
+                     " precededed it.  For instance: `-w /var/www/example -d example.com -d "
+                     "www.example.com -w /var/www/thing -d thing.net -d m.thing.net`")
     parse_dict = lambda s: dict(json.loads(s))
     # --webroot-map still has some awkward properties, so it is undocumented
     helpful.add("webroot", "--webroot-map", default={}, type=parse_dict,

--- a/letsencrypt/plugins/webroot.py
+++ b/letsencrypt/plugins/webroot.py
@@ -38,6 +38,7 @@ Use the following snippet in your ``server{...}`` stanza::
 and reload your daemon.
 
 """
+import argparse
 import errno
 import logging
 import os
@@ -53,6 +54,22 @@ from letsencrypt.plugins import common
 
 logger = logging.getLogger(__name__)
 
+class WebrootPathProcessor(argparse.Action):
+    def __call__(self, parser, config, webroot, option_string=None):
+        """
+        Keep a record of --webroot-path / -w flags during processing, so that
+        we know which apply to which -d flags
+        """
+        if not config.webroot_path:
+            config.webroot_path = []
+            # if any --domain flags preceded the first --webroot-path flag,
+            # apply that webroot path to those; subsequent entries in
+            # config.webroot_map are filled in by cli.DomainFlagProcessor
+            if config.domains:
+                config.webroot_map = dict([(d, webroot) for d in config.domains])
+            else:
+                config.webroot_map = {}
+        config.webroot_path.append(webroot)
 
 class Authenticator(common.Plugin):
     """Webroot Authenticator."""
@@ -72,7 +89,7 @@ to serve all files under specified web root ({0})."""
 
     @classmethod
     def add_parser_arguments(cls, add):
-        add("path", help="public_html / webroot path")
+        add("path", "-w", help="public_html / webroot path", action=WebrootPathAccumulator)
 
     def get_chall_pref(self, domain):  # pragma: no cover
         # pylint: disable=missing-docstring,no-self-use,unused-argument

--- a/letsencrypt/plugins/webroot.py
+++ b/letsencrypt/plugins/webroot.py
@@ -54,22 +54,7 @@ from letsencrypt.plugins import common
 
 logger = logging.getLogger(__name__)
 
-class WebrootPathProcessor(argparse.Action):
-    def __call__(self, parser, config, webroot, option_string=None):
-        """
-        Keep a record of --webroot-path / -w flags during processing, so that
-        we know which apply to which -d flags
-        """
-        if not config.webroot_path:
-            config.webroot_path = []
-            # if any --domain flags preceded the first --webroot-path flag,
-            # apply that webroot path to those; subsequent entries in
-            # config.webroot_map are filled in by cli.DomainFlagProcessor
-            if config.domains:
-                config.webroot_map = dict([(d, webroot) for d in config.domains])
-            else:
-                config.webroot_map = {}
-        config.webroot_path.append(webroot)
+
 
 class Authenticator(common.Plugin):
     """Webroot Authenticator."""
@@ -89,7 +74,7 @@ to serve all files under specified web root ({0})."""
 
     @classmethod
     def add_parser_arguments(cls, add):
-        add("path", "-w", help="public_html / webroot path", action=WebrootPathAccumulator)
+        pass
 
     def get_chall_pref(self, domain):  # pragma: no cover
         # pylint: disable=missing-docstring,no-self-use,unused-argument

--- a/letsencrypt/plugins/webroot.py
+++ b/letsencrypt/plugins/webroot.py
@@ -38,7 +38,6 @@ Use the following snippet in your ``server{...}`` stanza::
 and reload your daemon.
 
 """
-import argparse
 import errno
 import logging
 import os
@@ -92,8 +91,7 @@ to serve all files under specified web root ({0})."""
                 self.option_name("path")))
         for name, path in path_map.items():
             if not os.path.isdir(path):
-                raise errors.PluginError(
-                    path + " does not exist or is not a directory")
+                raise errors.PluginError(path + " does not exist or is not a directory")
             self.full_roots[name] = os.path.join(path, challenges.HTTP01.URI_ROOT_PATH)
 
             logger.debug("Creating root challenges validation dir at %s",
@@ -107,7 +105,7 @@ to serve all files under specified web root ({0})."""
                         "challenge responses: {1}", name, exception)
 
     def perform(self, achalls):  # pylint: disable=missing-docstring
-        assert self.full_root, "Webroot plugin appears to be missing webroot map"
+        assert self.full_roots, "Webroot plugin appears to be missing webroot map"
         return [self._perform_single(achall) for achall in achalls]
 
     def _path_for_achall(self, achall):

--- a/letsencrypt/plugins/webroot.py
+++ b/letsencrypt/plugins/webroot.py
@@ -15,7 +15,6 @@ from letsencrypt.plugins import common
 logger = logging.getLogger(__name__)
 
 
-
 class Authenticator(common.Plugin):
     """Webroot Authenticator."""
     zope.interface.implements(interfaces.IAuthenticator)
@@ -72,9 +71,10 @@ to serve all files under specified web root ({0})."""
         return [self._perform_single(achall) for achall in achalls]
 
     def _path_for_achall(self, achall):
-        path = self.full_roots[achall.domain]
-        if not path:
-            raise errors.PluginError("Cannot find path {0} for domain: {1}"
+        try:
+            path = self.full_roots[achall.domain]
+        except IndexError:
+            raise errors.PluginError("Cannot find webroot path for domain: {1}"
                         .format(path, achall.domain))
         return os.path.join(path, achall.chall.encode("token"))
 

--- a/letsencrypt/plugins/webroot.py
+++ b/letsencrypt/plugins/webroot.py
@@ -73,6 +73,8 @@ to serve all files under specified web root ({0})."""
 
     @classmethod
     def add_parser_arguments(cls, add):
+        # --webroot-path and --webroot-map are added in cli.py because they
+        # are parsed in conjunction with --domains
         pass
 
     def get_chall_pref(self, domain):  # pragma: no cover

--- a/letsencrypt/plugins/webroot.py
+++ b/letsencrypt/plugins/webroot.py
@@ -74,7 +74,10 @@ to serve all files under specified web root ({0})."""
         try:
             path = self.full_roots[achall.domain]
         except IndexError:
-            raise errors.PluginError("Cannot find webroot path for domain: {1}"
+            raise errors.PluginError("Missing --webroot-path for domain: {1}"
+                        .format(achall.domain))
+        if not os.path.exists(path):
+            raise errors.PluginError("Mysteriously missing path {0} for domain: {1}"
                         .format(path, achall.domain))
         return os.path.join(path, achall.chall.encode("token"))
 

--- a/letsencrypt/plugins/webroot_test.py
+++ b/letsencrypt/plugins/webroot_test.py
@@ -23,7 +23,7 @@ class AuthenticatorTest(unittest.TestCase):
     """Tests for letsencrypt.plugins.webroot.Authenticator."""
 
     achall = achallenges.KeyAuthorizationAnnotatedChallenge(
-        challb=acme_util.HTTP01_P, domain=None, account_key=KEY)
+        challb=acme_util.HTTP01_P, domain="thing.com", account_key=KEY)
 
     def setUp(self):
         from letsencrypt.plugins.webroot import Authenticator
@@ -31,7 +31,8 @@ class AuthenticatorTest(unittest.TestCase):
         self.validation_path = os.path.join(
             self.path, ".well-known", "acme-challenge",
             "ZXZhR3hmQURzNnBTUmIyTEF2OUlaZjE3RHQzanV4R0orUEN0OTJ3citvQQ")
-        self.config = mock.MagicMock(webroot_path=self.path)
+        self.config = mock.MagicMock(webroot_path=self.path,
+                                     webroot_map={"thing.com":self.path})
         self.auth = Authenticator(self.config, "webroot")
         self.auth.prepare()
 
@@ -46,14 +47,16 @@ class AuthenticatorTest(unittest.TestCase):
     def test_add_parser_arguments(self):
         add = mock.MagicMock()
         self.auth.add_parser_arguments(add)
-        self.assertEqual(1, add.call_count)
+        self.assertEqual(0, add.call_count) # became 0 when we moved the args to cli.py!
 
     def test_prepare_bad_root(self):
         self.config.webroot_path = os.path.join(self.path, "null")
+        self.config.webroot_map["thing.com"] = self.config.webroot_path
         self.assertRaises(errors.PluginError, self.auth.prepare)
 
     def test_prepare_missing_root(self):
         self.config.webroot_path = None
+        self.config.webroot_map = {}
         self.assertRaises(errors.PluginError, self.auth.prepare)
 
     def test_prepare_full_root_exists(self):

--- a/letsencrypt/plugins/webroot_test.py
+++ b/letsencrypt/plugins/webroot_test.py
@@ -32,7 +32,7 @@ class AuthenticatorTest(unittest.TestCase):
             self.path, ".well-known", "acme-challenge",
             "ZXZhR3hmQURzNnBTUmIyTEF2OUlaZjE3RHQzanV4R0orUEN0OTJ3citvQQ")
         self.config = mock.MagicMock(webroot_path=self.path,
-                                     webroot_map={"thing.com":self.path})
+                                     webroot_map={"thing.com": self.path})
         self.auth = Authenticator(self.config, "webroot")
         self.auth.prepare()
 

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -343,7 +343,7 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
 
     def test_parse_webroot(self):
         plugins = disco.PluginsRegistry.find_all()
-        webroot_args = ['--webroot',  '-w', '/var/www/example',
+        webroot_args = ['--webroot', '-w', '/var/www/example',
             '-d', 'example.com,www.example.com', '-w', '/var/www/superfluous',
             '-d', 'superfluo.us', '-d', 'www.superfluo.us']
         namespace = cli.prepare_and_parse_args(plugins, webroot_args)

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -339,6 +339,18 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
         namespace = cli.prepare_and_parse_args(plugins, long_args)
         self.assertEqual(namespace.domains, ['example.com', 'another.net'])
 
+        webroot_args = ['--webroot', '-d', 'stray.example.com', '-w',
+            '/var/www/example', '-d', 'example.com,www.example.com', '-w',
+            '/var/www/superfluous', '-d', 'superfluo.us', '-d', 'www.superfluo.us']
+        namespace = cli.prepare_and_parse_args(plugins, webroot_args)
+        open("/tmp/frogs", "w").write("%r" % namespace)
+        self.assertEqual(namespace.webroot_map, {
+            'example.com' : '/var/www/example',
+            'stray.example.com' : '/var/www/example',
+            'www.example.com' : '/var/www/example',
+            'www.superfluo.us' : '/var/www/superfluous',
+            'superfluo.us' : '/var/www/superfluous'})
+
     @mock.patch('letsencrypt.crypto_util.notAfter')
     @mock.patch('letsencrypt.cli.zope.component.getUtility')
     def test_certonly_new_request_success(self, mock_get_utility, mock_notAfter):

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -341,17 +341,22 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
         namespace = cli.prepare_and_parse_args(plugins, long_args)
         self.assertEqual(namespace.domains, ['example.com', 'another.net'])
 
+    def test_parse_webroot(self):
+        plugins = disco.PluginsRegistry.find_all()
         webroot_args = ['--webroot', '-d', 'stray.example.com', '-w',
             '/var/www/example', '-d', 'example.com,www.example.com', '-w',
             '/var/www/superfluous', '-d', 'superfluo.us', '-d', 'www.superfluo.us']
         namespace = cli.prepare_and_parse_args(plugins, webroot_args)
-        open("/tmp/frogs", "w").write("%r" % namespace)
         self.assertEqual(namespace.webroot_map, {
             'example.com' : '/var/www/example',
             'stray.example.com' : '/var/www/example',
             'www.example.com' : '/var/www/example',
             'www.superfluo.us' : '/var/www/superfluous',
             'superfluo.us' : '/var/www/superfluous'})
+
+        webroot_map_args = ['--webroot-map', '{"eg.com" : "/tmp"}']
+        namespace = cli.prepare_and_parse_args(plugins, webroot_map_args)
+        self.assertEqual(namespace.webroot_map, {u"eg.com" : u"/tmp"})
 
     @mock.patch('letsencrypt.crypto_util.notAfter')
     @mock.patch('letsencrypt.cli.zope.component.getUtility')

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -236,7 +236,8 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
             self._call(['plugins'] + list(args))
 
     @mock.patch('letsencrypt.cli.plugins_disco')
-    def test_plugins_no_args(self, mock_disco):
+    @mock.patch('letsencrypt.cli.HelpfulArgumentParser.determine_help_topics')
+    def test_plugins_no_args(self, _det, mock_disco):
         ifaces = []
         plugins = mock_disco.PluginsRegistry.find_all()
 
@@ -247,7 +248,8 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
         stdout.write.called_once_with(str(filtered))
 
     @mock.patch('letsencrypt.cli.plugins_disco')
-    def test_plugins_init(self, mock_disco):
+    @mock.patch('letsencrypt.cli.HelpfulArgumentParser.determine_help_topics')
+    def test_plugins_init(self, _det, mock_disco):
         ifaces = []
         plugins = mock_disco.PluginsRegistry.find_all()
 
@@ -261,10 +263,10 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
         stdout.write.called_once_with(str(verified))
 
     @mock.patch('letsencrypt.cli.plugins_disco')
-    def test_plugins_prepare(self, mock_disco):
+    @mock.patch('letsencrypt.cli.HelpfulArgumentParser.determine_help_topics')
+    def test_plugins_prepare(self, _det, mock_disco):
         ifaces = []
         plugins = mock_disco.PluginsRegistry.find_all()
-
         _, stdout, _, _ = self._call(['plugins', '--init', '--prepare'])
         plugins.visible.assert_called_once_with()
         plugins.visible().ifaces.assert_called_once_with(ifaces)

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -354,8 +354,7 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
             'superfluo.us': '/var/www/superfluous'})
 
         webroot_args = ['-d', 'stray.example.com'] + webroot_args
-        with self.assertRaises(errors.Error):
-            cli.prepare_and_parse_args(plugins, webroot_args)
+        self.assertRaises(errors.Error, cli.prepare_and_parse_args, plugins, webroot_args)
 
         webroot_map_args = ['--webroot-map', '{"eg.com" : "/tmp"}']
         namespace = cli.prepare_and_parse_args(plugins, webroot_map_args)

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -348,15 +348,15 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
             '/var/www/superfluous', '-d', 'superfluo.us', '-d', 'www.superfluo.us']
         namespace = cli.prepare_and_parse_args(plugins, webroot_args)
         self.assertEqual(namespace.webroot_map, {
-            'example.com' : '/var/www/example',
-            'stray.example.com' : '/var/www/example',
-            'www.example.com' : '/var/www/example',
-            'www.superfluo.us' : '/var/www/superfluous',
-            'superfluo.us' : '/var/www/superfluous'})
+            'example.com': '/var/www/example',
+            'stray.example.com': '/var/www/example',
+            'www.example.com': '/var/www/example',
+            'www.superfluo.us': '/var/www/superfluous',
+            'superfluo.us': '/var/www/superfluous'})
 
         webroot_map_args = ['--webroot-map', '{"eg.com" : "/tmp"}']
         namespace = cli.prepare_and_parse_args(plugins, webroot_map_args)
-        self.assertEqual(namespace.webroot_map, {u"eg.com" : u"/tmp"})
+        self.assertEqual(namespace.webroot_map, {u"eg.com": u"/tmp"})
 
     @mock.patch('letsencrypt.crypto_util.notAfter')
     @mock.patch('letsencrypt.cli.zope.component.getUtility')

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -343,16 +343,19 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
 
     def test_parse_webroot(self):
         plugins = disco.PluginsRegistry.find_all()
-        webroot_args = ['--webroot', '-d', 'stray.example.com', '-w',
-            '/var/www/example', '-d', 'example.com,www.example.com', '-w',
-            '/var/www/superfluous', '-d', 'superfluo.us', '-d', 'www.superfluo.us']
+        webroot_args = ['--webroot',  '-w', '/var/www/example',
+            '-d', 'example.com,www.example.com', '-w', '/var/www/superfluous',
+            '-d', 'superfluo.us', '-d', 'www.superfluo.us']
         namespace = cli.prepare_and_parse_args(plugins, webroot_args)
         self.assertEqual(namespace.webroot_map, {
             'example.com': '/var/www/example',
-            'stray.example.com': '/var/www/example',
             'www.example.com': '/var/www/example',
             'www.superfluo.us': '/var/www/superfluous',
             'superfluo.us': '/var/www/superfluous'})
+
+        webroot_args = ['-d', 'stray.example.com'] + webroot_args
+        with self.assertRaises(errors.Error):
+            cli.prepare_and_parse_args(plugins, webroot_args)
 
         webroot_map_args = ['--webroot-map', '{"eg.com" : "/tmp"}']
         namespace = cli.prepare_and_parse_args(plugins, webroot_map_args)


### PR DESCRIPTION
Closes: #1016.  Themost minimal way to use it is to interleave --webroot-path / -w flags with domain flags:

`letsencrypt --webroot -w /var/www/thing -d thing.com -d www.thing.com -w /var/www/stuff -d stuff.io -d www.stuff.io`

But the user can also pass in a map of domains to webroots:

`letsencrypt --webroot --webroot-map '{ "thing.com" : "/var/www/thing", "www.thing.com" : "/var/www/thing", "stuff.io" : "/var/www/stuff", "www.stuff.io" : "/var/www/stuff" }' -d thing.com -d stuff.io`
