### PR TITLE
Add installation of python-tools and python-pip for CentOS

### DIFF
--- a/bootstrap/_rpm_common.sh
+++ b/bootstrap/_rpm_common.sh
@@ -3,6 +3,7 @@
 # Tested with:
 #   - Fedora 22, 23 (x64)
 #   - Centos 7 (x64: on DigitalOcean droplet)
+#   - CentOS 7 Minimal install in a Hyper-V VM
 
 if type dnf 2>/dev/null
 then
@@ -21,12 +22,16 @@ fi
 if ! $tool install -y \
        python \
        python-devel \
-       python-virtualenv
+       python-virtualenv \
+       python-tools \
+       python-pip
 then
   if ! $tool install -y \
          python27 \
          python27-devel \
-         python27-virtualenv
+         python27-virtualenv \
+         python27-tools \
+         python27-pip
   then
     echo "Could not install Python dependencies. Aborting bootstrap!"
     exit 1

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -213,6 +213,7 @@ BootstrapRpmCommon() {
   # Tested with:
   #   - Fedora 22, 23 (x64)
   #   - Centos 7 (x64: on DigitalOcean droplet)
+  #   - CentOS 7 Minimal install in a Hyper-V VM
 
   if type dnf 2>/dev/null
   then
@@ -231,12 +232,16 @@ BootstrapRpmCommon() {
   if ! $SUDO $tool install -y \
          python \
          python-devel \
-         python-virtualenv
+         python-virtualenv \
+         python-tools \
+         python-pip
   then
     if ! $SUDO $tool install -y \
            python27 \
            python27-devel \
-           python27-virtualenv
+           python27-virtualenv \
+           python27-tools \
+           python27-pip
     then
       echo "Could not install Python dependencies. Aborting bootstrap!"
       exit 1

--- a/letsencrypt-auto-source/pieces/bootstrappers/rpm_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/rpm_common.sh
@@ -2,6 +2,7 @@ BootstrapRpmCommon() {
   # Tested with:
   #   - Fedora 22, 23 (x64)
   #   - Centos 7 (x64: on DigitalOcean droplet)
+  #   - CentOS 7 Minimal install in a Hyper-V VM
 
   if type dnf 2>/dev/null
   then
@@ -20,12 +21,16 @@ BootstrapRpmCommon() {
   if ! $SUDO $tool install -y \
          python \
          python-devel \
-         python-virtualenv
+         python-virtualenv \
+         python-tools \
+         python-pip
   then
     if ! $SUDO $tool install -y \
            python27 \
            python27-devel \
-           python27-virtualenv
+           python27-virtualenv \
+           python27-tools \
+           python27-pip
     then
       echo "Could not install Python dependencies. Aborting bootstrap!"
       exit 1


### PR DESCRIPTION
This replaces #1824, adding the necessary porting now that #1665 has landed.