### PR TITLE
When permissions don't work (maybe you're root), disable a unit test that assumes permissions work

### DIFF
--- a/letsencrypt/plugins/webroot_test.py
+++ b/letsencrypt/plugins/webroot_test.py
@@ -73,7 +73,7 @@ class AuthenticatorTest(unittest.TestCase):
         os.chmod(self.path, 0o000)
         try:
             open(permission_canary, "r")
-            print("Warning, running tests as root skips permissions tests...")
+            print "Warning, running tests as root skips permissions tests..."
         except IOError:
             # ok, permissions work, test away...
             self.assertRaises(errors.PluginError, self.auth.prepare)

--- a/letsencrypt/plugins/webroot_test.py
+++ b/letsencrypt/plugins/webroot_test.py
@@ -67,9 +67,8 @@ class AuthenticatorTest(unittest.TestCase):
     def test_prepare_reraises_other_errors(self):
         self.auth.full_path = os.path.join(self.path, "null")
         permission_canary = os.path.join(self.path, "rnd")
-        f = open(permission_canary, "w")
-        f.write("thingimy")
-        f.close()
+        with open(permission_canary, "w") as f:
+            f.write("thingimy")
         os.chmod(self.path, 0o000)
         try:
             open(permission_canary, "r")

--- a/letsencrypt/plugins/webroot_test.py
+++ b/letsencrypt/plugins/webroot_test.py
@@ -66,8 +66,17 @@ class AuthenticatorTest(unittest.TestCase):
 
     def test_prepare_reraises_other_errors(self):
         self.auth.full_path = os.path.join(self.path, "null")
+        permission_canary = os.path.join(self.path, "rnd")
+        f = open(permission_canary, "w")
+        f.write("thingimy")
+        f.close()
         os.chmod(self.path, 0o000)
-        self.assertRaises(errors.PluginError, self.auth.prepare)
+        try:
+            open(permission_canary, "r")
+            print("Warning, running tests as root skips permissions tests...")
+        except IOError:
+            # ok, permissions work, test away...
+            self.assertRaises(errors.PluginError, self.auth.prepare)
         os.chmod(self.path, 0o700)
 
     @mock.patch("letsencrypt.plugins.webroot.os.chown")


### PR DESCRIPTION
Fixes: #1979