### PR TITLE
Enable TravisCI apt packages cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ branches:
 # container-based infrastructure
 sudo: false
 
+# enable apt packages caching in order to speed up builds
+cache: apt
+
 addons:
   # make sure simplehttp simple verification works (custom /etc/hosts)
   hosts:


### PR DESCRIPTION
This commit enable travisCI cachin for the apt packages so to speed up build timing.

Reference: https://docs.travis-ci.com/user/caching/