### PR TITLE
Remove py26reqs.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,6 @@ COPY letsencrypt-apache /opt/letsencrypt/src/letsencrypt-apache/
 COPY letsencrypt-nginx /opt/letsencrypt/src/letsencrypt-nginx/
 
 
-# py26reqs.txt not installed!
 RUN virtualenv --no-site-packages -p python2 /opt/letsencrypt/venv && \
     /opt/letsencrypt/venv/bin/pip install \
     -e /opt/letsencrypt/src/acme \

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -32,7 +32,6 @@ RUN /opt/letsencrypt/src/ubuntu.sh && \
 # the above is not likely to change, so by putting it further up the
 # Dockerfile we make sure we cache as much as possible
 
-# py26reqs.txt not installed!
 COPY setup.py README.rst CHANGES.rst MANIFEST.in linter_plugin.py tox.cover.sh tox.ini pep8.travis.sh .pep8 .pylintrc /opt/letsencrypt/src/
 
 # all above files are necessary for setup.py, however, package source

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
-include py26reqs.txt
 include README.rst
 include CHANGES.rst
 include CONTRIBUTING.md

--- a/bootstrap/README
+++ b/bootstrap/README
@@ -2,6 +2,5 @@ This directory contains scripts that install necessary OS-specific
 prerequisite dependencies (see docs/using.rst).
 
 General dependencies:
-- git-core: git+https://*
 - ca-certificates: communication with demo ACMO server at
-  https://www.letsencrypt-demo.org, git+https://*
+  https://www.letsencrypt-demo.org

--- a/bootstrap/README
+++ b/bootstrap/README
@@ -2,6 +2,6 @@ This directory contains scripts that install necessary OS-specific
 prerequisite dependencies (see docs/using.rst).
 
 General dependencies:
-- git-core: py26reqs.txt git+https://*
+- git-core: git+https://*
 - ca-certificates: communication with demo ACMO server at
-  https://www.letsencrypt-demo.org, py26reqs.txt git+https://*
+  https://www.letsencrypt-demo.org, git+https://*

--- a/bootstrap/dev/venv.sh
+++ b/bootstrap/dev/venv.sh
@@ -4,7 +4,6 @@
 export VENV_ARGS="--python python2"
 
 ./bootstrap/dev/_venv_common.sh \
-  -r py26reqs.txt \
   -e acme[testing] \
   -e .[dev,docs,testing] \
   -e letsencrypt-apache \

--- a/bootstrap/venv.sh
+++ b/bootstrap/venv.sh
@@ -20,7 +20,7 @@ fi
 pip install -U setuptools
 pip install -U pip
 
-pip install -U -r py26reqs.txt letsencrypt letsencrypt-apache # letsencrypt-nginx
+pip install -U letsencrypt letsencrypt-apache # letsencrypt-nginx
 
 echo
 echo "Congratulations, Let's Encrypt has been successfully installed/updated!"

--- a/letsencrypt-auto
+++ b/letsencrypt-auto
@@ -175,7 +175,7 @@ if [ "$VERBOSE" = 1 ]  ; then
   echo
   $VENV_BIN/pip install -U setuptools
   $VENV_BIN/pip install -U pip
-  $VENV_BIN/pip install -r "$LEA_PATH"/py26reqs.txt -U letsencrypt letsencrypt-apache
+  $VENV_BIN/pip install -U letsencrypt letsencrypt-apache
   # nginx is buggy / disabled for now, but upgrade it if the user has
   # installed it manually
   if $VENV_BIN/pip freeze | grep -q letsencrypt-nginx ; then
@@ -187,8 +187,6 @@ else
   $VENV_BIN/pip install -U pip > /dev/null
   printf .
   # nginx is buggy / disabled for now...
-  $VENV_BIN/pip install -r "$LEA_PATH"/py26reqs.txt > /dev/null
-  printf .
   $VENV_BIN/pip install -U letsencrypt > /dev/null
   printf .
   $VENV_BIN/pip install -U letsencrypt-apache > /dev/null

--- a/py26reqs.txt
+++ b/py26reqs.txt
@@ -1,2 +1,0 @@
-# https://github.com/bw2/ConfigArgParse/issues/17
-git+https://github.com/kuba/ConfigArgParse.git@python2.6-0.9.3#egg=ConfigArgParse

--- a/setup.py
+++ b/setup.py
@@ -52,13 +52,13 @@ if sys.version_info < (2, 7):
     install_requires.extend([
         # only some distros recognize stdlib argparse as already satisfying
         'argparse',
-        'mock<1.1.0',
         'ConfigArgParse>=0.10.0',  # python2.6 support, upstream #17
+        'mock<1.1.0',
     ])
 else:
     install_requires.extend([
-        'mock',
         'ConfigArgParse',
+        'mock',
     ])
 
 dev_extras = [

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ version = meta['version']
 
 install_requires = [
     'acme=={0}'.format(version),
-    'ConfigArgParse>=0.10.0',  # python2.6 support, upstream #17
     'configobj',
     'cryptography>=0.7',  # load_pem_x509_certificate
     'parsedatetime',
@@ -54,9 +53,13 @@ if sys.version_info < (2, 7):
         # only some distros recognize stdlib argparse as already satisfying
         'argparse',
         'mock<1.1.0',
+        'ConfigArgParse>=0.10.0',  # python2.6 support, upstream #17
     ])
 else:
-    install_requires.append('mock')
+    install_requires.extend([
+        'mock',
+        'ConfigArgParse',
+    ])
 
 dev_extras = [
     # Pin astroid==1.3.5, pylint==1.4.2 as a workaround for #289

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ version = meta['version']
 
 install_requires = [
     'acme=={0}'.format(version),
-    'ConfigArgParse',
+    'ConfigArgParse>=0.10.0',  # python2.6 support, upstream #17
     'configobj',
     'cryptography>=0.7',  # load_pem_x509_certificate
     'parsedatetime',

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ envlist = py26,py27,py33,py34,py35,cover,lint
 commands =
     pip install -e acme[testing]
     nosetests -v acme
-    pip install -r py26reqs.txt -e .[testing]
+    pip install -e .[testing]
     nosetests -v letsencrypt
     pip install -e letsencrypt-apache
     nosetests -v letsencrypt_apache


### PR DESCRIPTION
ConfigArgParse 0.10 from PyPI supports Python 2.6, so there's no more
need to install a fixed version directly from a git branch.