### PR TITLE
letsencrypt-auto: prevent recording of deps in Gentoo's world set

### DIFF
--- a/bootstrap/_gentoo_common.sh
+++ b/bootstrap/_gentoo_common.sh
@@ -12,12 +12,12 @@ PACKAGES="
 
 case "$PACKAGE_MANAGER" in
   (paludis)
-    cave resolve --keep-targets if-possible $PACKAGES -x
+    cave resolve --preserve-world --keep-targets if-possible $PACKAGES -x
     ;;
   (pkgcore)
-    pmerge --noreplace $PACKAGES
+    pmerge --noreplace --oneshot $PACKAGES
     ;;
   (portage|*)
-    emerge --noreplace $PACKAGES
+    emerge --noreplace --oneshot $PACKAGES
     ;;
 esac

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -378,20 +378,49 @@ Packages for Debian Jessie are coming in the next few weeks.
 
 **Gentoo**
 
+The official Let's Encrypt client is available in Gentoo Portage. If you
+want to use the Apache plugin, it has to be installed separately:
+
 .. code-block:: shell
 
    emerge -av app-crypt/letsencrypt
+   emerge -av app-crypt/letsencrypt-apache
 
-Currently, the Apache and nginx plugins are not included in Portage. You can
-however use Layman to add the mrueg overlay which does include the plugin
-packages:
+Currently, only the Apache plugin is included in Portage. However, if you 
+want the nginx plugin, you can use Layman to add the mrueg overlay which 
+does include the nginx plugin package:
 
 .. code-block:: shell
 
    emerge -av app-portage/layman
    layman -S
    layman -a mrueg
-   emerge -av app-crypt/letsencrypt-apache app-crypt/letsencrypt-nginx
+   emerge -av app-crypt/letsencrypt-nginx
+
+When using the Apache plugin, you will run into a "cannot find a cert or key 
+directive" error if you're sporting the default Gentoo ``httpd.conf``.
+You can fix this by commenting out two lines in ``/etc/apache2/httpd.conf`` 
+as follows:
+
+Change
+
+.. code-block:: shell
+
+   <IfDefine SSL>
+   LoadModule ssl_module modules/mod_ssl.so
+   </IfDefine>
+
+to
+
+.. code-block:: shell
+
+   #<IfDefine SSL>
+   LoadModule ssl_module modules/mod_ssl.so
+   #</IfDefine>
+
+For the time being, this is the only way for the Apache plugin to recognise 
+the appropriate directives when installing the certificate.
+Note: this change is not required for the other plugins.
 
 **Other Operating Systems**
 

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -64,7 +64,7 @@ or for full help, type:
 
 ``letsencrypt-auto`` is the recommended method of running the Let's Encrypt
 client beta releases on systems that don't have a packaged version.  Debian,
-Arch linux, FreeBSD, and OpenBSD now have native packages, so on those
+Arch linux, Gentoo, FreeBSD, and OpenBSD now have native packages, so on those
 systems you can just install ``letsencrypt`` (and perhaps
 ``letsencrypt-apache``).  If you'd like to run the latest copy from Git, or
 run your own locally modified copy of the client, follow the instructions in
@@ -375,6 +375,23 @@ If you don't want to use the Apache plugin, you can omit the
 ``python-letsencrypt-apache`` package.
 
 Packages for Debian Jessie are coming in the next few weeks.
+
+**Gentoo**
+
+.. code-block:: shell
+
+   emerge -av app-crypt/letsencrypt
+
+Currently, the Apache and nginx plugins are not included in Portage. You can
+however use Layman to add the mrueg overlay which does include the plugin
+packages:
+
+.. code-block:: shell
+
+   emerge -av app-portage/layman
+   layman -S
+   layman -a mrueg
+   emerge -av app-crypt/letsencrypt-apache app-crypt/letsencrypt-nginx
 
 **Other Operating Systems**
 


### PR DESCRIPTION
(This is a second attempt of a previous PR I made and consequently f*cked up.. I closed that one.. :stuck_out_tongue: This one is with `git` on my local machine, so hopefully any conflicts/upstream master merging/whatever won't FUBAR it anymore.. :disappointed: )

Dependencies shouldn't be recorded into Gentoos [world set](https://wiki.gentoo.org/wiki/World_set_(Portage)). The current single switch to `emerge` "--noreplace" makes sure already installed dependencies are explicitly recorded into the world set, which isn't desirable. Adding "--oneshot" prevents this behaviour.
Cave: I have absolutely no clue how Paludis works. It's [manual](http://paludis.exherbo.org//clients/cave-resolve.html) and an entry in their [news](http://paludis.exherbo.org/news.html) (0.26.0_pre3) suggests --preserve-world should do the trick.

(Credits: [till.schaefer](https://community.letsencrypt.org/t/gentoo-letsencrypt-should-not-automatically-record-packages-to-the-world-config-file/7252))

By the way: Gentoo has a [native package](https://packages.gentoo.org/packages/app-crypt/letsencrypt) since Dec 3.