### PR TITLE
write servername/serveralias if copying a generic vhost

### DIFF
--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -865,6 +865,8 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         fp = vhost.filep
         vh_p = self.aug.match("/files%s//* [label()=~regexp('%s')]" %
                               (fp, parser.case_i("VirtualHost")))
+        if not vh_p:
+            return
         vh_path = vh_p[0]
         if (self.parser.find_dir("ServerName", target_name, start=vh_path, exclude=False)
            or self.parser.find_dir("ServerAlias", target_name, start=vh_path, exclude=False)):

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -382,7 +382,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
             if len(reasonable_vhosts) == 1:
                 best_candidate = reasonable_vhosts[0]
 
-        return (best_candidate)
+        return best_candidate
 
     def _non_default_vhosts(self):
         """Return all non _default_ only vhosts."""
@@ -861,6 +861,9 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         self.parser.add_dir(vh_path, "Include", self.mod_ssl_conf)
 
     def _add_servername_alias(self, target_name, vh_path):
+        if (self.parser.find_dir("ServerName", target_name, start=vh_path, exclude=False)
+           or self.parser.find_dir("ServerAlias", target_name, start=vh_path, exclude=False)):
+               return
         if not self.parser.find_dir("ServerName", None, start=vh_path, exclude=False):
             self.parser.add_dir(vh_path, "ServerName", target_name)
         else:

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -874,6 +874,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
             self.parser.add_dir(vh_path, "ServerName", target_name)
         else:
             self.parser.add_dir(vh_path, "ServerAlias", target_name)
