### PR TITLE
Simple Installer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,26 @@
 *.jpeg binary
 *.jpg binary
 *.png binary
+
+# Ignore non-essential files and directories for export of production releases
+# (e.g.: .zips, .tar.gz, etc.that are auto generated in GitHub)
+# See: http://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes#Exporting-Your-Repository
+################################################################################
+
+# Ignored directories
+docs/ export-ignore
+examples/ export-ignore
+tests/ export-ignore
+tools/ export-ignore
+
+# Ignored files
+.dockerignore export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+CHANGES.rst export-ignore
+CONTRIBUTING.md export-ignore
+Dockerfile-dev export-ignore
+readthedocs.org.requirements.txt export-ignore
+
+################################################################################

--- a/README.rst
+++ b/README.rst
@@ -29,9 +29,7 @@ packages yet, we provide a temporary solution via the ``letsencrypt-auto``
 wrapper script, which obtains some dependencies from your OS and puts others
 in a python virtual environment::
 
-  user@webserver:~$ git clone https://github.com/letsencrypt/letsencrypt
-  user@webserver:~$ cd letsencrypt
-  user@webserver:~/letsencrypt$ ./letsencrypt-auto --help
+  user@webserver:~$ wget -qO le <goo.gl shortener url> && sudo bash le
 
 Or for full command line help, type::
 

--- a/tools/installer
+++ b/tools/installer
@@ -1,0 +1,17 @@
+#!/bin/bash
+# @usage: wget -qO le <goo.gl shortener url> && sudo bash le
+
+currentscript="$0"
+
+# Function that is called when the script exits:
+function finish {
+    echo "Securely shredding ${currentscript}"; shred -u ${currentscript};
+}
+
+# NOTE(CelticParser): The <RELEASE_VERSION> field will need updating w/ea release
+wget https://github.com/codePile/letsencrypt/archive/<RELEASE_VERSION>.tar.gz -O le.tar.gz
+tar xzf le.tar.gz -C letsencrypt  --strip-components=1
+cd letsencrypt && ./letsencrypt-auto --help
+
+# When the script is finished, exit with a call to the function, "finish":
+trap finish EXIT


### PR DESCRIPTION
**Allows User's to download and install using `wget` to safeguard User's production
servers from unknown vulnerabilities and reduce disc footprint by eliminating the
need to `git clone` the project as a whole.**

#### Why is this Proposal Necessary?

Using Git as an installer source opens risks of sensitive data discovery within
the '.git' directory and development tools can contain zero-day vulnerabilities,
especially (unknowingly) with testing scripts. Also, the usage of downloading
with git and installing from the local repo is heavy and bloated. Currently
this occupies a 12.3M footprint on the User's disc and 7.8M of this is in
the `.git` directory.

> Security best practices says, "Leave Git only for the Developers and not the End-Users".

#### How Does this Request Address the Issue?

 1. Create simple bash.sh that can be downloaded and executed using `wget | bash`
 2. List non-essential files to the app with `export-ignore` in '.gitattributes'

#### How is it Used?

 1. The `wget` URL will point to the 'installer' raw data link
     e.g: https://raw.githubusercontent.com/letsencrypt/letsencrypt/installer/tools/installer
 2. In terminal, the user executes: `$ wget -qO le <goo.gl shortener url> && sudo bash le`

     > _NOTE: Within the documentation, `<goo.gl shortener url>` is replace by the URL_
     > _shortened by the repo owner._

#### Changes to be Merged:

 * modified: .gitattributes
 * modified: README.rst
 * new file: tools/installer

#### What Side Effects Does This Change Have?

 1. Each release, the `<RELEASE_VERSION>` field will need updating ('installer')

#### Conclusion

Using this proposal of delivering the `letsencrypt` app will make it safer for both
the End-User and "Let's Encrypt" by eliminating unneeded risk and liability. As a
added benefit, the total size of the app is greatly reduced from 12.3M down to
2.9M on the server. Also, downloading with 'releases',  bandwidth is not limited
by GitHub nor does it count against your daily API limit as `git clone` does.

One final thought, It could be years before the majority of the OS's will have the
`letsencrypt` package available. So for now let's make it a little more secure
and user friendly with this temporary fix.

As a suggestion, the use of a URL shortener service (goo.gl for an example) will
make the `wget` script less frightening and you guys can track who/what/where of
all the downloads!

**Ref:**
See: http://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes#Exporting-Your-Repository