### PR TITLE
Run RabbitMQ setup during test setup.

### DIFF
--- a/tests/boulder-fetch.sh
+++ b/tests/boulder-fetch.sh
@@ -33,6 +33,7 @@ wget https://github.com/jsha/boulder-tools/raw/master/goose.gz && \
   zcat goose.gz > $GOPATH/bin/goose && \
   chmod +x $GOPATH/bin/goose
 ./test/create_db.sh
+go run cmd/rabbitmq-setup/main.go -server amqp://localhost
 # listenbuddy is needed for ./start.py
 go get github.com/jsha/listenbuddy
 cd -


### PR DESCRIPTION
This was recently introduced on the Boulder side.

Note: long-term we want to have the client tests run the same setup steps as
Boulder does, with the same script. This is a quick fix to unbreak the build.