### PR TITLE
ownership and permission fixes to webroot plugin generated dirs/files

### DIFF
--- a/letsencrypt/plugins/webroot_test.py
+++ b/letsencrypt/plugins/webroot_test.py
@@ -74,9 +74,16 @@ class AuthenticatorTest(unittest.TestCase):
 
         # Remove exec bit from permission check, so that it
         # matches the file
+        # Also add group and other read permissions the same
+        # way they're added in the actual webroot code
+
+        # TODO: Should perhaps test ownership and permissions of
+        # .well-known and .well-known/acme-challenge directories?
+
         self.auth.perform([self.achall])
-        parent_permissions = (stat.S_IMODE(os.stat(self.path).st_mode) &
-                              ~stat.S_IEXEC)
+        parent_permissions = ((stat.S_IMODE(os.stat(self.path).st_mode) &
+                              ~(stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)) |
+                               stat.S_IRGRP | stat.S_IROTH)
 
         actual_permissions = stat.S_IMODE(os.stat(self.validation_path).st_mode)
 


### PR DESCRIPTION
Fix ownership and permissions of the .well-known directory. Without this the .well-known might end up owned by root. Also both .well-known directory and the validation file would end up with wrong permissions when system umask was stricter than 022.

Without this fix and 077 umask the validation would always fail with 403 error (AH00132: file permissions deny server access)