### PR TITLE
Reducing the PyOpenSSL version dep [do not merge]

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -12,8 +12,11 @@ install_requires = [
     'cryptography>=0.8',
     'ndg-httpsclient',  # urllib3 InsecurePlatformWarning (#304)
     'pyasn1',  # urllib3 InsecurePlatformWarning (#304)
-    # Connection.set_tlsext_host_name (>=0.13), X509Req.get_extensions (>=0.15)
-    'PyOpenSSL>=0.15',
+    # PyOpenSSL version dependencies:
+    # Connection.set_tlsext_host_name (>=0.13)
+    # X509Req (>=0.14)
+    # X509Req.get_extensions (>=0.15) but protected by fallback
+    'PyOpenSSL>=0.14',
     'pyrfc3339',
     'pytz',
     'requests',

--- a/acme/setup.py
+++ b/acme/setup.py
@@ -16,7 +16,7 @@ install_requires = [
     # Connection.set_tlsext_host_name (>=0.13)
     # X509Req (>=0.14)
     # X509Req.get_extensions (>=0.15) but protected by fallback
-    'PyOpenSSL>=0.14',
+    'PyOpenSSL==0.14',
     'pyrfc3339',
     'pytz',
     'requests',


### PR DESCRIPTION
Partially addresses #1861, facilitaes packaging on Debian Jessie and possibly Fedora 22, though not [Debian Wheezy](packages.debian.org/python-openssl) or [CentOS 6/7](https://www.rpmfind.net/linux/rpm2html/search.php?query=pyOpenSSL), which have 0.13.