### PR TITLE
Ability to suppress warning "Root (sudo) is required" in plugins [needs revision]

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -549,7 +549,11 @@ def record_chosen_plugins(config, plugins, auth, inst):
 
 def check_root_privileges(plugin):
     """Warns user about insufficient privileges."""
-    if plugin.is_root_required and not os.geteuid() == 0:
+    if not hasattr(plugin, 'is_root_required'):
+        return
+    if not plugin.is_root_required:
+        return
+    if not os.geteuid() == 0:
         logger.warning(
             "The plugin %s requires root privileges. "
             "Since you are not root (not using sudo) it may encounter errors.",

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -531,6 +531,11 @@ def choose_configurator_plugins(args, config, plugins, verb):  # pylint: disable
     if need_auth and not authenticator:
         diagnose_configurator_problem("authenticator", req_auth, plugins)
 
+    if need_inst:
+        check_root_privileges(installer)
+    if need_auth:
+        check_root_privileges(authenticator)
+
     record_chosen_plugins(config, plugins, authenticator, installer)
     return installer, authenticator
 
@@ -540,6 +545,15 @@ def record_chosen_plugins(config, plugins, auth, inst):
     cn = config.namespace
     cn.authenticator = plugins.find_init(auth).name if auth else "none"
     cn.installer = plugins.find_init(inst).name if inst else "none"
+
+
+def check_root_privileges(plugin):
+    """Warns user about insufficient privileges."""
+    if plugin.is_root_required and not os.geteuid() == 0:
+        logger.warning(
+            "The plugin %s requires root privileges. "
+            "Since you are not root (not using sudo) it may encounter errors.",
+            plugin.name)
 
 
 # TODO: Make run as close to auth + install as possible
@@ -1383,17 +1397,6 @@ def main(cli_args=sys.argv[1:]):
     report = reporter.Reporter()
     zope.component.provideUtility(report)
     atexit.register(report.atexit_print_messages)
-
-    if not os.geteuid() == 0:
-        logger.warning(
-            "Root (sudo) is required to run most of letsencrypt functionality.")
-        # check must be done after arg parsing as --help should work
-        # w/o root; on the other hand, e.g. "letsencrypt run
-        # --authenticator dns" or "letsencrypt plugins" does not
-        # require root as well
-        #return (
-        #    "{0}Root is required to run letsencrypt.  Please use sudo.{0}"
-        #    .format(os.linesep))
 
     return args.func(args, config, plugins)
 

--- a/letsencrypt/plugins/common.py
+++ b/letsencrypt/plugins/common.py
@@ -90,6 +90,16 @@ class Plugin(object):
 
         """
 
+    @property
+    def is_root_required(self):
+        """Is it necessary to warn user about insufficient privileges?
+
+        :returns: Whether the plugin requires root privileges
+        :rtype: bool
+
+        """
+        return True
+
 # other
 
 

--- a/letsencrypt/plugins/manual.py
+++ b/letsencrypt/plugins/manual.py
@@ -83,6 +83,11 @@ s.serve_forever()" """
                       else "/tmp/letsencrypt")
         self._httpd = None
 
+    @property
+    def is_root_required(self):
+        """Root privileges are not required."""
+        return False
+
     @classmethod
     def add_parser_arguments(cls, add):
         add("test-mode", action="store_true",

--- a/letsencrypt/plugins/manual_test.py
+++ b/letsencrypt/plugins/manual_test.py
@@ -103,6 +103,9 @@ class AuthenticatorTest(unittest.TestCase):
         self.auth_test_mode.cleanup(self.achalls)
         mock_killpg.assert_called_once_with(1234, signal.SIGTERM)
 
+    def test_is_root_required(self):
+        self.assertFalse(self.auth.is_root_required)
+
 
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover

--- a/letsencrypt/plugins/standalone_test.py
+++ b/letsencrypt/plugins/standalone_test.py
@@ -222,5 +222,8 @@ class AuthenticatorTest(unittest.TestCase):
             "server1": set(), "server2": set([])})
         self.auth.servers.stop.assert_called_with(2)
 
+    def test_is_root_required(self):
+        self.assertTrue(self.auth.is_root_required)
+
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover

--- a/letsencrypt/plugins/webroot.py
+++ b/letsencrypt/plugins/webroot.py
@@ -31,6 +31,11 @@ to serve all files under specified web root ({0})."""
     def more_info(self):  # pylint: disable=missing-docstring,no-self-use
         return self.MORE_INFO.format(self.conf("path"))
 
+    @property
+    def is_root_required(self):
+        """Root privileges are not required in most cases."""
+        return False
+
     @classmethod
     def add_parser_arguments(cls, add):
         # --webroot-path and --webroot-map are added in cli.py because they

--- a/letsencrypt/plugins/webroot_test.py
+++ b/letsencrypt/plugins/webroot_test.py
@@ -118,6 +118,9 @@ class AuthenticatorTest(unittest.TestCase):
         self.auth.cleanup([self.achall])
         self.assertFalse(os.path.exists(self.validation_path))
 
+    def test_is_root_required(self):
+        self.assertFalse(self.auth.is_root_required)
+
 
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -564,6 +564,11 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
         logger.addHandler(mock_handler)
         mock_uid.return_value = 1
 
+        plugin = mock.MagicMock()  # plugin may have no attribute
+        del plugin.is_root_required
+        cli.check_root_privileges(plugin)
+        mock_handler.handle.assert_not_called()
+
         plugin = mock.MagicMock(is_root_required=False)
         cli.check_root_privileges(plugin)
         mock_handler.handle.assert_not_called()


### PR DESCRIPTION
Some plugins do not require root privileges.
The warning is misleading, e.g. https://github.com/plesk/letsencrypt-plesk/issues/35
Proposed solution is to expose is_root_required property in order to check root privileges on demand.