### PR TITLE
Better Nginx error handling.

### DIFF
--- a/letsencrypt-nginx/letsencrypt_nginx/configurator.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/configurator.py
@@ -311,17 +311,11 @@ class NginxConfigurator(common.Plugin):
         """
         snakeoil_cert, snakeoil_key = self._get_snakeoil_paths()
         ssl_block = [['listen', '{0} ssl'.format(self.config.tls_sni_01_port)],
-                     # access and error logs necessary for integration
-                     # testing (non-root)
-                     ['access_log', os.path.join(
-                         self.config.work_dir, 'access.log')],
-                     ['error_log', os.path.join(
-                         self.config.work_dir, 'error.log')],
                      ['ssl_certificate', snakeoil_cert],
                      ['ssl_certificate_key', snakeoil_key],
                      ['include', self.parser.loc["ssl_options"]]]
         self.parser.add_server_directives(
-            vhost.filep, vhost.names, ssl_block)
+            vhost.filep, vhost.names, ssl_block, replace=False)
         vhost.ssl = True
         vhost.raw.extend(ssl_block)
         vhost.addrs.add(obj.Addr(
@@ -384,7 +378,7 @@ class NginxConfigurator(common.Plugin):
             [['return', '301 https://$host$request_uri']]
         ]]
         self.parser.add_server_directives(
-            vhost.filep, vhost.names, redirect_block)
+            vhost.filep, vhost.names, redirect_block, replace=False)
         logger.info("Redirecting all traffic to ssl in %s", vhost.filep)
 
     ######################################
@@ -393,11 +387,10 @@ class NginxConfigurator(common.Plugin):
     def restart(self):
         """Restarts nginx server.
 
-        :returns: Success
-        :rtype: bool
+        :raises .errors.MisconfigurationError: If either the reload fails.
 
         """
-        return nginx_restart(self.conf('ctl'), self.nginx_conf)
+        nginx_restart(self.conf('ctl'), self.nginx_conf)
 
     def config_test(self):  # pylint: disable=no-self-use
         """Check the configuration of Nginx for errors.
@@ -631,18 +624,15 @@ def nginx_restart(nginx_ctl, nginx_conf="/etc/nginx.conf"):
 
             if nginx_proc.returncode != 0:
                 # Enter recovery routine...
-                logger.error("Nginx Restart Failed!\n%s\n%s", stdout, stderr)
-                return False
+                raise errors.MisconfigurationError(
+                    "nginx restart failed:\n%s\n%s" % (stdout, stderr))
 
     except (OSError, ValueError):
-        logger.fatal("Nginx Restart Failed - Please Check the Configuration")
-        sys.exit(1)
+        raise errors.MisconfigurationError("nginx restart failed")
     # Nginx can take a moment to recognize a newly added TLS SNI servername, so sleep
     # for a second. TODO: Check for expected servername and loop until it
     # appears or return an error if looping too long.
     time.sleep(1)
-
-    return True
 
 
 def temp_install(options_ssl):

--- a/letsencrypt-nginx/letsencrypt_nginx/parser.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/parser.py
@@ -518,8 +518,12 @@ def _add_directive(block, directive, replace):
         # Append directive. Fail if the name is not a repeatable directive name,
         # and there is already a copy of that directive with a different value
         # in the config file.
-        if location != -1 and directive[0].__str__() not in repeatable_directives:
-            if block[location][1] == directive[1]:
+        directive_name = directive[0]
+        directive_value = directive[1]
+        if location != -1 and directive_name.__str__() not in repeatable_directives:
+            if block[location][1] == directive_value:
+                # There's a conflict, but the existing value matches the one we
+                # want to insert, so it's fine.
                 pass
             else:
                 raise errors.MisconfigurationError(

--- a/letsencrypt-nginx/letsencrypt_nginx/tests/parser_test.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/tests/parser_test.py
@@ -127,7 +127,8 @@ class NginxParserTest(util.NginxTest):
                                       set(['localhost',
                                            r'~^(www\.)?(example|bar)\.']),
                                       [['foo', 'bar'], ['ssl_certificate',
-                                                        '/etc/ssl/cert.pem']])
+                                                        '/etc/ssl/cert.pem']],
+                                      replace=False)
         ssl_re = re.compile(r'\n\s+ssl_certificate /etc/ssl/cert.pem')
         dump = nginxparser.dumps(nparser.parsed[nparser.abs_path('nginx.conf')])
         self.assertEqual(1, len(re.findall(ssl_re, dump)))
