### PR TITLE
Apache configurator respects Listen ip:port statements

### DIFF
--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -120,7 +120,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         self.version = version
         self.vhosts = None
         self._enhance_func = {"redirect": self._enable_redirect,
-                "ensure-http-header": self._set_http_header}
+                              "ensure-http-header": self._set_http_header}
 
     @property
     def mod_ssl_conf(self):
@@ -570,18 +570,18 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
                 # The Listen statement specifies an ip
                 _, ip = listen[::-1].split(":", 1)
                 ip = ip[::-1]
-                if "%s:%s" %(ip, port) not in listens:
+                if "%s:%s" % (ip, port) not in listens:
                     if port == "443":
-                        args = ["%s:%s" %(ip, port)]
+                        args = ["%s:%s" % (ip, port)]
                     else:
                         # Non-standard ports should specify https protocol
-                        args = ["%s:%s" %(ip, port), "https"]
+                        args = ["%s:%s" % (ip, port), "https"]
                     self.parser.add_dir_to_ifmodssl(
                         parser.get_aug_path(
                             self.parser.loc["listen"]), "Listen", args)
                     self.save_notes += "Added Listen %s:%s directive to %s\n" % (
-                                          ip, port, self.parser.loc["listen"])
-                    listens.append("%s:%s" %(ip, port))
+                                       ip, port, self.parser.loc["listen"])
+                    listens.append("%s:%s" % (ip, port))
 
     def make_addrs_sni_ready(self, addrs):
         """Checks to see if the server is ready for SNI challenges.


### PR DESCRIPTION
Fixes #1739. 

The current `prepare_server_https` method fails if Apache is set up to bind to specific IPs only. It believes that there is no `Listen` statement at all, and adds a generic `Listen 443`. If a specific `Listen 127.0.0.1:443` already exists, apache fails to start up as it tries to bind to an already occupied port. (`/var/log/apache2/error.log`: `Address already in use: AH00072: make_sock: could not bind to address 0.0.0.0:443`. 

The fix in this pull requests now iterates through all Listen statements, and checks if they are on the correct port and if not, adds the appropriate Listen statement. Its not perfect yet, as it creates a new Listen statement for every listen statement which is not the target ssl port, no matter if a vhost for which we want to create a certificate actually needs this IP. But this is quite the edge case and I can't think of a neat way of integrating this restriction.

I have added some additional tests which give full coverage. 