### PR TITLE
Merge Augeas lens fix for backslashes in regexps

### DIFF
--- a/letsencrypt-apache/letsencrypt_apache/augeas_lens/httpd.aug
+++ b/letsencrypt-apache/letsencrypt_apache/augeas_lens/httpd.aug
@@ -59,7 +59,7 @@ let empty               = Util.empty_dos
 let indent              = Util.indent
 
 (* borrowed from shellvars.aug *)
-let char_arg_dir  = /[^\\ '"\t\r\n]|\\\\"|\\\\'/
+let char_arg_dir  = /([^\\ '"\t\r\n]|[^\\ '"\t\r\n][^ '"\t\r\n]*[^\\ '"\t\r\n])|\\\\"|\\\\'/
 let char_arg_sec  = /[^ '"\t\r\n>]|\\\\"|\\\\'/
 let cdot = /\\\\./
 let cl = /\\\\\n/


### PR DESCRIPTION
This fix has now landed upstream:

https://github.com/hercules-team/augeas/issues/307
https://github.com/hercules-team/augeas/commit/155746c72f76937a21b1a035da5c56090a54ed13

Fixes: #1626 

Currently fixes anarcat's example from #1531, but not the Drupal .htaccess file.