### PR TITLE
[Test] Use demandimport to load modules on demand

### DIFF
--- a/letsencrypt/_demandimport.py
+++ b/letsencrypt/_demandimport.py
@@ -4,7 +4,9 @@
     might cause problems as some `ImportError's aren't raised immediately. """
 
 import demandimport
-demandimport.enable()
 
-demandimport.ignore('PyICU')      # parsedatetime
-demandimport.ignore('simplejson') # requests.compat
+def enable():
+    demandimport.enable()
+
+    demandimport.ignore('PyICU')      # parsedatetime
+    demandimport.ignore('simplejson') # requests.compat

--- a/letsencrypt/_demandimport.py
+++ b/letsencrypt/_demandimport.py
@@ -6,4 +6,5 @@
 import demandimport
 demandimport.enable()
 
-demandimport.ignore('PyICU')
+demandimport.ignore('PyICU')      # parsedatetime
+demandimport.ignore('simplejson') # requests.compat

--- a/letsencrypt/_demandimport.py
+++ b/letsencrypt/_demandimport.py
@@ -1,0 +1,9 @@
+""" Use demandimport to postpone actually loading a module until it is
+    first used.  This will decrease start-up time a lot, as most imported
+    modules are not used at all --- however, some third-party modules
+    might cause problems as some `ImportError's aren't raised immediately. """
+
+import demandimport
+demandimport.enable()
+
+demandimport.ignore('PyICU')

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -5,7 +5,7 @@
 
 import demandimport # load module on demand
 demandimport.enable()
-demandimport.ignore('pyICU')
+demandimport.ignore('PyICU')
 
 import argparse
 import atexit

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -3,7 +3,8 @@
 # pylint: disable=too-many-lines
 # (TODO: split this file into main.py and cli.py)
 
-import letsencrypt._demandimport as de; de.enable() # load modules on demand
+import letsencrypt.ondemandimport
+letsencrypt.ondemandimport.enable()# load modules on demand
 
 import argparse
 import atexit

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -3,9 +3,7 @@
 # pylint: disable=too-many-lines
 # (TODO: split this file into main.py and cli.py)
 
-import demandimport # load module on demand
-demandimport.enable()
-demandimport.ignore('PyICU')
+import letsencrypt._demandimport # load modules on demand
 
 import argparse
 import atexit

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -3,7 +3,7 @@
 # pylint: disable=too-many-lines
 # (TODO: split this file into main.py and cli.py)
 
-import letsencrypt._demandimport # load modules on demand
+import letsencrypt._demandimport as de; de.enable() # load modules on demand
 
 import argparse
 import atexit

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -2,6 +2,10 @@
 # TODO: Sanity check all input.  Be sure to avoid shell code etc...
 # pylint: disable=too-many-lines
 # (TODO: split this file into main.py and cli.py)
+
+import demandimport # load module on demand
+demandimport.enable()
+
 import argparse
 import atexit
 import functools

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -5,6 +5,7 @@
 
 import demandimport # load module on demand
 demandimport.enable()
+demandimport.ignore('pyICU')
 
 import argparse
 import atexit

--- a/letsencrypt/ondemandimport.py
+++ b/letsencrypt/ondemandimport.py
@@ -6,6 +6,7 @@
 import demandimport
 
 def enable():
+    """ Configures and enables on-demand module importing. """
     demandimport.enable()
 
     demandimport.ignore('PyICU')      # parsedatetime

--- a/letsencrypt/ondemandimport.py
+++ b/letsencrypt/ondemandimport.py
@@ -3,10 +3,14 @@
     modules are not used at all --- however, some third-party modules
     might cause problems as some `ImportError's aren't raised immediately. """
 
+import sys
 import demandimport
 
 def enable():
     """ Configures and enables on-demand module importing. """
+    if sys.version_info < (2, 7):
+        return # demandimport isn't reliable on Python <2.7
+
     demandimport.enable()
 
     demandimport.ignore('PyICU')      # parsedatetime

--- a/letsencrypt/ondemandimport.py
+++ b/letsencrypt/ondemandimport.py
@@ -3,6 +3,7 @@
     modules are not used at all --- however, some third-party modules
     might cause problems as some `ImportError's aren't raised immediately. """
 
+import os
 import sys
 import demandimport
 
@@ -10,6 +11,8 @@ def enable():
     """ Configures and enables on-demand module importing. """
     if sys.version_info < (2, 7):
         return # demandimport isn't reliable on Python <2.7
+    if os.environ.get('LETSENCRYPT_NO_DEMANDIMPORT'):
+        return
 
     demandimport.enable()
 

--- a/letsencrypt/renewer.py
+++ b/letsencrypt/renewer.py
@@ -7,7 +7,8 @@ within lineages of successor certificates, according to configuration.
 .. todo:: Call new installer API to restart servers after deployment
 
 """
-import letsencrypt._demandimport as de; de.enable() # load modules on demand
+import letsencrypt.ondemandimport
+letsencrypt.ondemandimport.enable()# load modules on demand
 
 import argparse
 import logging

--- a/letsencrypt/renewer.py
+++ b/letsencrypt/renewer.py
@@ -7,7 +7,7 @@ within lineages of successor certificates, according to configuration.
 .. todo:: Call new installer API to restart servers after deployment
 
 """
-import letsencrypt._demandimport # load modules on demand
+import letsencrypt._demandimport as de; de.enable() # load modules on demand
 
 import argparse
 import logging

--- a/letsencrypt/renewer.py
+++ b/letsencrypt/renewer.py
@@ -9,6 +9,7 @@ within lineages of successor certificates, according to configuration.
 """
 import demandimport # load modules on demand
 demandimport.enable()
+demandimport.ignore('pyICU')
 
 import argparse
 import logging

--- a/letsencrypt/renewer.py
+++ b/letsencrypt/renewer.py
@@ -7,6 +7,9 @@ within lineages of successor certificates, according to configuration.
 .. todo:: Call new installer API to restart servers after deployment
 
 """
+import demandimport # load modules on demand
+demandimport.enable()
+
 import argparse
 import logging
 import os

--- a/letsencrypt/renewer.py
+++ b/letsencrypt/renewer.py
@@ -9,7 +9,7 @@ within lineages of successor certificates, according to configuration.
 """
 import demandimport # load modules on demand
 demandimport.enable()
-demandimport.ignore('pyICU')
+demandimport.ignore('PyICU')
 
 import argparse
 import logging

--- a/letsencrypt/renewer.py
+++ b/letsencrypt/renewer.py
@@ -7,9 +7,7 @@ within lineages of successor certificates, according to configuration.
 .. todo:: Call new installer API to restart servers after deployment
 
 """
-import demandimport # load modules on demand
-demandimport.enable()
-demandimport.ignore('PyICU')
+import letsencrypt._demandimport # load modules on demand
 
 import argparse
 import logging

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ install_requires = [
     'six',
     'zope.component',
     'zope.interface',
+    'demandimport',
 ]
 
 # env markers in extras_require cause problems with older pip: #517


### PR DESCRIPTION
Uses Mercurial's on-demand module loading to speed up start-up times, which should make letsencrypt more snappy.  This PR isn't ready to be merged yet: it's here to let Travis have a go at it.