### PR TITLE
Warn the user when --chain-path or --fullchain-path are missing but are required [minor revision requested]

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -237,7 +237,9 @@ The following files are available:
   server certificate, i.e. root and intermediate certificates only.
 
   This is what Apache < 2.4.8 needs for `SSLCertificateChainFile
-  <https://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslcertificatechainfile>`_.
+  <https://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslcertificatechainfile>`_,
+  and what nginx >= 1.3.7 needs for `ssl_trusted_certificate
+  <http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_trusted_certificate>`_.
 
 ``fullchain.pem``
   All certificates, **including** server certificate. This is

--- a/letsencrypt-nginx/letsencrypt_nginx/configurator.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/configurator.py
@@ -181,7 +181,7 @@ class NginxConfigurator(common.Plugin):
         self.save_notes += ("Changed vhost at %s with addresses of %s\n" %
                             (vhost.filep,
                              ", ".join(str(addr) for addr in vhost.addrs)))
-        self.save_notes += "\tssl_certificate %s\n" % cert_path
+        self.save_notes += "\tssl_certificate %s\n" % fullchain_path
         self.save_notes += "\tssl_certificate_key %s\n" % key_path
 
     #######################

--- a/letsencrypt-nginx/letsencrypt_nginx/configurator.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/configurator.py
@@ -142,7 +142,8 @@ class NginxConfigurator(common.Plugin):
         """
         if not fullchain_path:
             raise errors.PluginError(
-                "--fullchain-path is required for nginx plugin.")
+                "The nginx plugin currently requires --fullchain-path to "
+                "install a cert.")
 
         vhost = self.choose_vhost(domain)
         cert_directives = [['ssl_certificate', fullchain_path],

--- a/letsencrypt-nginx/letsencrypt_nginx/configurator.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/configurator.py
@@ -140,6 +140,10 @@ class NginxConfigurator(common.Plugin):
             a lack of directives or configuration
 
         """
+        if not fullchain_path:
+            raise errors.PluginError(
+                "--fullchain-path is required for nginx plugin.")
+
         vhost = self.choose_vhost(domain)
         cert_directives = [['ssl_certificate', fullchain_path],
                            ['ssl_certificate_key', key_path]]

--- a/letsencrypt-nginx/letsencrypt_nginx/tests/configurator_test.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/tests/configurator_test.py
@@ -134,6 +134,15 @@ class NginxConfiguratorTest(util.NginxTest):
             None,
             "example/fullchain.pem")
 
+    def test_deploy_cert_requires_fullchain_path(self):
+        self.config.version = (1, 3, 1)
+        self.assertRaises(errors.PluginError, self.config.deploy_cert,
+            "www.example.com",
+            "example/cert.pem",
+            "example/key.pem",
+            "example/chain.pem",
+            None)
+
     def test_deploy_cert(self):
         server_conf = self.config.parser.abs_path('server.conf')
         nginx_conf = self.config.parser.abs_path('nginx.conf')

--- a/letsencrypt-nginx/letsencrypt_nginx/tests/configurator_test.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/tests/configurator_test.py
@@ -125,6 +125,15 @@ class NginxConfiguratorTest(util.NginxTest):
         self.assertTrue(util.contains_at_depth(generated_conf,
                                                ['ssl_trusted_certificate', 'example/chain.pem'], 2))
 
+    def test_deploy_cert_stapling_requires_chain_path(self):
+        self.config.version = (1, 3, 7)
+        self.assertRaises(errors.PluginError, self.config.deploy_cert,
+            "www.example.com",
+            "example/cert.pem",
+            "example/key.pem",
+            None,
+            "example/fullchain.pem")
+
     def test_deploy_cert(self):
         server_conf = self.config.parser.abs_path('server.conf')
         nginx_conf = self.config.parser.abs_path('nginx.conf')


### PR DESCRIPTION
Both options are not required as per `letsencrypt --help install`. The nginx plugin does not fail when they are required but missing, and generates a broken nginx configuration file instead.

See https://github.com/twstrike/letsencrypt/issues/3 and https://github.com/twstrike/letsencrypt/issues/5 for the original discussion.