### PR TITLE
Support trailing period in domain names

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -1196,10 +1196,9 @@ def _plugins_parsing(helpful, plugins):
                      "handle different domains; each domain will have the webroot path that"
                      " preceded it.  For instance: `-w /var/www/example -d example.com -d "
                      "www.example.com -w /var/www/thing -d thing.net -d m.thing.net`")
-    parse_dict = lambda s: dict(json.loads(s))
     # --webroot-map still has some awkward properties, so it is undocumented
-    helpful.add("webroot", "--webroot-map", default={}, type=parse_dict,
-                help=argparse.SUPPRESS)
+    helpful.add("webroot", "--webroot-map", default={},
+                action=WebrootMapProcessor, help=argparse.SUPPRESS)
 
 
 class WebrootPathProcessor(argparse.Action): # pylint: disable=missing-docstring
@@ -1227,6 +1226,14 @@ class WebrootPathProcessor(argparse.Action): # pylint: disable=missing-docstring
             raise errors.Error("If you specify multiple webroot paths, one of "
                                "them must precede all domain flags")
         config.webroot_path.append(webroot)
+
+
+class WebrootMapProcessor(argparse.Action): # pylint: disable=missing-docstring
+    def __call__(self, parser, config, webroot_map_arg, option_string=None):
+        webroot_map = json.loads(webroot_map_arg)
+        for domain, webroot in webroot_map.iteritems():
+            domain = domain[:-1] if domain.endswith('.') else domain
+            config.webroot_map[domain] = webroot
 
 
 class DomainFlagProcessor(argparse.Action): # pylint: disable=missing-docstring

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -1236,6 +1236,7 @@ class DomainFlagProcessor(argparse.Action): # pylint: disable=missing-docstring
         {domain : webrootpath} if -w / --webroot-path is in use
         """
         for domain in (d.strip() for d in domain_arg.split(",")):
+            domain = domain[:-1] if domain.endswith('.') else domain
             if domain not in config.domains:
                 config.domains.append(domain)
                 # Each domain has a webroot_path of the most recent -w flag

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -379,9 +379,11 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
         webroot_args = ['-d', 'stray.example.com'] + webroot_args
         self.assertRaises(errors.Error, cli.prepare_and_parse_args, plugins, webroot_args)
 
-        webroot_map_args = ['--webroot-map', '{"eg.com" : "/tmp"}']
+        webroot_map_args = ['--webroot-map',
+                            '{"eg.com": "/tmp", "www.eg.com.": "/tmp"}']
         namespace = cli.prepare_and_parse_args(plugins, webroot_map_args)
-        self.assertEqual(namespace.webroot_map, {u"eg.com": u"/tmp"})
+        self.assertEqual(namespace.webroot_map,
+                         {u"eg.com": u"/tmp", u"www.eg.com": u"/tmp"})
 
     @mock.patch('letsencrypt.cli._suggest_donate')
     @mock.patch('letsencrypt.crypto_util.notAfter')

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -330,6 +330,10 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
         namespace = cli.prepare_and_parse_args(plugins, short_args)
         self.assertEqual(namespace.domains, ['example.com'])
 
+        short_args = ['-d', 'trailing.period.com.']
+        namespace = cli.prepare_and_parse_args(plugins, short_args)
+        self.assertEqual(namespace.domains, ['trailing.period.com'])
+
         short_args = ['-d', 'example.com,another.net,third.org,example.com']
         namespace = cli.prepare_and_parse_args(plugins, short_args)
         self.assertEqual(namespace.domains, ['example.com', 'another.net',
@@ -338,6 +342,10 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
         long_args = ['--domains', 'example.com']
         namespace = cli.prepare_and_parse_args(plugins, long_args)
         self.assertEqual(namespace.domains, ['example.com'])
+
+        long_args = ['--domains', 'trailing.period.com.']
+        namespace = cli.prepare_and_parse_args(plugins, long_args)
+        self.assertEqual(namespace.domains, ['trailing.period.com'])
 
         long_args = ['--domains', 'example.com,another.net,example.com']
         namespace = cli.prepare_and_parse_args(plugins, long_args)
@@ -360,7 +368,7 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
         plugins = disco.PluginsRegistry.find_all()
         webroot_args = ['--webroot', '-w', '/var/www/example',
             '-d', 'example.com,www.example.com', '-w', '/var/www/superfluous',
-            '-d', 'superfluo.us', '-d', 'www.superfluo.us']
+            '-d', 'superfluo.us', '-d', 'www.superfluo.us.']
         namespace = cli.prepare_and_parse_args(plugins, webroot_args)
         self.assertEqual(namespace.webroot_map, {
             'example.com': '/var/www/example',


### PR DESCRIPTION
Removes trailing period if present in the domain name #2065
Should the same be done for domain names passed in webroot_map? It's not really documented so I wasn't sure how to handle it.