### PR TITLE
Prioritise dnf over yum

### DIFF
--- a/bootstrap/_rpm_common.sh
+++ b/bootstrap/_rpm_common.sh
@@ -4,12 +4,12 @@
 #   - Fedora 22, 23 (x64)
 #   - Centos 7 (x64: onD igitalOcean droplet)
 
-if type yum 2>/dev/null
-then
-  tool=yum
-elif type dnf 2>/dev/null
+if type dnf 2>/dev/null
 then
   tool=dnf
+elif type yum 2>/dev/null
+then
+  tool=yum
 else
   echo "Neither yum nor dnf found. Aborting bootstrap!"
   exit 1


### PR DESCRIPTION
Perhaps it is better to prioritise dnf over yum here, like this?

dnf officially replaces yum, so it's probably safe to assume that it's the preferred package manager on any system with it installed