### PR TITLE
Don't specify nargs when deprecating args

### DIFF
--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -98,7 +98,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
             help="SSL vhost configuration extension.")
         add("server-root", default=constants.CLI_DEFAULTS["server_root"],
             help="Apache server root directory.")
-        le_util.add_deprecated_argument(add, "init-script", 1)
+        le_util.add_deprecated_argument(add, "init-script")
 
     def __init__(self, *args, **kwargs):
         """Initialize an Apache Configurator.

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -769,7 +769,7 @@ class HelpfulArgumentParser(object):
             kwargs["help"] = argparse.SUPPRESS
             self.parser.add_argument(*args, **kwargs)
 
-    def add_deprecated_argument(self, argument_name, num_args):
+    def add_deprecated_argument(self, argument_name):
         """Adds a deprecated argument with the name argument_name.
 
         Deprecated arguments are not shown in the help. If they are used
@@ -777,11 +777,10 @@ class HelpfulArgumentParser(object):
         argument is deprecated and no other action is taken.
 
         :param str argument_name: Name of deprecated argument.
-        :param int nargs: Number of arguments the option takes.
 
         """
-        le_util.add_deprecated_argument(
-            self.parser.add_argument, argument_name, num_args)
+        le_util.add_deprecated_argument(self.parser.add_argument,
+                                        argument_name)
 
     def add_group(self, topic, **kwargs):
         """
@@ -956,7 +955,7 @@ def prepare_and_parse_args(plugins, args):
         help="Require that all configuration files are owned by the current "
              "user; only needed if your config is somewhere unsafe like /tmp/")
 
-    helpful.add_deprecated_argument("--agree-dev-preview", 0)
+    helpful.add_deprecated_argument("--agree-dev-preview")
 
     _create_subparsers(helpful)
     _paths_parser(helpful)

--- a/letsencrypt/le_util.py
+++ b/letsencrypt/le_util.py
@@ -259,17 +259,18 @@ def safe_email(email):
         return False
 
 
-def add_deprecated_argument(add_argument, argument_name, nargs):
+def add_deprecated_argument(add_argument, argument_name):
     """Adds a deprecated argument with the name argument_name.
 
     Deprecated arguments are not shown in the help. If they are used on
     the command line, a warning is shown stating that the argument is
     deprecated and no other action is taken.
 
+    The deprecated argument must be optional.
+
     :param callable add_argument: Function that adds arguments to an
         argument parser/group.
     :param str argument_name: Name of deprecated argument.
-    :param nargs: Value for nargs when adding the argument to argparse.
 
     """
     class ShowWarning(argparse.Action):
@@ -279,7 +280,8 @@ def add_deprecated_argument(add_argument, argument_name, nargs):
                 "Use of {0} is deprecated.\n".format(option_string))
 
     add_argument(argument_name, action=ShowWarning,
-                 help=argparse.SUPPRESS, nargs=nargs)
+                 help=argparse.SUPPRESS, nargs="*")
+
 
 def check_domain_sanity(domain):
     """Method which validates domain value and errors out if

--- a/letsencrypt/tests/le_util_test.py
+++ b/letsencrypt/tests/le_util_test.py
@@ -291,18 +291,18 @@ class AddDeprecatedArgumentTest(unittest.TestCase):
     def setUp(self):
         self.parser = argparse.ArgumentParser()
 
-    def _call(self, argument_name, nargs):
+    def _call(self, argument_name):
         from letsencrypt.le_util import add_deprecated_argument
 
-        add_deprecated_argument(self.parser.add_argument, argument_name, nargs)
+        add_deprecated_argument(self.parser.add_argument, argument_name)
 
     def test_warning_no_arg(self):
-        self._call("--old-option", 0)
+        self._call("--old-option")
         stderr = self._get_argparse_warnings(["--old-option"])
         self.assertTrue("--old-option is deprecated" in stderr)
 
     def test_warning_with_arg(self):
-        self._call("--old-option", 1)
+        self._call("--old-option")
         stderr = self._get_argparse_warnings(["--old-option", "42"])
         self.assertTrue("--old-option is deprecated" in stderr)
 
@@ -313,7 +313,7 @@ class AddDeprecatedArgumentTest(unittest.TestCase):
         return stderr.getvalue()
 
     def test_help(self):
-        self._call("--old-option", 2)
+        self._call("--old-option")
         stdout = StringIO.StringIO()
         with mock.patch("letsencrypt.le_util.sys.stdout", new=stdout):
             try:


### PR DESCRIPTION
Removes the parameter having you specify the number of args in `add_deprecated_argument`. Instead, `*` is used for `nargs` which consumes all arguments after the flag being deprecated up to the next flag.

[Documentation](https://docs.python.org/2/library/argparse.html#nargs)