### PR TITLE
Default: renew 30 days before expiry, rather than 10

### DIFF
--- a/letsencrypt/storage.py
+++ b/letsencrypt/storage.py
@@ -565,7 +565,8 @@ class RenewableCert(object):  # pylint: disable=too-many-instance-attributes
                 return True
 
             # Renews some period before expiry time
-            interval = self.configuration.get("renew_before_expiry", "30 days")
+            default_interval = constants.RENEWER_DEFAULTS["renew_before_expiry"]
+            interval = self.configuration.get("renew_before_expiry", default_interval)
             expiry = crypto_util.notAfter(self.version(
                 "cert", self.latest_common_version()))
             now = pytz.UTC.fromutc(datetime.datetime.utcnow())

--- a/letsencrypt/storage.py
+++ b/letsencrypt/storage.py
@@ -564,7 +564,7 @@ class RenewableCert(object):  # pylint: disable=too-many-instance-attributes
                 logger.debug("Should renew, certificate is revoked.")
                 return True
 
-            # Renewals on the basis of expiry time
+            # Renews some period before expiry time
             interval = self.configuration.get("renew_before_expiry", "30 days")
             expiry = crypto_util.notAfter(self.version(
                 "cert", self.latest_common_version()))

--- a/letsencrypt/storage.py
+++ b/letsencrypt/storage.py
@@ -565,7 +565,7 @@ class RenewableCert(object):  # pylint: disable=too-many-instance-attributes
                 return True
 
             # Renewals on the basis of expiry time
-            interval = self.configuration.get("renew_before_expiry", "10 days")
+            interval = self.configuration.get("renew_before_expiry", "30 days")
             expiry = crypto_util.notAfter(self.version(
                 "cert", self.latest_common_version()))
             now = pytz.UTC.fromutc(datetime.datetime.utcnow())


### PR DESCRIPTION
 - gives more time for various fallback strategies if renewal doesn't work the
   first time