### PR TITLE
Suppress spurious output

### DIFF
--- a/bootstrap/_deb_common.sh
+++ b/bootstrap/_deb_common.sh
@@ -24,11 +24,11 @@ apt-get update
 # distro version (#346)
 
 virtualenv=
-if apt-cache show virtualenv > /dev/null ; then
+if apt-cache show virtualenv > /dev/null 2>&1; then
   virtualenv="virtualenv"
 fi
 
-if apt-cache show python-virtualenv > /dev/null ; then
+if apt-cache show python-virtualenv > /dev/null 2>&1; then
   virtualenv="$virtualenv python-virtualenv"
 fi
 


### PR DESCRIPTION
Suppress spurious output while testing for the presence of the virtualenv or python-virtualenv package.