### PR TITLE
Increase Security & Reduce Payload When Using Git

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,8 @@ packages yet, we provide a temporary solution via the ``letsencrypt-auto``
 wrapper script, which obtains some dependencies from your OS and puts others
 in a python virtual environment::
 
-  user@webserver:~$ git clone https://github.com/letsencrypt/letsencrypt
+  user@webserver:~$ git clone --depth=1 --branch=master https://github.com/letsencrypt/letsencrypt letsencrypt
+  user@webserver:~$ rm -rf !$/.git // Omit for Contributors/Developers or re init
   user@webserver:~$ cd letsencrypt
   user@webserver:~/letsencrypt$ ./letsencrypt-auto --help
 


### PR DESCRIPTION
`--depth=1 --branch=master` The depth option will make sure to copy the least bit of history possible. This reduces the payload on the serving host (GitHub) and not requesting the entire git history to minimize the footprint on the implementing server.

Adding ` letsencrypt` to the end of the clone ensures the repo is cloned into its own directory and is accessible by the next command:

`rm -rf !$/.git` Removes the '.git' directory from the 'letsencrypt' directory making it not a Git repository any more. This, more importantly, improves security for both the user and the repo. Without getting into details (_and politics that are beyond me_); Studies have shown that most breaches into servers and repo's are caused by leaving the .git commit history on production servers that "can contain" sensitive data. To be safe, lets just delete it.