### PR TITLE
Various shelly fixes to letsencrypt-auto

### DIFF
--- a/letsencrypt-auto
+++ b/letsencrypt-auto
@@ -87,17 +87,13 @@ ExperimentalBootstrap() {
 }
 
 DeterminePythonVersion() {
-  if command -v python2.7 > /dev/null ; then
-    export LE_PYTHON=${LE_PYTHON:-python2.7}
-  elif command -v python27 > /dev/null ; then
-    export LE_PYTHON=${LE_PYTHON:-python27}
-  elif command -v python2 > /dev/null ; then
-    export LE_PYTHON=${LE_PYTHON:-python2}
-  elif command -v python > /dev/null ; then
-    export LE_PYTHON=${LE_PYTHON:-python}
-  else
+  for LE_PYTHON in "$LE_PYTHON" python2.7 python27 python2 python; do
+    # break (while keeping the LE_PYTHON value) if found
+    command -v "$LE_PYTHON" > /dev/null && break
+  done ||
+    # otherwise the retval from the failed final try falls here.
     echo "Cannot find any Pythons... please install one!"
-  fi
+  export LE_PYTHON
 
   PYVER=`$LE_PYTHON --version 2>&1 | cut -d" " -f 2 | cut -d. -f1,2 | sed 's/\.//'`
   if [ $PYVER -eq 26 ] ; then

--- a/letsencrypt-auto
+++ b/letsencrypt-auto
@@ -23,12 +23,13 @@ BOOTSTRAP=${LEA_PATH}/bootstrap
 # additionally responds to --verbose (more output) and --debug (allow support
 # for experimental platforms)
 for arg in "$@" ; do
-  # This first clause is redundant with the third, but hedging on portability
-  if [ "$arg" = "-v" ] || [ "$arg" = "--verbose" ] || echo "$arg" | grep -E -- "-v+$" ; then
-    VERBOSE=1
-  elif [ "$arg" = "--debug" ] ; then
-    DEBUG=1
-  fi
+  case "$arg" in  # (
+    -v*|--verbose)
+      VERBOSE=1;; # (
+    --debug)
+      DEBUG=1;;
+  esac
+done
 done
 
 # letsencrypt-auto needs root access to bootstrap OS dependencies, and


### PR DESCRIPTION
Fixed:
* weird logic in DeterminePythonVersion.

Other changes:
* Let's just use `case` for option parsing. Here `-v*` should be a good-enough approximation.
  * P.S. original regex is just a regex -- `-E` looks unnecessary.
    * Do you mean `^-v+$`? It looks weird to take something like `dont-be-verbose` as an option switch.

See the commit messages for more info.