### PR TITLE
Search all paths included from across the configuration for VirtualHosts

### DIFF
--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -488,15 +488,27 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         :rtype: list
 
         """
-        # Search vhost-root, httpd.conf for possible virtual hosts
-        paths = self.aug.match(
-            ("/files%s//*[label()=~regexp('%s')]" %
-             (self.conf("vhost-root"), parser.case_i("VirtualHost"))))
-
+        # Search base config, and all included paths for VirtualHosts
         vhs = []
+        vhost_paths = {}
+        for vhost_path in self.parser.parser_paths.keys():
+            paths = self.aug.match(
+                ("/files%s//*[label()=~regexp('%s')]" %
+                    (vhost_path, parser.case_i("VirtualHost"))))
+            for path in paths:
+                new_vhost = self._create_vhost(path)
+                realpath = os.path.realpath(new_vhost.filep)
+                if realpath not in vhost_paths.keys():
+                    vhs.append(new_vhost)
+                    vhost_paths[realpath] = new_vhost.filep
+                elif realpath == new_vhost.filep:
+                    # Prefer "real" vhost paths instead of symlinked ones
+                    # ex: sites-enabled/vh.conf -> sites-available/vh.conf
 
-        for path in paths:
-            vhs.append(self._create_vhost(path))
+                    # remove old (most likely) symlinked one
+                    vhs = [v for v in vhs if v.filep != vhost_paths[realpath]]
+                    vhs.append(new_vhost)
+                    vhost_paths[realpath] = realpath
 
         return vhs
 

--- a/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
+++ b/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
@@ -128,20 +128,10 @@ class TwoVhost80Test(util.ApacheTest):
         self.assertEqual(found, 6)
 
         # Handle case of non-debian layout get_virtual_hosts
-        orig_conf = self.config.conf
         with mock.patch(
                 "letsencrypt_apache.configurator.ApacheConfigurator.conf"
-        )  as mock_conf:
-            def conf_sideeffect(key):
-                """Handle calls to configurator.conf()
-                :param key: configuration key
-                :return: configuration value
-                """
-                if key == "handle-sites":
-                    return False
-                else:
-                    return orig_conf(key)
-            mock_conf.side_effect = conf_sideeffect
+        ) as mock_conf:
+            mock_conf.return_value = False
             vhs = self.config.get_virtual_hosts()
             self.assertEqual(len(vhs), 6)
 


### PR DESCRIPTION
Follow the includes in apache configuration to search for the VirtualHost configurations. With this patch we will be able to find the paths in users active configuration, and not being restricted to single directories  for virtualhost files.

Fixes #1043