### PR TITLE
Looks like sudo is required now, trying to add this flag for travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ branches:
     - /^test-.*$/
 
 # container-based infrastructure
-sudo: false
+sudo: required
 
 addons:
   # make sure simplehttp simple verification works (custom /etc/hosts)


### PR DESCRIPTION
looks like sudo is required now, trying to add this flag so that travis CI tests pass.