### PR TITLE
Always install ndg-httpsclient and pyasn1

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -11,6 +11,8 @@ install_requires = [
     # load_pem_private/public_key (>=0.6)
     # rsa_recover_prime_factors (>=0.8)
     'cryptography>=0.8',
+    'ndg-httpsclient',  # urllib3 InsecurePlatformWarning (#304)
+    'pyasn1',  # urllib3 InsecurePlatformWarning (#304)
     # Connection.set_tlsext_host_name (>=0.13)
     'PyOpenSSL>=0.13',
     'pyrfc3339',
@@ -30,11 +32,6 @@ if sys.version_info < (2, 7):
     ])
 else:
     install_requires.append('mock')
-
-if sys.version_info < (2, 7, 9):
-    # For secure SSL connection with Python 2.7 (InsecurePlatformWarning)
-    install_requires.append('ndg-httpsclient')
-    install_requires.append('pyasn1')
 
 docs_extras = [
     'Sphinx>=1.0',  # autodoc_member_order = 'bysource', autodoc_default_flags

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ version = meta['version']
 # Please update tox.ini when modifying dependency version requirements
 install_requires = [
     'acme=={0}'.format(version),
+    'ConfigArgParse>=0.10.0',  # python2.6 support, upstream #17
     'configobj',
     'cryptography>=0.7',  # load_pem_x509_certificate
     'parsedatetime',
@@ -52,12 +53,10 @@ if sys.version_info < (2, 7):
     install_requires.extend([
         # only some distros recognize stdlib argparse as already satisfying
         'argparse',
-        'ConfigArgParse>=0.10.0',  # python2.6 support, upstream #17
         'mock<1.1.0',
     ])
 else:
     install_requires.extend([
-        'ConfigArgParse',
         'mock',
     ])
 


### PR DESCRIPTION
Solution to #2175 for `0.2.0`. We can reconsider making these dependencies conditional in the next release after more testing.