### PR TITLE
Python 3 Travis testing for acme.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,15 @@ env:
     - TOXENV=py27 BOULDER_INTEGRATION=1
     - TOXENV=py33
     - TOXENV=py34
-    - TOXENV=py35
     - TOXENV=lint
     - TOXENV=cover
 # Disabled for now due to requiring sudo -> causing more boulder integration
 # DNS timeouts :(
 #    - TOXENV=apacheconftest
+matrix:
+  include:
+    - env: TOXENV=py35
+      python: 3.5
 
 
 # Only build pushes to the master branch, PRs, and branches beginning with

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ env:
   matrix:
     - TOXENV=py26 BOULDER_INTEGRATION=1
     - TOXENV=py27 BOULDER_INTEGRATION=1
+    - TOXENV=py33
+    - TOXENV=py34
+    - TOXENV=py35
     - TOXENV=lint
     - TOXENV=cover
 # Disabled for now due to requiring sudo -> causing more boulder integration

--- a/acme/setup.py
+++ b/acme/setup.py
@@ -66,6 +66,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Security',
     ],


### PR DESCRIPTION
Despite its description, https://github.com/letsencrypt/letsencrypt/pull/630, removed not only Python 2.6 support, but also Travis tests against Python 3. ACME library supports Python 3 and Travis should tests it.

This must be merged before any pending PRs against acme library.