### PR TITLE
Make all except/raises Python 3 compatible.

### DIFF
--- a/letsencrypt-apache/letsencrypt_apache/display_ops.py
+++ b/letsencrypt-apache/letsencrypt_apache/display_ops.py
@@ -85,12 +85,12 @@ def _vhost_menu(domain, vhosts):
             "or Address of {0}.{1}Which virtual host would you "
             "like to choose?".format(domain, os.linesep),
             choices, help_label="More Info", ok_label="Select")
-    except errors.MissingCommandlineFlag, e:
+    except errors.MissingCommandlineFlag as e:
         msg = ("Failed to run Apache plugin non-interactively{1}{0}{1}"
                "(The best solution is to add ServerName or ServerAlias "
                "entries to the VirtualHost directives of your apache "
                "configuration files.)".format(e, os.linesep))
-        raise errors.MissingCommandlineFlag, msg
+        raise errors.MissingCommandlineFlag(msg)
 
     return code, tag
 

--- a/letsencrypt-apache/letsencrypt_apache/tests/display_ops_test.py
+++ b/letsencrypt-apache/letsencrypt_apache/tests/display_ops_test.py
@@ -37,7 +37,7 @@ class SelectVhostTest(unittest.TestCase):
         mock_util().menu.side_effect = errors.MissingCommandlineFlag("no vhost default")
         try:
             self._call(self.vhosts)
-        except errors.MissingCommandlineFlag, e:
+        except errors.MissingCommandlineFlag as e:
             self.assertTrue("VirtualHost directives" in e.message)
 
     @mock.patch("letsencrypt_apache.display_ops.zope.component.getUtility")

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -543,7 +543,7 @@ def choose_configurator_plugins(args, config, plugins, verb):
                    '{1} and "--help plugins" for more information.)'.format(
                    req_auth, os.linesep, cli_command))
 
-            raise errors.MissingCommandlineFlag, msg
+            raise errors.MissingCommandlineFlag(msg)
     else:
         need_inst = need_auth = False
     if verb == "certonly":
@@ -591,7 +591,7 @@ def run(args, config, plugins):  # pylint: disable=too-many-branches,too-many-lo
     """Obtain a certificate and install."""
     try:
         installer, authenticator = choose_configurator_plugins(args, config, plugins, "run")
-    except errors.PluginSelectionError, e:
+    except errors.PluginSelectionError as e:
         return e.message
 
     domains = _find_domains(config, installer)
@@ -626,7 +626,7 @@ def obtain_cert(args, config, plugins):
     try:
         # installers are used in auth mode to determine domain names
         installer, authenticator = choose_configurator_plugins(args, config, plugins, "certonly")
-    except errors.PluginSelectionError, e:
+    except errors.PluginSelectionError as e:
         return e.message
 
     # TODO: Handle errors from _init_le_client?
@@ -655,7 +655,7 @@ def install(args, config, plugins):
     try:
         installer, _ = choose_configurator_plugins(args, config,
                                                    plugins, "install")
-    except errors.PluginSelectionError, e:
+    except errors.PluginSelectionError as e:
         return e.message
 
     domains = _find_domains(config, installer)

--- a/letsencrypt/client.py
+++ b/letsencrypt/client.py
@@ -146,7 +146,7 @@ def perform_registration(acme, config):
     """
     try:
         return acme.register(messages.NewRegistration.from_data(email=config.email))
-    except messages.Error, e:
+    except messages.Error as e:
         err = repr(e)
         if "MX record" in err or "Validation of contact mailto" in err:
             config.namespace.email = display_ops.get_email(more=True, invalid=True)

--- a/letsencrypt/display/ops.py
+++ b/letsencrypt/display/ops.py
@@ -82,7 +82,7 @@ def pick_plugin(config, default, plugins, question, ifaces):
                 "Missing command line flags. For non-interactive execution, "
                 "you will need to specify a plugin on the command line.  Run "
                 "with '--help plugins' to see a list of options, and see "
-                " https://eff.org/letsencrypt-plugins for more detail on what "
+                "https://eff.org/letsencrypt-plugins for more detail on what "
                 "the plugins do and how to use them.")
 
         filtered = plugins.visible().ifaces(ifaces)

--- a/letsencrypt/display/ops.py
+++ b/letsencrypt/display/ops.py
@@ -78,11 +78,12 @@ def pick_plugin(config, default, plugins, question, ifaces):
             # it's really bad to auto-select the single available plugin in
             # non-interactive mode, because an update could later add a second
             # available plugin
-            raise errors.MissingCommandlineFlag, ("Missing command line flags. For non-interactive "
-                "execution, you will need to specify a plugin on the command line.  Run with "
-                "'--help plugins' to see a list of options, and see "
-                " https://eff.org/letsencrypt-plugins for more detail on what the plugins "
-                "do and how to use them.")
+            raise errors.MissingCommandlineFlag(
+                "Missing command line flags. For non-interactive execution, "
+                "you will need to specify a plugin on the command line.  Run "
+                "with '--help plugins' to see a list of options, and see "
+                " https://eff.org/letsencrypt-plugins for more detail on what "
+                "the plugins do and how to use them.")
 
         filtered = plugins.visible().ifaces(ifaces)
 
@@ -158,7 +159,7 @@ def get_email(more=False, invalid=False):
     except errors.MissingCommandlineFlag:
         msg = ("You should register before running non-interactively, or provide --agree-tos"
                " and --email <email_address> flags")
-        raise errors.MissingCommandlineFlag, msg
+        raise errors.MissingCommandlineFlag(msg)
 
     if code == display_util.OK:
         if le_util.safe_email(email):

--- a/letsencrypt/display/util.py
+++ b/letsencrypt/display/util.py
@@ -428,7 +428,7 @@ class NoninteractiveDisplay(object):
             msg += "\n" + extra
         if cli_flag:
             msg += "\n\n(You can set this with the {0} flag)".format(cli_flag)
-        raise errors.MissingCommandlineFlag, msg
+        raise errors.MissingCommandlineFlag(msg)
 
     def notification(self, message, height=10, pause=False):
         # pylint: disable=unused-argument

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -138,7 +138,7 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
         try:
             with mock.patch('letsencrypt.cli.sys.stderr'):
                 cli.main(self.standard_args + args[:])  # NOTE: parser can alter its args!
-        except errors.MissingCommandlineFlag, exc:
+        except errors.MissingCommandlineFlag as exc:
             self.assertTrue(message in str(exc))
         self.assertTrue(exc is not None)
 

--- a/tests/letstest/multitester.py
+++ b/tests/letstest/multitester.py
@@ -141,7 +141,7 @@ def make_instance(instance_name,
     # give instance a name
     try:
         new_instance.create_tags(Tags=[{'Key': 'Name', 'Value': instance_name}])
-    except botocore.exceptions.ClientError, e:
+    except botocore.exceptions.ClientError as e:
         if "InvalidInstanceID.NotFound" in str(e):
             # This seems to be ephemeral... retry
             time.sleep(1)


### PR DESCRIPTION
Made all the `except` & `raise` statements use the newer form that Python 3 supports. letsencrypt already uses this in some places prior to this change, so this isn't breaking compatibility with ancient versions of Python, as that's already done.

Additionally, I removed a double space in front of a URL that I came across.