### PR TITLE
fix "grep: /etc/os-release: No such file or directory"

### DIFF
--- a/letsencrypt-auto
+++ b/letsencrypt-auto
@@ -126,7 +126,7 @@ then
   elif [ -f /etc/redhat-release ] ; then
     echo "Bootstrapping dependencies for RedHat-based OSes..."
     $SUDO $BOOTSTRAP/_rpm_common.sh
-  elif `grep -q openSUSE /etc/os-release` ; then
+  elif [ -f /etc/os-release ] && `grep -q openSUSE /etc/os-release` ; then
     echo "Bootstrapping dependencies for openSUSE-based OSes..."
     $SUDO $BOOTSTRAP/_suse_common.sh
   elif [ -f /etc/arch-release ] ; then


### PR DESCRIPTION
Removes the error message `grep: /etc/os-release: No such file or directory`
when running `./letsencrypt-auto --help`