+        self._add_servernames(vhost)
 
     def _add_name_vhost_if_necessary(self, vhost):
         """Add NameVirtualHost Directives if necessary for new vhost.

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -864,7 +864,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
     def _add_servername_alias(self, target_name, vhost):
         fp = vhost.filep
         vh_p = self.aug.match("/files%s//* [label()=~regexp('%s')]" %
-                              (ssl_fp, parser.case_i("VirtualHost")))
+                              (fp, parser.case_i("VirtualHost")))
         vh_path = vh_p[0]
         if (self.parser.find_dir("ServerName", target_name, start=vh_path, exclude=False)
            or self.parser.find_dir("ServerAlias", target_name, start=vh_path, exclude=False)):

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -708,7 +708,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
 
         # Add directives
         self._add_dummy_ssl_directives(vh_p)
-        self.save("don't lose ssl directives", True)
+        self.save()
         if target_name:
             self._add_servername_alias(target_name, vh_p)
 

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -708,6 +708,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
 
         # Add directives
         self._add_dummy_ssl_directives(vh_p)
+        self.save("don't lose ssl directives", True)
         if target_name:
             self._add_servername_alias(target_name, vh_p)
 
@@ -863,7 +864,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
     def _add_servername_alias(self, target_name, vh_path):
         if (self.parser.find_dir("ServerName", target_name, start=vh_path, exclude=False)
            or self.parser.find_dir("ServerAlias", target_name, start=vh_path, exclude=False)):
-               return
+            return
         if not self.parser.find_dir("ServerName", None, start=vh_path, exclude=False):
             self.parser.add_dir(vh_path, "ServerName", target_name)
         else:

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -693,7 +693,6 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
 
         # Reload augeas to take into account the new vhost
         self.aug.load()
-        #TODO: add line to write vhost name
         # Get Vhost augeas path for new vhost
         vh_p = self.aug.match("/files%s//* [label()=~regexp('%s')]" %
                               (ssl_fp, parser.case_i("VirtualHost")))

--- a/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
+++ b/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
@@ -162,7 +162,7 @@ class TwoVhost80Test(util.ApacheTest):
         mock_select.return_value = self.vh_truth[0]
         chosen_vhost = self.config.choose_vhost("none.com")
         self.assertEqual(
-            self.vh_truth[0].get_names(), chosen_vhost.get_names())
+            self.vh_truth[6].get_names(), chosen_vhost.get_names())
 
         # Make sure we go from HTTP -> HTTPS
         self.assertFalse(self.vh_truth[0].ssl)

--- a/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
+++ b/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
@@ -188,12 +188,12 @@ class TwoVhost80Test(util.ApacheTest):
     def test_find_best_vhost(self):
         # pylint: disable=protected-access
         self.assertEqual(
-            (self.vh_truth[3], True), self.config._find_best_vhost("letsencrypt.demo"))
+            self.vh_truth[3], self.config._find_best_vhost("letsencrypt.demo"))
         self.assertEqual(
-            (self.vh_truth[0], True),
+            self.vh_truth[0],
             self.config._find_best_vhost("encryption-example.demo"))
         self.assertEqual(
-            self.config._find_best_vhost("does-not-exist.com"), (None, True))
+            self.config._find_best_vhost("does-not-exist.com"), None)
 
     def test_find_best_vhost_variety(self):
         # pylint: disable=protected-access
@@ -202,7 +202,7 @@ class TwoVhost80Test(util.ApacheTest):
                              obj.Addr(("zombo.com",))]),
             True, False)
         self.config.vhosts.append(ssl_vh)
-        self.assertEqual(self.config._find_best_vhost("zombo.com"), (ssl_vh, True))
+        self.assertEqual(self.config._find_best_vhost("zombo.com"), ssl_vh)
 
     def test_find_best_vhost_default(self):
         # pylint: disable=protected-access
@@ -213,7 +213,7 @@ class TwoVhost80Test(util.ApacheTest):
         ]
 
         self.assertEqual(
-            self.config._find_best_vhost("example.demo"), (self.vh_truth[2], True))
+            self.config._find_best_vhost("example.demo"), self.vh_truth[2])
 
     def test_non_default_vhosts(self):
         # pylint: disable=protected-access

--- a/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
+++ b/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
@@ -161,8 +161,9 @@ class TwoVhost80Test(util.ApacheTest):
     def test_choose_vhost_select_vhost_non_ssl(self, mock_select):
         mock_select.return_value = self.vh_truth[0]
         chosen_vhost = self.config.choose_vhost("none.com")
+        self.vh_truth[0].aliases.add("none.com")
         self.assertEqual(
-            self.vh_truth[6].get_names(), chosen_vhost.get_names())
+            self.vh_truth[0].get_names(), chosen_vhost.get_names())
 
         # Make sure we go from HTTP -> HTTPS
         self.assertFalse(self.vh_truth[0].ssl)

--- a/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
+++ b/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
@@ -188,12 +188,12 @@ class TwoVhost80Test(util.ApacheTest):
     def test_find_best_vhost(self):
         # pylint: disable=protected-access
         self.assertEqual(
-            self.vh_truth[3], self.config._find_best_vhost("letsencrypt.demo"))
+            (self.vh_truth[3], True), self.config._find_best_vhost("letsencrypt.demo"))
         self.assertEqual(
-            self.vh_truth[0],
+            (self.vh_truth[0], True),
             self.config._find_best_vhost("encryption-example.demo"))
-        self.assertTrue(
-            self.config._find_best_vhost("does-not-exist.com") is None)
+        self.assertEqual(
+            self.config._find_best_vhost("does-not-exist.com"), (None, True))
 
     def test_find_best_vhost_variety(self):
         # pylint: disable=protected-access
@@ -202,7 +202,7 @@ class TwoVhost80Test(util.ApacheTest):
                              obj.Addr(("zombo.com",))]),
             True, False)
         self.config.vhosts.append(ssl_vh)
-        self.assertEqual(self.config._find_best_vhost("zombo.com"), ssl_vh)
+        self.assertEqual(self.config._find_best_vhost("zombo.com"), (ssl_vh, True))
 
     def test_find_best_vhost_default(self):
         # pylint: disable=protected-access
@@ -213,7 +213,7 @@ class TwoVhost80Test(util.ApacheTest):
         ]
 
         self.assertEqual(
-            self.config._find_best_vhost("example.demo"), self.vh_truth[2])
+            self.config._find_best_vhost("example.demo"), (self.vh_truth[2], True))
 
     def test_non_default_vhosts(self):
         # pylint: disable=protected-access

--- a/letsencrypt-apache/letsencrypt_apache/tests/util.py
+++ b/letsencrypt-apache/letsencrypt_apache/tests/util.py
@@ -151,7 +151,13 @@ def get_vh_truth(temp_dir, config_name):
                 os.path.join(aug_pre, ("default-ssl-port-only.conf/"
                                        "IfModule/VirtualHost")),
                 set([obj.Addr.fromstring("_default_:443")]), True, False),
+            obj.VirtualHost(
+                os.path.join(prefix, "encryption-example.conf"),
+                os.path.join(aug_pre, "encryption-example.conf/VirtualHost"),
+                set([obj.Addr.fromstring("*:80")]),
+                False, True, "encryption-example.demo")
         ]
+        vh_truth[6].aliases.add("none.com")
         return vh_truth
 
     return None  # pragma: no cover

--- a/letsencrypt-apache/letsencrypt_apache/tests/util.py
+++ b/letsencrypt-apache/letsencrypt_apache/tests/util.py
@@ -150,14 +150,8 @@ def get_vh_truth(temp_dir, config_name):
                 os.path.join(prefix, "default-ssl-port-only.conf"),
                 os.path.join(aug_pre, ("default-ssl-port-only.conf/"
                                        "IfModule/VirtualHost")),
-                set([obj.Addr.fromstring("_default_:443")]), True, False),
-            obj.VirtualHost(
-                os.path.join(prefix, "encryption-example.conf"),
-                os.path.join(aug_pre, "encryption-example.conf/VirtualHost"),
-                set([obj.Addr.fromstring("*:80")]),
-                False, True, "encryption-example.demo")
+                set([obj.Addr.fromstring("_default_:443")]), True, False)
         ]
-        vh_truth[6].aliases.add("none.com")
         return vh_truth
 
     return None  # pragma: no cover


### PR DESCRIPTION
added code to input the server name to a file if it doesn't have one.
two parts of this could use outside opinions:
1) using _find_best_vhost to determine if it's a generic vhost, we could also use augeas in make_vhost_ssl
2) passing these two new flags to make_vhost_ssl, I'm a bit worried about flag inflation

corresponds to #1991  