### PR TITLE
Added a descriptive error if domain list includes a Unicode-encoded IDN

### DIFF
--- a/letsencrypt/configuration.py
+++ b/letsencrypt/configuration.py
@@ -148,7 +148,7 @@ def _check_config_domain_sanity(domains):
     # Unicode
     try:
         for domain in domains:
-            domain.encode('ascii',errors='strict')
+            domain.encode('ascii')
     except UnicodeDecodeError:
         raise errors.ConfigurationError(
             "Internationalized domain names are not supported")

--- a/letsencrypt/configuration.py
+++ b/letsencrypt/configuration.py
@@ -144,6 +144,15 @@ def _check_config_domain_sanity(domains):
     if any("xn--" in d for d in domains):
         raise errors.ConfigurationError(
             "Punycode domains are not supported")
+
+    # Unicode
+    try:
+        for domain in domains:
+            domain.encode('ascii',errors='strict')
+    except UnicodeDecodeError:
+        raise errors.ConfigurationError(
+            "Internationalized domain names are not supported")
+
     # FQDN checks from
     # http://www.mkyong.com/regular-expressions/domain-name-regular-expression-example/
     #  Characters used, domain parts < 63 chars, tld > 1 < 64 chars


### PR DESCRIPTION
The current error for IDNs passed in Unicode form is incorrect and does not describe the actual problem:

```
$ letsencrypt --manual -d example.com -d ёжикв.сайт
Requested domain is not a FQDN
```

This change checks for any domains that cannot be encoded as ASCII, and if one is present:

```
$ letsencrypt --manual -d example.com -d ёжикв.сайт
Internationalized domain names are not supported
```