### PR TITLE
Bump version number

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 
-version = '0.2.0.dev0'
+version = '0.2.1.dev0'
 
 # Please update tox.ini when modifying dependency version requirements
 install_requires = [

--- a/letsencrypt-apache/setup.py
+++ b/letsencrypt-apache/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 
-version = '0.2.0.dev0'
+version = '0.2.1.dev0'
 
 # Please update tox.ini when modifying dependency version requirements
 install_requires = [

--- a/letsencrypt-compatibility-test/setup.py
+++ b/letsencrypt-compatibility-test/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 
-version = '0.2.0.dev0'
+version = '0.2.1.dev0'
 
 install_requires = [
     'letsencrypt=={0}'.format(version),

--- a/letsencrypt-nginx/setup.py
+++ b/letsencrypt-nginx/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 
-version = '0.2.0.dev0'
+version = '0.2.1.dev0'
 
 # Please update tox.ini when modifying dependency version requirements
 install_requires = [

--- a/letsencrypt/__init__.py
+++ b/letsencrypt/__init__.py
@@ -1,4 +1,4 @@
 """Let's Encrypt client."""
 
 # version number like 1.2.3a0, must have at least 2 parts, like 1.2
-__version__ = '0.2.0.dev0'
+__version__ = '0.2.1.dev0'

--- a/letshelp-letsencrypt/setup.py
+++ b/letshelp-letsencrypt/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 
-version = '0.2.0.dev0'
+version = '0.2.1.dev0'
 
 install_requires = [
     'setuptools',  # pkg_resources


### PR DESCRIPTION
Bumps version number to `0.2.1.dev0`. For the time being, pde and I decided to always bump the patch version while doing releases. This prevents us from deciding on the next version number before the release is ready and aims to be more conservative (instead of creating `1.0.0.dev0` and then releasing `0.3.0.dev0`).

I believe this should be preferred over #2199 because we have never included the non-dev version number in git history before (at least Kuba or I never did). Instead, the non-dev version simply exists in a tag as a reference.