### PR TITLE
Update configuration.py domain regex pattern error

### DIFF
--- a/letsencrypt/configuration.py
+++ b/letsencrypt/configuration.py
@@ -148,6 +148,6 @@ def _check_config_domain_sanity(domains):
     # http://www.mkyong.com/regular-expressions/domain-name-regular-expression-example/
     #  Characters used, domain parts < 63 chars, tld > 1 < 64 chars
     #  first and last char is not "-"
-    fqdn = re.compile("^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,63}$")
+    fqdn = re.compile("^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\.)+[A-Za-z]{2,63}$")
     if any(True for d in domains if not fqdn.match(d)):
         raise errors.ConfigurationError("Requested domain is not a FQDN")


### PR DESCRIPTION
The domain regex pattern was failing to recognize a valid domain and returning error "Requested domain is not a FQDN" when attempting to renew via cli commands. I removed extra backslash in front of the period to fix the pattern.