### PR TITLE
Update new_authzr_uri when querying or updating a registration

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -66,15 +66,13 @@ class Client(object):  # pylint: disable=too-many-instance-attributes
     @classmethod
     def _regr_from_response(cls, response, uri=None, new_authzr_uri=None,
                             terms_of_service=None):
-        terms_of_service = (
-            response.links['terms-of-service']['url']
-            if 'terms-of-service' in response.links else terms_of_service)
+        if 'terms-of-service' in response.links:
+            terms_of_service = response.links['terms-of-service']['url']
+        if 'next' in response.links:
+            new_authzr_uri = response.links['next']['url']
 
         if new_authzr_uri is None:
-            try:
-                new_authzr_uri = response.links['next']['url']
-            except KeyError:
-                raise errors.ClientError('"next" link missing')
+            raise errors.ClientError(response, 'missing "new_authrz_uri"')
 
         return messages.RegistrationResource(
             body=messages.Registration.from_json(response.json()),

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -72,7 +72,7 @@ class Client(object):  # pylint: disable=too-many-instance-attributes
             new_authzr_uri = response.links['next']['url']
 
         if new_authzr_uri is None:
-            raise errors.ClientError(response, 'missing "new_authrz_uri"')
+            raise errors.ClientError('"next" link missing')
 
         return messages.RegistrationResource(
             body=messages.Registration.from_json(response.json()),

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -127,6 +127,13 @@ class ClientTest(unittest.TestCase):
         self.response.json.return_value = self.regr.body.to_json()
         self.assertEqual(self.regr, self.client.query_registration(self.regr))
 
+    def test_query_registration_updates_new_authzr_uri(self):
+        self.response.json.return_value = self.regr.body.to_json()
+        self.response.links = {'next': {'url': 'UPDATED'}}
+        self.assertEqual(
+            'UPDATED',
+            self.client.query_registration(self.regr).new_authzr_uri)
+
     def test_agree_to_tos(self):
         self.client.update_registration = mock.Mock()
         self.client.agree_to_tos(self.regr)


### PR DESCRIPTION
Sets new_authzr_uri  in _reg_from_response if the link is available in the response.