### PR TITLE
Avoid trailing whitespace in pretty-printed JSON

### DIFF
--- a/acme/acme/jose/interfaces.py
+++ b/acme/acme/jose/interfaces.py
@@ -194,7 +194,7 @@ class JSONDeSerializable(object):
         :rtype: str
 
         """
-        return self.json_dumps(sort_keys=True, indent=4)
+        return self.json_dumps(sort_keys=True, indent=4, separators=(',', ': '))
 
     @classmethod
     def json_dump_default(cls, python_object):

--- a/acme/acme/jose/interfaces_test.py
+++ b/acme/acme/jose/interfaces_test.py
@@ -1,8 +1,6 @@
 """Tests for acme.jose.interfaces."""
 import unittest
 
-import six
-
 
 class JSONDeSerializableTest(unittest.TestCase):
     # pylint: disable=too-many-instance-attributes
@@ -92,9 +90,8 @@ class JSONDeSerializableTest(unittest.TestCase):
         self.assertEqual('["foo1", "foo2"]', self.seq.json_dumps())
 
     def test_json_dumps_pretty(self):
-        filler = ' ' if six.PY2 else ''
         self.assertEqual(self.seq.json_dumps_pretty(),
-                         '[\n    "foo1",{0}\n    "foo2"\n]'.format(filler))
+                         '[\n    "foo1",\n    "foo2"\n]')
 
     def test_json_dump_default(self):
         from acme.jose.interfaces import JSONDeSerializable


### PR DESCRIPTION
Fixes a failing test on Python 3.3:

    ======================================================================
    FAIL: test_json_dumps_pretty (acme.jose.interfaces_test.JSONDeSerializableTest)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/home/mg/src/letsencrypt/acme/acme/jose/interfaces_test.py", line 97, in test_json_dumps_pretty
        '[\n    "foo1",{0}\n    "foo2"\n]'.format(filler))
    AssertionError: '[\n    "foo1", \n    "foo2"\n]' != '[\n    "foo1",\n    "foo2"\n]'
      [
    -     "foo1",
    ?            -
    +     "foo1",
          "foo2"
      ]

    ----------------------------------------------------------------------

(The test expected trailing whitespace on Python < 3.0, while it
should've been checking for Python < 3.4.)