### PR TITLE
Don't use cryptography version 1.2

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -9,7 +9,7 @@ version = '0.2.0.dev0'
 install_requires = [
     # load_pem_private/public_key (>=0.6)
     # rsa_recover_prime_factors (>=0.8)
-    'cryptography>=0.8',
+    'cryptography>=0.8,<1.2',
     # Connection.set_tlsext_host_name (>=0.13), X509Req.get_extensions (>=0.15)
     'PyOpenSSL>=0.15',
     'pyrfc3339',

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ version = meta['version']
 install_requires = [
     'acme=={0}'.format(version),
     'configobj',
-    'cryptography>=0.7',  # load_pem_x509_certificate
+    'cryptography>=0.7,<1.2',  # load_pem_x509_certificate
     'parsedatetime',
     'psutil>=2.1.0',  # net_connections introduced in 2.1.0
     'PyOpenSSL',


### PR DESCRIPTION
PyOpenSSL fails when using this version on Ubuntu 12.04.5 (Travis). I modified `setup.py` to install an older version of cryptography until pyca/pyopenssl#407 is resolved. Once it is, these changes should be reverted.