### PR TITLE
Remove ! at end of url (fixes open url in gnome-terminal)

### DIFF
--- a/letsencrypt/display/ops.py
+++ b/letsencrypt/display/ops.py
@@ -245,7 +245,7 @@ def success_installation(domains):
 
     """
     util(interfaces.IDisplay).notification(
-        "Congratulations! You have successfully enabled {0}!{1}{1}"
+        "Congratulations! You have successfully enabled {0}{1}{1}"
         "You should test your configuration at:{1}{2}".format(
             _gen_https_names(domains),
             os.linesep,


### PR DESCRIPTION
The ! at the end of the url is parsed as part of
the url if one uses "Open Link" in gnome-terminal.