### PR TITLE
Added some standard apache2 modules that make tests fail.

### DIFF
--- a/letsencrypt-apache/letsencrypt_apache/tests/testdata/debian_apache_2_4/two_vhost_80/apache2/mods-available/authz_svn.load
+++ b/letsencrypt-apache/letsencrypt_apache/tests/testdata/debian_apache_2_4/two_vhost_80/apache2/mods-available/authz_svn.load
@@ -1,0 +1,5 @@
+# Depends: dav_svn
+<IfModule !mod_dav_svn.c>
+    Include mods-enabled/dav_svn.load
+</IfModule>
+LoadModule authz_svn_module /usr/lib/apache2/modules/mod_authz_svn.so

--- a/letsencrypt-apache/letsencrypt_apache/tests/testdata/debian_apache_2_4/two_vhost_80/apache2/mods-available/dav.load
+++ b/letsencrypt-apache/letsencrypt_apache/tests/testdata/debian_apache_2_4/two_vhost_80/apache2/mods-available/dav.load
@@ -1,0 +1,3 @@
+<IfModule !mod_dav.c>
+	LoadModule dav_module /usr/lib/apache2/modules/mod_dav.so
+</IfModule>

--- a/letsencrypt-apache/letsencrypt_apache/tests/testdata/debian_apache_2_4/two_vhost_80/apache2/mods-available/dav_svn.conf
+++ b/letsencrypt-apache/letsencrypt_apache/tests/testdata/debian_apache_2_4/two_vhost_80/apache2/mods-available/dav_svn.conf
@@ -1,0 +1,56 @@
+# dav_svn.conf - Example Subversion/Apache configuration
+#
+# For details and further options see the Apache user manual and
+# the Subversion book.
+#
+# NOTE: for a setup with multiple vhosts, you will want to do this
+# configuration in /etc/apache2/sites-available/*, not here.
+
+# <Location URL> ... </Location>
+# URL controls how the repository appears to the outside world.
+# In this example clients access the repository as http://hostname/svn/
+# Note, a literal /svn should NOT exist in your document root.
+#<Location /svn>
+
+  # Uncomment this to enable the repository
+  #DAV svn
+
+  # Set this to the path to your repository
+  #SVNPath /var/lib/svn
+  # Alternatively, use SVNParentPath if you have multiple repositories under
+  # under a single directory (/var/lib/svn/repo1, /var/lib/svn/repo2, ...).
+  # You need either SVNPath and SVNParentPath, but not both.
+  #SVNParentPath /var/lib/svn
+
+  # Access control is done at 3 levels: (1) Apache authentication, via
+  # any of several methods.  A "Basic Auth" section is commented out
+  # below.  (2) Apache <Limit> and <LimitExcept>, also commented out
+  # below.  (3) mod_authz_svn is a svn-specific authorization module
+  # which offers fine-grained read/write access control for paths
+  # within a repository.  (The first two layers are coarse-grained; you
+  # can only enable/disable access to an entire repository.)  Note that
+  # mod_authz_svn is noticeably slower than the other two layers, so if
+  # you don't need the fine-grained control, don't configure it.
+
+  # Basic Authentication is repository-wide.  It is not secure unless
+  # you are using https.  See the 'htpasswd' command to create and
+  # manage the password file - and the documentation for the
+  # 'auth_basic' and 'authn_file' modules, which you will need for this
+  # (enable them with 'a2enmod').
+  #AuthType Basic
+  #AuthName "Subversion Repository"
+  #AuthUserFile /etc/apache2/dav_svn.passwd
+
+  # To enable authorization via mod_authz_svn (enable that module separately):
+  #<IfModule mod_authz_svn.c>
+  #AuthzSVNAccessFile /etc/apache2/dav_svn.authz
+  #</IfModule>
+
+  # The following three lines allow anonymous read, but make
+  # committers authenticate themselves.  It requires the 'authz_user'
+  # module (enable it with 'a2enmod').
+  #<LimitExcept GET PROPFIND OPTIONS REPORT>
+    #Require valid-user
+  #</LimitExcept> 
+
+#</Location>

--- a/letsencrypt-apache/letsencrypt_apache/tests/testdata/debian_apache_2_4/two_vhost_80/apache2/mods-available/dav_svn.load
+++ b/letsencrypt-apache/letsencrypt_apache/tests/testdata/debian_apache_2_4/two_vhost_80/apache2/mods-available/dav_svn.load
@@ -1,0 +1,7 @@
+# Depends: dav
+<IfModule !mod_dav_svn.c>
+    <IfModule !mod_dav.c>
+        Include mods-enabled/dav.load
+    </IfModule>
+    LoadModule dav_svn_module /usr/lib/apache2/modules/mod_dav_svn.so
+</IfModule>

--- a/letsencrypt-apache/letsencrypt_apache/tests/testdata/debian_apache_2_4/two_vhost_80/apache2/mods-enabled/authz_svn.load
+++ b/letsencrypt-apache/letsencrypt_apache/tests/testdata/debian_apache_2_4/two_vhost_80/apache2/mods-enabled/authz_svn.load
@@ -1,0 +1,1 @@
+../mods-available/authz_svn.load

--- a/letsencrypt-apache/letsencrypt_apache/tests/testdata/debian_apache_2_4/two_vhost_80/apache2/mods-enabled/dav.load
+++ b/letsencrypt-apache/letsencrypt_apache/tests/testdata/debian_apache_2_4/two_vhost_80/apache2/mods-enabled/dav.load
@@ -1,0 +1,1 @@
+../mods-available/dav.load

--- a/letsencrypt-apache/letsencrypt_apache/tests/testdata/debian_apache_2_4/two_vhost_80/apache2/mods-enabled/dav_svn.conf
+++ b/letsencrypt-apache/letsencrypt_apache/tests/testdata/debian_apache_2_4/two_vhost_80/apache2/mods-enabled/dav_svn.conf
@@ -1,0 +1,1 @@
+../mods-available/dav_svn.conf

--- a/letsencrypt-apache/letsencrypt_apache/tests/testdata/debian_apache_2_4/two_vhost_80/apache2/mods-enabled/dav_svn.load
+++ b/letsencrypt-apache/letsencrypt_apache/tests/testdata/debian_apache_2_4/two_vhost_80/apache2/mods-enabled/dav_svn.load
@@ -1,0 +1,1 @@
+../mods-available/dav_svn.load


### PR DESCRIPTION
letsencrypt failed on our server when parsing our apache2.4 config (see below). It turned out that the files where the error happens are standard apache2 modules. Therefore we added the module configuration that triggers the failure. Now many tests fail with "AttributeError: 'NoneType' object has no attribute 'lower'" in letsencrypt_apache/parser.py", line 311.
Thanks for providing this great project!
