### PR TITLE
Reorder travis tests for performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,10 @@ env:
     - TOXENV=py27 BOULDER_INTEGRATION=1
     - TOXENV=py26-oldest BOULDER_INTEGRATION=1
     - TOXENV=py27-oldest BOULDER_INTEGRATION=1
-    - TOXENV=py33
-    - TOXENV=py34
     - TOXENV=lint
     - TOXENV=cover
+    - TOXENV=py33
+    - TOXENV=py34
 # Disabled for now due to requiring sudo -> causing more boulder integration
 # DNS timeouts :(
 #    - TOXENV=apacheconftest


### PR DESCRIPTION
 - lint is slow, so get started on it earlier
 - py33 and py34 are fast, so it's fine if they start very late