### PR TITLE
Use print_function not print_statement

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -1,4 +1,6 @@
 """Let's Encrypt CLI."""
+from __future__ import print_function
+
 # TODO: Sanity check all input.  Be sure to avoid shell code etc...
 # pylint: disable=too-many-lines
 # (TODO: split this file into main.py and cli.py)
@@ -574,7 +576,7 @@ def plugins_cmd(args, config, plugins):  # TODO: Use IDisplay rather than print
     logger.debug("Filtered plugins: %r", filtered)
 
     if not args.init and not args.prepare:
-        print str(filtered)
+        print(str(filtered))
         return
 
     filtered.init(config)
@@ -582,13 +584,13 @@ def plugins_cmd(args, config, plugins):  # TODO: Use IDisplay rather than print
     logger.debug("Verified plugins: %r", verified)
 
     if not args.prepare:
-        print str(verified)
+        print(str(verified))
         return
 
     verified.prepare()
     available = verified.available()
     logger.debug("Prepared plugins: %s", available)
-    print str(available)
+    print(str(available))
 
 
 def read_file(filename, mode="rb"):
@@ -681,7 +683,7 @@ class HelpfulArgumentParser(object):
         self.help_arg = max(help1, help2)
         if self.help_arg is True:
             # just --help with no topic; avoid argparse altogether
-            print usage
+            print(usage)
             sys.exit(0)
         self.visible_topics = self.determine_help_topics(self.help_arg)
         self.groups = {}  # elements are added by .add_group()
@@ -785,12 +787,12 @@ class HelpfulArgumentParser(object):
 
         """
         if self.visible_topics[topic]:
-            #print "Adding visible group " + topic
+            #print("Adding visible group " + topic)
             group = self.parser.add_argument_group(topic, **kwargs)
             self.groups[topic] = group
             return group
         else:
-            #print "Invisible group " + topic
+            #print("Invisible group " + topic)
             return self.silent_parser
 
     def add_plugin_args(self, plugins):
@@ -802,7 +804,7 @@ class HelpfulArgumentParser(object):
         """
         for name, plugin_ep in plugins.iteritems():
             parser_or_group = self.add_group(name, description=plugin_ep.description)
-            #print parser_or_group
+            #print(parser_or_group)
             plugin_ep.plugin_cls.inject_parser_options(parser_or_group, name)
 
     def determine_help_topics(self, chosen_topic):

--- a/letsencrypt/renewer.py
+++ b/letsencrypt/renewer.py
@@ -7,6 +7,8 @@ within lineages of successor certificates, according to configuration.
 .. todo:: Call new installer API to restart servers after deployment
 
 """
+from __future__ import print_function
+
 import argparse
 import logging
 import os
@@ -169,7 +171,7 @@ def main(cli_args=sys.argv[1:]):
                                constants.CONFIG_DIRS_MODE, uid)
 
     for renewal_file in os.listdir(cli_config.renewal_configs_dir):
-        print "Processing", renewal_file
+        print("Processing " + renewal_file)
         try:
             # TODO: Before trying to initialize the RenewableCert object,
             #       we could check here whether the combination of the config

--- a/letsencrypt/reporter.py
+++ b/letsencrypt/reporter.py
@@ -1,4 +1,6 @@
 """Collects and displays information to the user."""
+from __future__ import print_function
+
 import collections
 import logging
 import os
@@ -75,8 +77,8 @@ class Reporter(object):
             no_exception = sys.exc_info()[0] is None
             bold_on = sys.stdout.isatty()
             if bold_on:
-                print le_util.ANSI_SGR_BOLD
-            print 'IMPORTANT NOTES:'
+                print(le_util.ANSI_SGR_BOLD)
+            print('IMPORTANT NOTES:')
             first_wrapper = textwrap.TextWrapper(
                 initial_indent=' - ', subsequent_indent=(' ' * 3))
             next_wrapper = textwrap.TextWrapper(
@@ -89,9 +91,9 @@ class Reporter(object):
                     sys.stdout.write(le_util.ANSI_SGR_RESET)
                     bold_on = False
                 lines = msg.text.splitlines()
-                print first_wrapper.fill(lines[0])
+                print(first_wrapper.fill(lines[0]))
                 if len(lines) > 1:
-                    print "\n".join(
-                        next_wrapper.fill(line) for line in lines[1:])
+                    print("\n".join(
+                        next_wrapper.fill(line) for line in lines[1:]))
         if bold_on:
             sys.stdout.write(le_util.ANSI_SGR_RESET)


### PR DESCRIPTION
Change the print statements used into print functions.

The print statement is not valid in Python 3, however the print function
is valid in at least 2.6+. __future__ provides support for older versions
as well as being required for the linter.