### PR TITLE
Show error detail to the user.

### DIFF
--- a/letsencrypt/auth_handler.py
+++ b/letsencrypt/auth_handler.py
@@ -540,11 +540,11 @@ def _generate_failed_chall_msg(failed_achalls):
 
     """
     typ = failed_achalls[0].error.typ
-    msg = [
-        "The following errors were reported by the server:".format(typ)]
+    msg = ["The following errors were reported by the server:"]
 
     for achall in failed_achalls:
-        msg.append("\n\nDomain: %s\nType:   %s\nDetail: %s" % (achall.domain, achall.error.typ, achall.error.detail))
+        msg.append("\n\nDomain: %s\nType:   %s\nDetail: %s" % (
+            achall.domain, achall.error.typ, achall.error.detail))
 
     if typ in _ERROR_HELP:
         msg.append("\n\n")

--- a/letsencrypt/auth_handler.py
+++ b/letsencrypt/auth_handler.py
@@ -543,13 +543,8 @@ def _generate_failed_chall_msg(failed_achalls):
     msg = [
         "The following '{0}' errors were reported by the server:".format(typ)]
 
-    problems = dict()
     for achall in failed_achalls:
-        problems.setdefault(achall.error.description, set()).add(achall.domain)
-    for problem in problems:
-        msg.append("\n\nDomains: ")
-        msg.append(", ".join(sorted(problems[problem])))
-        msg.append("\nError: {0}".format(problem))
+        msg.append("\n\nDomain: %s\nDetail: %s\n" % (achall.domain, achall.error.detail))
 
     if typ in _ERROR_HELP:
         msg.append("\n\n")

--- a/letsencrypt/auth_handler.py
+++ b/letsencrypt/auth_handler.py
@@ -541,10 +541,10 @@ def _generate_failed_chall_msg(failed_achalls):
     """
     typ = failed_achalls[0].error.typ
     msg = [
-        "The following '{0}' errors were reported by the server:".format(typ)]
+        "The following errors were reported by the server:".format(typ)]
 
     for achall in failed_achalls:
-        msg.append("\n\nDomain: %s\nDetail: %s\n" % (achall.domain, achall.error.detail))
+        msg.append("\n\nDomain: %s\nType:   %s\nDetail: %s" % (achall.domain, achall.error.typ, achall.error.detail))
 
     if typ in _ERROR_HELP:
         msg.append("\n\n")

--- a/letsencrypt/tests/auth_handler_test.py
+++ b/letsencrypt/tests/auth_handler_test.py
@@ -467,7 +467,7 @@ class ReportFailedChallsTest(unittest.TestCase):
         auth_handler._report_failed_challs([self.http01, self.tls_sni_same])
         call_list = mock_zope().add_message.call_args_list
         self.assertTrue(len(call_list) == 1)
-        self.assertTrue("Domains: example.com\n" in call_list[0][0][0])
+        self.assertTrue("Domain: example.com\nDetail: detail" in call_list[0][0][0])
 
     @mock.patch("letsencrypt.auth_handler.zope.component.getUtility")
     def test_different_errors_and_domains(self, mock_zope):

--- a/letsencrypt/tests/auth_handler_test.py
+++ b/letsencrypt/tests/auth_handler_test.py
@@ -467,7 +467,7 @@ class ReportFailedChallsTest(unittest.TestCase):
         auth_handler._report_failed_challs([self.http01, self.tls_sni_same])
         call_list = mock_zope().add_message.call_args_list
         self.assertTrue(len(call_list) == 1)
-        self.assertTrue("Domain: example.com\nDetail: detail" in call_list[0][0][0])
+        self.assertTrue("Domain: example.com\nType:   tls\nDetail: detail" in call_list[0][0][0])
 
     @mock.patch("letsencrypt.auth_handler.zope.component.getUtility")
     def test_different_errors_and_domains(self, mock_zope):


### PR DESCRIPTION
Previously this code would show the user a hardcoded message based on the error
type, but it's much more useful to show the error detail field, which often
helps debug the problem.