### PR TITLE
Add staging server hint to avoid rate limit issues

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -31,16 +31,21 @@ Firstly, please `install Git`_ and run the following commands:
 
 .. _`install Git`: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
 
+.. note:: On RedHat/CentOS 6 you will need to enable the EPEL_
+   repository before install.
+
+.. _EPEL: http://fedoraproject.org/wiki/EPEL
+
 To install and run the client you just need to type:
 
 .. code-block:: shell
 
    ./letsencrypt-auto
 
-.. note:: On RedHat/CentOS 6 you will need to enable the EPEL_
-   repository before install.
-
-.. _EPEL: http://fedoraproject.org/wiki/EPEL
+.. hint:: During the beta phase, Let's Encrypt enforces strict rate limits on
+   the number of certificates issued for one domain. It is recommended to
+   initially use the test server via `--test-cert` until you get the desired
+   certificates.
 
 Throughout the documentation, whenever you see references to
 ``letsencrypt`` script/binary, you can substitute in


### PR DESCRIPTION
Users accidentally running into rate limit is the most common issue on the community forum and on IRC.

This adds a more obvious hint encouraging users to use the staging server initially.

I moved the EPEL note up a bit so those two boxes aren't right next to each other, and because it makes more sense to put it before the command IMO. Happy to change that though, comes down to personal preference.

fixes parts of #1545 