### PR TITLE
Allow issuing certificates without authz-handshake

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -286,19 +286,18 @@ class Client(object):  # pylint: disable=too-many-instance-attributes
         # TODO: check and raise UnexpectedUpdate
         return updated_authzr, response
 
-    def request_issuance(self, csr, authzrs):
+    def request_issuance(self, csr, new_cert_uri):
         """Request issuance.
 
         :param csr: CSR
         :type csr: `OpenSSL.crypto.X509Req` wrapped in `.ComparableX509`
 
-        :param authzrs: `list` of `.AuthorizationResource`
+        :param new_cert_uri: new-cert URI
 
         :returns: Issued certificate
         :rtype: `.messages.CertificateResource`
 
         """
-        assert authzrs, "Authorizations list is empty"
         logger.debug("Requesting issuance...")
 
         # TODO: assert len(authzrs) == number of SANs
@@ -306,7 +305,7 @@ class Client(object):  # pylint: disable=too-many-instance-attributes
 
         content_type = self.DER_CONTENT_TYPE  # TODO: add 'cert_type 'argument
         response = self.net.post(
-            authzrs[0].new_cert_uri,  # TODO: acme-spec #90
+            new_cert_uri,
             req,
             content_type=content_type,
             headers={'Accept': content_type})
@@ -319,7 +318,7 @@ class Client(object):  # pylint: disable=too-many-instance-attributes
             raise errors.ClientError('"Location" Header missing')
 
         return messages.CertificateResource(
-            uri=uri, authzrs=authzrs, cert_chain_uri=cert_chain_uri,
+            uri=uri, cert_chain_uri=cert_chain_uri,
             body=jose.ComparableX509(OpenSSL.crypto.load_certificate(
                 OpenSSL.crypto.FILETYPE_ASN1, response.content)))
 

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -73,7 +73,7 @@ class ClientTest(unittest.TestCase):
 
         # Request issuance
         self.certr = messages.CertificateResource(
-            body=messages_test.CERT, authzrs=(self.authzr,),
+            body=messages_test.CERT,
             uri='https://www.letsencrypt-demo.org/acme/cert/1',
             cert_chain_uri='https://www.letsencrypt-demo.org/ca')
 
@@ -231,7 +231,7 @@ class ClientTest(unittest.TestCase):
         self.response.headers['Location'] = self.certr.uri
         self.response.links['up'] = {'url': self.certr.cert_chain_uri}
         self.assertEqual(self.certr, self.client.request_issuance(
-            messages_test.CSR, (self.authzr,)))
+            messages_test.CSR, self.certr.uri))
         # TODO: check POST args
 
     def test_request_issuance_missing_up(self):

--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -408,11 +408,9 @@ class CertificateResource(ResourceWithURI):
     :ivar acme.jose.util.ComparableX509 body:
         `OpenSSL.crypto.X509` wrapped in `.ComparableX509`
     :ivar unicode cert_chain_uri: URI found in the 'up' ``Link`` header
-    :ivar tuple authzrs: `tuple` of `AuthorizationResource`.
 
     """
     cert_chain_uri = jose.Field('cert_chain_uri')
-    authzrs = jose.Field('authzrs')
 
 
 @Directory.register

--- a/acme/acme/messages_test.py
+++ b/acme/acme/messages_test.py
@@ -338,7 +338,7 @@ class CertificateResourceTest(unittest.TestCase):
     def setUp(self):
         from acme.messages import CertificateResource
         self.certr = CertificateResource(
-            body=CERT, uri=mock.sentinel.uri, authzrs=(),
+            body=CERT, uri=mock.sentinel.uri,
             cert_chain_uri=mock.sentinel.cert_chain_uri)
 
     def test_json_de_serializable(self):

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -998,6 +998,10 @@ def prepare_and_parse_args(plugins, args):
         "automation", "--duplicate", dest="duplicate", action="store_true",
         help="Allow making a certificate lineage that duplicates an existing one "
              "(both can be renewed in parallel)")
+    helpful.add(
+        "automation", "--skip-authz", dest="skip_authz", action="store_true",
+        help="Skip domain authentication. This requires the domains to have been "
+             "authenticated in a previous run.")
 
     helpful.add_group(
         "testing", description="The following flags are meant for "

--- a/letsencrypt/client.py
+++ b/letsencrypt/client.py
@@ -221,11 +221,16 @@ class Client(object):
 
         logger.debug("CSR: %s, domains: %s", csr, domains)
 
-        authzr = self.auth_handler.get_authorizations(domains)
+        if not self.config.skip_authz:
+            authzrs = self.auth_handler.get_authorizations(domains)
+            certr_url = authzrs[0].new_cert_uri
+        else:
+            certr_url = self.acme.directory['new-cert']
+
         certr = self.acme.request_issuance(
             jose.ComparableX509(OpenSSL.crypto.load_certificate_request(
                 OpenSSL.crypto.FILETYPE_ASN1, csr.data)),
-            authzr)
+            certr_url)
         return certr, self.acme.fetch_chain(certr)
 
     def obtain_certificate_from_csr(self, csr):


### PR DESCRIPTION
I'm interested in a situation where there are two front-end webservers without shared filesystem, that each should have ssl certificates. Only one is serving at one time, the other is a hot spare. If I read the spec correctly, this should be possible by 
 - having the agent private key on both servers (one-time manual setup),
 - letting the active webserver run authentication for a given domain (new-authz)
 - have both webservers call new-cert

This patch adds a parameter --skip-authz which skips the authz
handshake. The intended use is a situation where the client
authorization and certificate generation happen on different machines.

To allow for this, some changes in acme were also necessary:
 - Client.request_issuance now directly takes new_cert_uri instead of
   authzrs
 - messages.CertificateResource no longer contains authzrs, as these
   do not necessarily exist without authz-handshake. As far as I could
   see, this parameter was unused.