### PR TITLE
Ignore venv in letstest dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ letsencrypt.log
 # letstest
 tests/letstest/letest-*/
 tests/letstest/*.pem
+tests/letstest/venv/


### PR DESCRIPTION
Convenience for those running test farm tests from inside a venv.