### PR TITLE
OSX: check if augeas, dialog are already installed

### DIFF
--- a/bootstrap/mac.sh
+++ b/bootstrap/mac.sh
@@ -4,8 +4,15 @@ if ! hash brew 2>/dev/null; then
     ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 fi
 
-brew install augeas
-brew install dialog
+if [ -z "$(brew list --versions augeas)" ]; then
+    echo "augeas Not Installed\nInstalling augeas from Homebrew..."
+    brew install augeas
+fi
+
+if [ -z "$(brew list --versions dialog)" ]; then
+    echo "dialog Not Installed\nInstalling dialog from Homebrew..."
+    brew install dialog
+fi
 
 if ! hash pip 2>/dev/null; then
     echo "pip Not Installed\nInstalling python from Homebrew..."


### PR DESCRIPTION
This check avoids the following 2 noisy warnings:

    Warning: augeas-1.4.0 already installed
    Warning: dialog-1.2-20150528 already installed