### PR TITLE
Revert "Quikfix"

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -17,7 +17,7 @@ install_requires = [
     'pyrfc3339',
     'pytz',
     'requests',
-    'setuptools==18.5',  # pkg_resources
+    'setuptools',  # pkg_resources
     'six',
     'werkzeug',
 ]


### PR DESCRIPTION
Reverts changes in #1613 caused by a bug in version 18.6 of setuptools. They have released a patch in version 18.6.1 so my semi-hacky fix is no longer necessary.

You can see discussion of the problem [here](https://bitbucket.org/pypa/setuptools/issues/464/typeerror-in-install_wrapper_scripts).