### PR TITLE
Allow old versions to fail gracefully

### DIFF
--- a/letsencrypt-auto
+++ b/letsencrypt-auto
@@ -100,7 +100,7 @@ DeterminePythonVersion() {
     exit 1
   fi
 
-  PYVER=`$LE_PYTHON --version 2>&1 | cut -d" " -f 2 | cut -d. -f1,2 | sed 's/\.//'`
+  PYVER=`$LE_PYTHON -V 2>&1 | cut -d" " -f 2 | cut -d. -f1,2 | sed 's/\.//'`
   if [ $PYVER -eq 26 ] ; then
     ExperimentalBootstrap "Python 2.6"
   elif [ $PYVER -lt 26 ] ; then


### PR DESCRIPTION
Context:
Old versions of python fail with bash test errors because `python --version` is not available for old versions of python.

```
./letsencrypt-auto: line 104: [: too many arguments
./letsencrypt-auto: line 106: [: too many arguments
```

Change:
Old and new versions of python support `-V` instead of `--version`. This allow them to pass the version tests and fail with 'ancient version' version message.