### PR TITLE
Revert "Temporarily disable Apache 2.2 support"

### DIFF
--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -155,7 +155,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         # Set Version
         if self.version is None:
             self.version = self.get_version()
-        if self.version < (2, 4):
+        if self.version < (2, 2):
             raise errors.NotSupportedError(
                 "Apache Version %s not supported.", str(self.version))
 


### PR DESCRIPTION
Objective: reenable Apache 2.2 support for 0.2.1.  My instinct is that we should land this and then hopefully @SwartzCr can get 2.2 working in another PR.