### PR TITLE
Small Apache 2.2 fixes

### DIFF
--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -874,14 +874,11 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         # See if the exact address appears in any other vhost
         # Remember 1.1.1.1:* == 1.1.1.1 -> hence any()
         for addr in vhost.addrs:
-
             # In Apache 2.2, when a NameVirtualHost directive is not
             # set, "*" and "_default_" will conflict when sharing a port
-            addrs = [addr]
-            if addr.get_addr() == "*":
-                addrs.append(obj.Addr(("_default_", addr.get_port(),)))
-            elif addr.get_addr() == "_default_":
-                addrs.append(obj.Addr(("*", addr.get_port(),)))
+            if addr.get_addr() in ("*", "_default_"):
+                addrs = [obj.Addr((a, addr.get_port(),))
+                         for a in ("*", "_default_")]
 
             for test_vh in self.vhosts:
                 if (vhost.filep != test_vh.filep and

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -874,9 +874,18 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         # See if the exact address appears in any other vhost
         # Remember 1.1.1.1:* == 1.1.1.1 -> hence any()
         for addr in vhost.addrs:
+
+            # In Apache 2.2, when a NameVirtualHost directive is not
+            # set, "*" and "_default_" will conflict when sharing a port
+            addrs = [addr]
+            if addr.get_addr() == "*":
+                addrs.append(obj.Addr(("_default_", addr.get_port(),)))
+            elif addr.get_addr() == "_default_":
+                addrs.append(obj.Addr(("*", addr.get_port(),)))
+
             for test_vh in self.vhosts:
                 if (vhost.filep != test_vh.filep and
-                        any(test_addr == addr for
+                        any(test_addr in addrs for
                             test_addr in test_vh.addrs) and
                         not self.is_name_vhost(addr)):
                     self.add_name_vhost(addr)

--- a/letsencrypt-apache/letsencrypt_apache/parser.py
+++ b/letsencrypt-apache/letsencrypt_apache/parser.py
@@ -597,7 +597,7 @@ class ApacheParser(object):
         .. todo:: Make sure that files are included
 
         """
-        default = self._set_user_config_file()
+        default = self.loc["root"]
 
         temp = os.path.join(self.root, "ports.conf")
         if os.path.isfile(temp):
@@ -617,23 +617,6 @@ class ApacheParser(object):
                 return os.path.join(self.root, name)
 
         raise errors.NoInstallationError("Could not find configuration root")
-
-    def _set_user_config_file(self):
-        """Set the appropriate user configuration file
-
-        .. todo:: This will have to be updated for other distros versions
-
-        :param str root: pathname which contains the user config
-
-        """
-        # Basic check to see if httpd.conf exists and
-        # in hierarchy via direct include
-        # httpd.conf was very common as a user file in Apache 2.2
-        if (os.path.isfile(os.path.join(self.root, "httpd.conf")) and
-                self.find_dir("Include", "httpd.conf", self.loc["root"])):
-            return os.path.join(self.root, "httpd.conf")
-        else:
-            return os.path.join(self.root, "apache2.conf")
 
 
 def case_i(string):

--- a/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
+++ b/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
@@ -606,6 +606,14 @@ class TwoVhost80Test(util.ApacheTest):
         self.config._add_name_vhost_if_necessary(self.vh_truth[0])
         self.assertTrue(self.config.save.called)
 
+        new_addrs = set()
+        for addr in self.vh_truth[0].addrs:
+            new_addrs.add(obj.Addr(("_default_", addr.get_port(),)))
+
+        self.vh_truth[0].addrs = new_addrs
+        self.config._add_name_vhost_if_necessary(self.vh_truth[0])
+        self.assertEqual(self.config.save.call_count, 2)
+
     @mock.patch("letsencrypt_apache.configurator.tls_sni_01.ApacheTlsSni01.perform")
     @mock.patch("letsencrypt_apache.configurator.ApacheConfigurator.restart")
     def test_perform(self, mock_restart, mock_perform):

--- a/letsencrypt-apache/letsencrypt_apache/tests/parser_test.py
+++ b/letsencrypt-apache/letsencrypt_apache/tests/parser_test.py
@@ -106,23 +106,13 @@ class BasicParserTest(util.ParserTest):
     def test_set_locations(self):
         with mock.patch("letsencrypt_apache.parser.os.path") as mock_path:
 
-            mock_path.isfile.side_effect = [True, False, False]
+            mock_path.isfile.side_effect = [False, False]
 
             # pylint: disable=protected-access
             results = self.parser._set_locations()
 
             self.assertEqual(results["default"], results["listen"])
             self.assertEqual(results["default"], results["name"])
-
-    def test_set_user_config_file(self):
-        # pylint: disable=protected-access
-        path = os.path.join(self.parser.root, "httpd.conf")
-        open(path, 'w').close()
-        self.parser.add_dir(self.parser.loc["default"], "Include",
-                            "httpd.conf")
-
-        self.assertEqual(
-            path, self.parser._set_user_config_file())
 
     @mock.patch("letsencrypt_apache.parser.ApacheParser._get_runtime_cfg")
     def test_update_runtime_variables(self, mock_cfg):


### PR DESCRIPTION
Fixes:
* Trying to modify the wrong config file in CentOS6.
* Not adding `NameVirtualHost` causing `_default_` and `*` conflicts.