@@ -136,12 +137,15 @@ class NginxParserTest(util.NginxTest):
         names = set(['alias', 'another.alias', 'somename'])
         nparser.add_server_directives(server_conf, names,
                                       [['foo', 'bar'], ['ssl_certificate',
-                                                        '/etc/ssl/cert2.pem']])
-        nparser.add_server_directives(server_conf, names, [['foo', 'bar']])
+                                                        '/etc/ssl/cert2.pem']],
+                                      replace=False)
+        nparser.add_server_directives(server_conf, names, [['foo', 'bar']],
+                                      replace=False)
         self.assertEqual(nparser.parsed[server_conf],
-                         [['ssl_certificate', '/etc/ssl/cert2.pem'],
+                         [['server_name', 'somename  alias  another.alias'],
                           ['foo', 'bar'],
-                          ['server_name', 'somename  alias  another.alias']])
+                          ['ssl_certificate', '/etc/ssl/cert2.pem']
+                          ])
 
     def test_add_http_directives(self):
         nparser = parser.NginxParser(self.config_path, self.ssl_options)
@@ -165,17 +169,19 @@ class NginxParserTest(util.NginxTest):
         target = set(['.example.com', 'example.*'])
         filep = nparser.abs_path('sites-enabled/example.com')
         nparser.add_server_directives(
-            filep, target, [['server_name', 'foo bar']], True)
+            filep, target, [['server_name', 'foobar.com']], replace=True)
         self.assertEqual(
             nparser.parsed[filep],
             [[['server'], [['listen', '69.50.225.155:9000'],
                            ['listen', '127.0.0.1'],
-                           ['server_name', 'foo bar'],
-                           ['server_name', 'foo bar']]]])
+                           ['server_name', 'foobar.com'],
+                           ['server_name', 'example.*'],
+                           ]]])
         self.assertRaises(errors.MisconfigurationError,
                           nparser.add_server_directives,
-                          filep, set(['foo', 'bar']),
-                          [['ssl_certificate', 'cert.pem']], True)
+                          filep, set(['foobar.com', 'example.*']),
+                          [['ssl_certificate', 'cert.pem']],
+                          replace=True)
 
     def test_get_best_match(self):
         target_name = 'www.eff.org'
@@ -217,7 +223,8 @@ class NginxParserTest(util.NginxTest):
                                       set(['.example.com', 'example.*']),
                                       [['ssl_certificate', 'foo.pem'],
                                        ['ssl_certificate_key', 'bar.key'],
-                                       ['listen', '443 ssl']])
+                                       ['listen', '443 ssl']],
+                                      replace=False)
         c_k = nparser.get_all_certs_keys()
         self.assertEqual(set([('foo.pem', 'bar.key', filep)]), c_k)
 

--- a/letsencrypt-nginx/tests/boulder-integration.conf.sh
+++ b/letsencrypt-nginx/tests/boulder-integration.conf.sh
@@ -20,13 +20,14 @@ events {
 }
 
 http {
-  # Set an array of temp and cache file options that will otherwise default to
+  # Set an array of temp, cache and log file options that will otherwise default to
   # restricted locations accessible only to root.
   client_body_temp_path $root/client_body;
   fastcgi_temp_path $root/fastcgi_temp;
   proxy_temp_path $root/proxy_temp;
   #scgi_temp_path $root/scgi_temp;
   #uwsgi_temp_path $root/uwsgi_temp;
+  access_log $root/error.log;
 
   # This should be turned off in a Virtualbox VM, as it can cause some
   # interesting issues with data corruption in delivered files.
@@ -53,9 +54,6 @@ http {
     listen [::]:8081 default ipv6only=on;
 
     root $root/webroot;
-
-    access_log $root/access.log;
-    error_log $root/error.log;
 
     location / {
       # First attempt to serve request as file, then as directory, then fall


### PR DESCRIPTION
Raise MisconfigurationError on restart failure, so we don't attempt to continue
with an authorization we know will fail.

Log at debug level the config files that are about to be written out, so it's
easier to debug restart failures.

Fix https://github.com/letsencrypt/letsencrypt/issues/942:
Error out if adding a conflicting directive.

Remove unnecessarily-inserted access_log and error_log directives. These were
added to make integration testing easier but are no longer needed. Incidentally
this makes the plugin work with some configs where it wouldn't have worked
previously.

Change the semantics of add_server_directives with replace=True so only the
first instance of a given directive is replaced, not all of them. This works
fine with the one place in the code that calls add_server_directives with
replace=True, because all of the involved directives aren't allowed to be
duplicated in a given block.

Make add_http_directives do inserts into the structure itself, since its needs
were significantly different than the more general add_server_directives. This
also allows us to narrow the scope of the `block.insert(0, directive)` hack that
we inserted to work around https://trac.nginx.org/nginx/ticket/810, since it's
only necessary for http blocks.