### PR TITLE
Remove Content-Type checks from http-01

### DIFF
--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -269,13 +269,6 @@ class HTTP01Response(KeyAuthorizationChallengeResponse):
         logger.debug("Received %s: %s. Headers: %s", http_response,
                      http_response.text, http_response.headers)
 
-        found_ct = http_response.headers.get(
-            "Content-Type", chall.CONTENT_TYPE)
-        if found_ct != chall.CONTENT_TYPE:
-            logger.debug("Wrong Content-Type: found %r, expected %r",
-                         found_ct, chall.CONTENT_TYPE)
-            return False
-
         challenge_response = http_response.text.rstrip(self.WHITESPACE_CUTSET)
         if self.key_authorization != challenge_response:
             logger.debug("Key authorization from response (%r) doesn't match "
@@ -291,9 +284,6 @@ class HTTP01(KeyAuthorizationChallenge):
     """ACME http-01 challenge."""
     response_cls = HTTP01Response
     typ = response_cls.typ
-
-    CONTENT_TYPE = "text/plain"
-    """Only valid value for Content-Type if the header is included."""
 
     URI_ROOT_PATH = ".well-known/acme-challenge"
     """URI root path for the server provisioned resource."""

--- a/acme/acme/challenges_test.py
+++ b/acme/acme/challenges_test.py
@@ -92,7 +92,6 @@ class HTTP01ResponseTest(unittest.TestCase):
         from acme.challenges import HTTP01
         self.chall = HTTP01(token=(b'x' * 16))
         self.response = self.chall.response(KEY)
-        self.good_headers = {'Content-Type': HTTP01.CONTENT_TYPE}
 
     def test_to_partial_json(self):
         self.assertEqual(self.jmsg, self.msg.to_partial_json())
@@ -113,16 +112,14 @@ class HTTP01ResponseTest(unittest.TestCase):
     @mock.patch("acme.challenges.requests.get")
     def test_simple_verify_good_validation(self, mock_get):
         validation = self.chall.validation(KEY)
-        mock_get.return_value = mock.MagicMock(
-            text=validation, headers=self.good_headers)
+        mock_get.return_value = mock.MagicMock(text=validation)
         self.assertTrue(self.response.simple_verify(
             self.chall, "local", KEY.public_key()))
         mock_get.assert_called_once_with(self.chall.uri("local"))
 
     @mock.patch("acme.challenges.requests.get")
     def test_simple_verify_bad_validation(self, mock_get):
-        mock_get.return_value = mock.MagicMock(
-            text="!", headers=self.good_headers)
+        mock_get.return_value = mock.MagicMock(text="!")
         self.assertFalse(self.response.simple_verify(
             self.chall, "local", KEY.public_key()))
 
@@ -131,16 +128,10 @@ class HTTP01ResponseTest(unittest.TestCase):
         from acme.challenges import HTTP01Response
         mock_get.return_value = mock.MagicMock(
             text=(self.chall.validation(KEY) +
-                  HTTP01Response.WHITESPACE_CUTSET), headers=self.good_headers)
+                  HTTP01Response.WHITESPACE_CUTSET))
         self.assertTrue(self.response.simple_verify(
             self.chall, "local", KEY.public_key()))
         mock_get.assert_called_once_with(self.chall.uri("local"))
-
-    @mock.patch("acme.challenges.requests.get")
-    def test_simple_verify_bad_content_type(self, mock_get):
-        mock_get().text = self.chall.token
-        self.assertFalse(self.response.simple_verify(
-            self.chall, "local", KEY.public_key()))
 
     @mock.patch("acme.challenges.requests.get")
     def test_simple_verify_connection_error(self, mock_get):

--- a/acme/acme/standalone.py
+++ b/acme/acme/standalone.py
@@ -133,7 +133,6 @@ class HTTP01RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                 self.log_message("Serving HTTP01 with token %r",
                                  resource.chall.encode("token"))
                 self.send_response(http_client.OK)
-                self.send_header("Content-type", resource.chall.CONTENT_TYPE)
                 self.end_headers()
                 self.wfile.write(resource.validation.encode())
                 return

--- a/letsencrypt/plugins/manual.py
+++ b/letsencrypt/plugins/manual.py
@@ -46,8 +46,6 @@ Make sure your web server displays the following content at
 
 {validation}
 
-Content-Type header MUST be set to {ct}.
-
 If you don't have HTTP server configured, you can run the following
 command on the target server (as root):
 
@@ -75,7 +73,6 @@ printf "%s" {validation} > {achall.URI_ROOT_PATH}/{encoded_token}
 # run only once per server:
 $(command -v python2 || command -v python2.7 || command -v python2.6) -c \\
 "import BaseHTTPServer, SimpleHTTPServer; \\
-SimpleHTTPServer.SimpleHTTPRequestHandler.extensions_map = {{'': '{ct}'}}; \\
 s = BaseHTTPServer.HTTPServer(('', {port}), SimpleHTTPServer.SimpleHTTPRequestHandler); \\
 s.serve_forever()" """
     """Command template."""
@@ -142,7 +139,7 @@ s.serve_forever()" """
             # TODO(kuba): pipes still necessary?
             validation=pipes.quote(validation),
             encoded_token=achall.chall.encode("token"),
-            ct=achall.CONTENT_TYPE, port=port)
+            port=port)
         if self.conf("test-mode"):
             logger.debug("Test mode. Executing the manual command: %s", command)
             # sh shipped with OS X does't support echo -n, but supports printf
@@ -174,7 +171,7 @@ s.serve_forever()" """
             self._notify_and_wait(self.MESSAGE_TEMPLATE.format(
                 validation=validation, response=response,
                 uri=achall.chall.uri(achall.domain),
-                ct=achall.CONTENT_TYPE, command=command))
+                command=command))
 
         if not response.simple_verify(
                 achall.chall, achall.domain,

--- a/letsencrypt/plugins/webroot.py
+++ b/letsencrypt/plugins/webroot.py
@@ -1,43 +1,4 @@
-"""Webroot plugin.
-
-Content-Type
-------------
-
-This plugin requires your webserver to use a specific `Content-Type`
-header in the HTTP response.
-
-Apache2
-~~~~~~~
-
-.. note:: Instructions written and tested for Debian Jessie. Other
-   operating systems might use something very similar, but you might
-   still need to readjust some commands.
-
-Create ``/etc/apache2/conf-available/letsencrypt.conf``, with
-the following contents::
-
-  <IfModule mod_headers.c>
-    <LocationMatch "/.well-known/acme-challenge/*">
-      Header set Content-Type "text/plain"
-    </LocationMatch>
-  </IfModule>
-
-and then run ``a2enmod headers; a2enconf letsencrypt``; depending on the
-output you will have to either ``service apache2 restart`` or ``service
-apache2 reload``.
-
-nginx
-~~~~~
-
-Use the following snippet in your ``server{...}`` stanza::
-
-  location ~ /.well-known/acme-challenge/(.*) {
-    default_type text/plain;
-  }
-
-and reload your daemon.
-
-"""
+"""Webroot plugin."""
 import errno
 import logging
 import os


### PR DESCRIPTION
Content-Type type restrictions were removed in ACME, see
https://github.com/ietf-wg-acme/acme/commit/69ac2baade014796e5258a077e7600921cd1879d

Boulder does not restrict Content-Type currently, see https://github.com/letsencrypt/boulder/issues/1089 (which is obsolete).

Manual test against staging succeeded (\w manual and standalone plugin).