### PR TITLE
Set python version in the travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,16 @@ env:
   global:
     - GOPATH=/tmp/go
     - PATH=$GOPATH/bin:$PATH
-  matrix:
-    - TOXENV=py26 BOULDER_INTEGRATION=1
-    - TOXENV=py27 BOULDER_INTEGRATION=1
-    - TOXENV=lint
-    - TOXENV=cover
+matrix:
+  include:
+    - python: "2.6"
+      env: TOXENV=py26 BOULDER_INTEGRATION=1
+    - python: "2.7"
+      env: TOXENV=py27 BOULDER_INTEGRATION=1
+    - python: "2.7"
+      env: TOXENV=lint
+    - python: "2.7"
+      env: TOXENV=cover
 
 
 # Only build pushes to the master branch, PRs, and branches beginning with
@@ -44,7 +49,6 @@ addons:
     sources:
     - augeas
     packages:  # keep in sync with bootstrap/ubuntu.sh and Boulder
-    - python
     - python-dev
     - python-virtualenv
     - gcc


### PR DESCRIPTION
This commit enforce travis to test against python version 2.7.

In fact currently even if the file travis.yml specify to use python language, not specifying the version in the test matrix causes the environment to be not initialized/optimized for python testing as shown in the following screenshot:
![screenshot from 2015-12-27 12 54 09](https://cloud.githubusercontent.com/assets/217034/12010123/35e381f6-ac99-11e5-9150-bdd29b8d5b82.png)

I've also removed ```python``` from the manually installed packages, probably the same could be done for ```python-dev``` and ```python-virtualenv```