### PR TITLE
Csrdoc

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -1086,7 +1086,8 @@ def _create_subparsers(helpful):
                 "--csr", type=read_file,
                 help="Path to a Certificate Signing Request (CSR) in DER"
                 " format; note that the .csr file *must* contain a Subject"
-                " Alternative Name field for each domain you want certified.")
+                " Alternative Name field for each domain you want certified."
+                " Currently --csr only works with the 'certonly' subcommand'")
     helpful.add("rollback",
                 "--checkpoints", type=int, metavar="N",
                 default=flag_default("rollback_checkpoints"),


### PR DESCRIPTION
Document that --csr only works with "certonly".  Partially mitigates #2206.