### PR TITLE
Run le-auto tests on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
   global:
     - GOPATH=/tmp/go
     - PATH=$GOPATH/bin:$PATH
+
 matrix:
   include:
     - python: "2.6"
@@ -47,6 +48,10 @@ matrix:
       env: TOXENV=py34
     - python: "3.5"
       env: TOXENV=py35
+    - sudo: required
+      env: TOXENV=le_auto
+      services: docker
+      before_install:
 
 # Only build pushes to the master branch, PRs, and branches beginning with
 # `test-`. This reduces the number of simultaneous Travis runs, which speeds

--- a/letsencrypt-auto-source/Dockerfile
+++ b/letsencrypt-auto-source/Dockerfile
@@ -7,7 +7,6 @@ FROM ubuntu:trusty
 RUN useradd --create-home --home-dir /home/lea --shell /bin/bash --groups sudo --uid 1000 lea
 
 # Let that user sudo:
-RUN adduser lea sudo
 RUN sed -i.bkp -e \
       's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' \
       /etc/sudoers


### PR DESCRIPTION
Run le-auto tests on Travis.

* We choose a different Travis infra for one of the jobs, as in https://github.com/numpy/numpy/blob/master/.travis.yml#L49.
* We keep the language as "python" so the installation of packages (like tox, which we need) doesn't fail.
* Override the before_install to disable the dpkg stuff the other jobs need.
* adduser is redundant with `--groups sudo` above, so we delete it.