### PR TITLE
fix issue with parsing renewal confs

### DIFF
--- a/letsencrypt/renewer.py
+++ b/letsencrypt/renewer.py
@@ -179,7 +179,9 @@ def main(cli_args=sys.argv[1:]):
             #       RenewableCert object for this cert at all, which could
             #       dramatically improve performance for large deployments
             #       where autorenewal is widely turned off.
-            cert = storage.RenewableCert(renewal_file, cli_config)
+            cert = storage.RenewableCert(
+                            os.path.join(cli_config.renewal_configs_dir, renewal_file),
+                            cli_config)
         except errors.CertStorageError:
             # This indicates an invalid renewal configuration file, such
             # as one missing a required parameter (in the future, perhaps

--- a/letsencrypt/storage.py
+++ b/letsencrypt/storage.py
@@ -260,7 +260,7 @@ class RenewableCert(object):  # pylint: disable=too-many-instance-attributes
 
         :returns: The path to the current version of the specified
             member.
-        :rtype: str
+        :rtype: str or None
 
         """
         if kind not in ALL_FOUR:

--- a/letsencrypt/tests/renewer_test.py
+++ b/letsencrypt/tests/renewer_test.py
@@ -764,6 +764,8 @@ class RenewableCertTests(BaseRenewableCertTest):
 
     def test_bad_config_file(self):
         from letsencrypt import renewer
+        os.unlink(os.path.join(self.cli_config.renewal_configs_dir,
+                               "example.org.conf"))
         with open(os.path.join(self.cli_config.renewal_configs_dir,
                                "bad.conf"), "w") as f:
             f.write("incomplete = configfile\n")


### PR DESCRIPTION
previously it only passed the name of the config file which prevented the following code from opening it. Now we pass the full path
split on multiple lines for linting