### PR TITLE
Allow trailing period in fqdn as per #2065

### DIFF
--- a/letsencrypt/le_util.py
+++ b/letsencrypt/le_util.py
@@ -315,6 +315,7 @@ def check_domain_sanity(domain):
     # http://www.mkyong.com/regular-expressions/domain-name-regular-expression-example/
     #  Characters used, domain parts < 63 chars, tld > 1 < 64 chars
     #  first and last char is not "-"
-    fqdn = re.compile("^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,63}$")
+    #  last character may be a "."
+    fqdn = re.compile("^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,63}.?$")
     if not fqdn.match(domain):
         raise errors.ConfigurationError("Requested domain is not a FQDN")


### PR DESCRIPTION
Updated `check_domain_sanity()` regex to allow for trailing period.

Fixes: https://github.com/letsencrypt/letsencrypt/issues/2065