### PR TITLE
The actual 0.1.1 release

### DIFF
--- a/letsencrypt-compatibility-test/setup.py
+++ b/letsencrypt-compatibility-test/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 
-version = '0.2.0.dev0'
+version = '0.1.1'
 
 install_requires = [
     'letsencrypt=={0}'.format(version),

--- a/letsencrypt/__init__.py
+++ b/letsencrypt/__init__.py
@@ -1,4 +1,4 @@
 """Let's Encrypt client."""
 
 # version number like 1.2.3a0, must have at least 2 parts, like 1.2
-__version__ = '0.2.0.dev0'
+__version__ = '0.1.1'


### PR DESCRIPTION
Due to bug #1966, the previous v0.1.1 tag was missing a version change to
letsencrypt/__init__.py this commit and the v0.1.1-corrected tag are the code
that was signed and uploaded to PyPI.