### PR TITLE
Select broader wildcard matching pattern for augeas paths if overlapping

### DIFF
--- a/letsencrypt-apache/letsencrypt_apache/parser.py
+++ b/letsencrypt-apache/letsencrypt_apache/parser.py
@@ -500,18 +500,19 @@ class ApacheParser(object):
         """
 
         try:
-            use_new = False
-            remove_old = False
             new_file_match = os.path.basename(filepath)
             existing_match = self.parser_paths[os.path.dirname(filepath)]
-            if existing_match == new_file_match:
-                # True here to let augeas verify that the path is parsed
+            if existing_match == "*":
+                use_new = False
+            else:
                 use_new = True
-            elif new_file_match == "*":
-                use_new = True
+            if new_file_match == "*":
                 remove_old = True
+            else:
+                remove_old = False
         except KeyError:
             use_new = True
+            remove_old = False
         return use_new, remove_old
 
     def _remove_httpd_transform(self, filepath):

--- a/letsencrypt-apache/letsencrypt_apache/tests/parser_test.py
+++ b/letsencrypt-apache/letsencrypt_apache/tests/parser_test.py
@@ -36,7 +36,7 @@ class BasicParserTest(util.ParserTest):
 
         """
         file_path = os.path.join(
-            self.config_path, "sites-available", "letsencrypt.conf")
+            self.config_path, "not-parsed-by-default", "letsencrypt.conf")
 
         self.parser._parse_file(file_path)  # pylint: disable=protected-access
 


### PR DESCRIPTION
If multiple augeas paths are added for same FS directory under /augeas/load/Httpd/incl out of which one is a wildcard path, eg:

```
/etc/apache2/sites-enabled/*.conf
/etc/apache2/sites-enabled/*
```

augeas doesn't parse the files under the directory at all. This PR works around the problem by checking if a path with (full) wildcard already exists for the directory in question, and skips adding new, more specific ones if so. Also if a more specific ones are already found, and wildcard is being added, remove the existing more specific matching paths with only the wildcard path.

Fixes #1043

Examples before the modifications:

Does not work:
```
/etc/apache2/sites-enabled/*.conf
/etc/apache2/sites-enabled/*
```
Works:
```
/etc/apache2/sites-enabled/*.conf
/etc/apache2/sites-enabled/*.other
```

Ping @domcleal , I don't know if this is intended behaviour.