### PR TITLE
Don't error if the current_target is a hard file [needs revision]

### DIFF
--- a/letsencrypt/storage.py
+++ b/letsencrypt/storage.py
@@ -270,7 +270,10 @@ class RenewableCert(object):  # pylint: disable=too-many-instance-attributes
             logger.debug("Expected symlink %s for %s does not exist.",
                          link, kind)
             return None
-        target = os.readlink(link)
+        if os.path.islink(link):
+            target = os.readlink(link)
+        else:
+            target = link
         if not os.path.isabs(target):
             target = os.path.join(os.path.dirname(link), target)
         return os.path.abspath(target)

--- a/letsencrypt/storage.py
+++ b/letsencrypt/storage.py
@@ -274,7 +274,7 @@ class RenewableCert(object):  # pylint: disable=too-many-instance-attributes
         try:
             target = os.readlink(link)
         except OSError as e:
-            if not e.errno is errno.EINVAL:
+            if not e.errno == errno.EINVAL:
                 raise
             raise errors.CertStorageError(
                 'Expected %s to be a symlink to a file in %s, was a '

--- a/letsencrypt/storage.py
+++ b/letsencrypt/storage.py
@@ -270,10 +270,14 @@ class RenewableCert(object):  # pylint: disable=too-many-instance-attributes
             logger.debug("Expected symlink %s for %s does not exist.",
                          link, kind)
             return None
-        if os.path.islink(link):
+        try:
             target = os.readlink(link)
-        else:
-            target = link
+        except OSError as e:
+            logger.debug('Expected %s to be a symlink to a file in %s, was a'
+                         'hard file. Did you modify the letsencrypt directory?',
+                         link, self.cli_config.archive_dir)
+            raise
+
         if not os.path.isabs(target):
             target = os.path.join(os.path.dirname(link), target)
         return os.path.abspath(target)

--- a/letsencrypt/tests/renewer_test.py
+++ b/letsencrypt/tests/renewer_test.py
@@ -198,6 +198,16 @@ class RenewableCertTests(BaseRenewableCertTest):
                                                       "example.org",
                                                       "cert17.pem")))
 
+        # Users may scp the "live" dir somewhere and scp it back without
+        # realizing that the "live" dir contains symlinks. Test that the error
+        # message in this case is readable
+        os.unlink(self.test_rc.cert)
+        with open(self.test_rc.cert, "w") as f:
+            f.write("cert")
+        with self.assertRaises(errors.CertStorageError) as cm:
+            self.test_rc.current_target("cert"),
+        self.assertTrue('cert.pem to be a symlink' in cm.exception.message)
+
     def test_current_version(self):
         for ver in (1, 5, 10, 20):
             os.symlink(os.path.join("..", "..", "archive", "example.org",

--- a/letsencrypt/tests/renewer_test.py
+++ b/letsencrypt/tests/renewer_test.py
@@ -205,7 +205,7 @@ class RenewableCertTests(BaseRenewableCertTest):
         with open(self.test_rc.cert, "w") as f:
             f.write("cert")
         with self.assertRaises(errors.CertStorageError) as cm:
-            self.test_rc.current_target("cert"),
+            self.test_rc.current_target("cert")
         self.assertTrue('cert.pem to be a symlink' in cm.exception.message)
 
     def test_current_version(self):

--- a/letsencrypt/tests/renewer_test.py
+++ b/letsencrypt/tests/renewer_test.py
@@ -198,14 +198,6 @@ class RenewableCertTests(BaseRenewableCertTest):
                                                       "example.org",
                                                       "cert17.pem")))
 
-        # Non-symlink logic
-        os.unlink(self.test_rc.cert)
-        with open(self.test_rc.cert, "w") as f:
-            f.write("cert")
-        self.test_rc.current_target("cert")
-        self.assertTrue(os.path.samefile(self.test_rc.current_target("cert"),
-                                         self.test_rc.cert))
-
     def test_current_version(self):
         for ver in (1, 5, 10, 20):
             os.symlink(os.path.join("..", "..", "archive", "example.org",

--- a/letsencrypt/tests/renewer_test.py
+++ b/letsencrypt/tests/renewer_test.py
@@ -198,6 +198,14 @@ class RenewableCertTests(BaseRenewableCertTest):
                                                       "example.org",
                                                       "cert17.pem")))
 
+        # Non-symlink logic
+        os.unlink(self.test_rc.cert)
+        with open(self.test_rc.cert, "w") as f:
+            f.write("cert")
+        self.test_rc.current_target("cert")
+        self.assertTrue(os.path.samefile(self.test_rc.current_target("cert"),
+                                         self.test_rc.cert))
+
     def test_current_version(self):
         for ver in (1, 5, 10, 20):
             os.symlink(os.path.join("..", "..", "archive", "example.org",

--- a/letsencrypt/tests/renewer_test.py
+++ b/letsencrypt/tests/renewer_test.py
@@ -204,9 +204,8 @@ class RenewableCertTests(BaseRenewableCertTest):
         os.unlink(self.test_rc.cert)
         with open(self.test_rc.cert, "w") as f:
             f.write("cert")
-        with self.assertRaises(errors.CertStorageError) as cm:
-            self.test_rc.current_target("cert")
-        self.assertTrue('cert.pem to be a symlink' in cm.exception.message)
+        self.assertRaises(errors.CertStorageError,
+                          self.test_rc.current_target, "cert")
 
     def test_current_version(self):
         for ver in (1, 5, 10, 20):


### PR DESCRIPTION
In at least some scenarios when you run

```
letsencrypt certonly --webroot -w <directory> -d <domain>
```

The client exits with the error "OSError: [Errno 22] Invalid argument:
'/etc/letsencrypt/live/<other-domain>/cert.pem'". Particularly confusing is the
fact that this error message is from letsencrypt 1) attempting to read a file
that exists and 2) attempting to read a domain that's not related to the domain
being validated.

The error comes from the letsencrypt client attempting to find duplicate
certs, and resolve symlinks by calling `os.readlink`. However, in some cases
letsencrypt attempts to call `os.readlink` on a hard file, which throws an
error in Python.

Since `current_target` is only attempting to retrieve the path to the given
certificate, it seems safe enough to check if a file is a symlink before
attempting to dereference it with `os.readlink`.

I verified that this patch fixes the issue on my own server - without the
patch, I get the error in #2054 and with the patch, I'm able to get a
certificate.

Fixes https://github.com/letsencrypt/letsencrypt/issues/2054.