### PR TITLE
Ignore renewal configs that don't end in .conf

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -194,6 +194,8 @@ def _find_duplicative_certs(config, domains):
     le_util.make_or_verify_dir(configs_dir, mode=0o755, uid=os.geteuid())
 
     for renewal_file in os.listdir(configs_dir):
+        if not renewal_file.endswith(".conf"):
+            continue
         try:
             full_path = os.path.join(configs_dir, renewal_file)
             candidate_lineage = storage.RenewableCert(full_path, cli_config)

--- a/letsencrypt/renewer.py
+++ b/letsencrypt/renewer.py
@@ -172,6 +172,8 @@ def main(cli_args=sys.argv[1:]):
                                constants.CONFIG_DIRS_MODE, uid)
 
     for renewal_file in os.listdir(cli_config.renewal_configs_dir):
+        if not renewal_file.endswith(".conf"):
+            continue
         print("Processing " + renewal_file)
         try:
             # TODO: Before trying to initialize the RenewableCert object,

--- a/letsencrypt/tests/renewer_test.py
+++ b/letsencrypt/tests/renewer_test.py
@@ -68,6 +68,13 @@ class BaseRenewableCertTest(unittest.TestCase):
         config.write()
         self.config = config
 
+        # We also create a file that isn't a renewal config in the same
+        # location to test that logic that reads in all-and-only renewal
+        # configs will ignore it and NOT attempt to parse it.
+        junk = open(os.path.join(self.tempdir, "renewal", "IGNORE.THIS"), "w")
+        junk.write("This file should be ignored!")
+        junk.close()
+
         self.defaults = configobj.ConfigObj()
         self.test_rc = storage.RenewableCert(config.filename, self.cli_config)
 


### PR DESCRIPTION
Pretty trivial fix to #2254.

(Maybe be missing test coverage for one new line; let's see.)