### PR TITLE
ACME: default to new_authzr_uri from Directory [needs revision]

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -181,40 +181,41 @@ class Client(object):  # pylint: disable=too-many-instance-attributes
             raise errors.UnexpectedUpdate(authzr)
         return authzr
 
-    def request_challenges(self, identifier, new_authzr_uri):
+    def request_challenges(self, identifier, new_authzr_uri=None):
         """Request challenges.
 
-        :param identifier: Identifier to be challenged.
-        :type identifier: `.messages.Identifier`
-
-        :param str new_authzr_uri: new-authorization URI
+        :param .messages.Identifier identifier: Identifier to be challenged.
+        :param str new_authzr_uri: ``new-authorization`` URI. If omitted,
+            will default to value found in ``directory``.
 
         :returns: Authorization Resource.
         :rtype: `.AuthorizationResource`
 
         """
         new_authz = messages.NewAuthorization(identifier=identifier)
-        response = self.net.post(new_authzr_uri, new_authz)
+        response = self.net.post(self.directory.new_authz
+                                 if new_authzr_uri is None else new_authzr_uri,
+                                 new_authz)
         # TODO: handle errors
         assert response.status_code == http_client.CREATED
         return self._authzr_from_response(response, identifier)
 
-    def request_domain_challenges(self, domain, new_authz_uri):
+    def request_domain_challenges(self, domain, new_authzr_uri=None):
         """Request challenges for domain names.
 
         This is simply a convenience function that wraps around
         `request_challenges`, but works with domain names instead of
-        generic identifiers.
+        generic identifiers. See ``request_challenges`` for more
+        documentation.
 
         :param str domain: Domain name to be challenged.
-        :param str new_authzr_uri: new-authorization URI
 
         :returns: Authorization Resource.
         :rtype: `.AuthorizationResource`
 
         """
         return self.request_challenges(messages.Identifier(
-            typ=messages.IDENTIFIER_FQDN, value=domain), new_authz_uri)
+            typ=messages.IDENTIFIER_FQDN, value=domain), new_authzr_uri)
 
     def answer_challenge(self, challb, response):
         """Answer challenge.

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -36,6 +36,7 @@ class ClientTest(unittest.TestCase):
         self.directory = messages.Directory({
             messages.NewRegistration: 'https://www.letsencrypt-demo.org/acme/new-reg',
             messages.Revocation: 'https://www.letsencrypt-demo.org/acme/revoke-cert',
+            messages.NewAuthorization: 'https://www.letsencrypt-demo.org/acme/new-authz',
         })
 
         from acme.client import Client
@@ -133,7 +134,7 @@ class ClientTest(unittest.TestCase):
         regr = self.client.update_registration.call_args[0][0]
         self.assertEqual(self.regr.terms_of_service, regr.body.agreement)
 
-    def test_request_challenges(self):
+    def _prepare_response_for_request_challenges(self):
         self.response.status_code = http_client.CREATED
         self.response.headers['Location'] = self.authzr.uri
         self.response.json.return_value = self.authz.to_json()
@@ -141,10 +142,20 @@ class ClientTest(unittest.TestCase):
             'next': {'url': self.authzr.new_cert_uri},
         }
 
-        self.client.request_challenges(self.identifier, self.authzr.uri)
-        # TODO: test POST call arguments
+    def test_request_challenges(self):
+        self._prepare_response_for_request_challenges()
+        self.client.request_challenges(self.identifier)
+        self.net.post.assert_called_once_with(
+            self.directory.new_authz,
+            messages.NewAuthorization(identifier=self.identifier))
 
-        # TODO: split here and separate test
+    def test_requets_challenges_custom_uri(self):
+        self._prepare_response_for_request_challenges()
+        self.client.request_challenges(self.identifier, 'URI')
+        self.net.post.assert_called_once_with('URI', mock.ANY)
+
+    def test_request_challenges_unexpected_update(self):
+        self._prepare_response_for_request_challenges()
         self.response.json.return_value = self.authz.update(
             identifier=self.identifier.update(value='foo')).to_json()
         self.assertRaises(
@@ -153,15 +164,20 @@ class ClientTest(unittest.TestCase):
 
     def test_request_challenges_missing_next(self):
         self.response.status_code = http_client.CREATED
-        self.assertRaises(
-            errors.ClientError, self.client.request_challenges,
-            self.identifier, self.regr)
+        self.assertRaises(errors.ClientError, self.client.request_challenges,
+                          self.identifier)
 
     def test_request_domain_challenges(self):
         self.client.request_challenges = mock.MagicMock()
         self.assertEqual(
             self.client.request_challenges(self.identifier),
-            self.client.request_domain_challenges('example.com', self.regr))
+            self.client.request_domain_challenges('example.com'))
+
+    def test_request_domain_challenges_custom_uri(self):
+        self.client.request_challenges = mock.MagicMock()
+        self.assertEqual(
+            self.client.request_challenges(self.identifier, 'URI'),
+            self.client.request_domain_challenges('example.com', 'URI'))
 
     def test_answer_challenge(self):
         self.response.links['up'] = {'url': self.challr.authzr_uri}


### PR DESCRIPTION
Had to clean up tests at the same time. It looks like `regr` wasn't changed to `new_authzr_uri` even...