### PR TITLE
Pass the SAN list as a string object, not a unicode object

### DIFF
--- a/letsencrypt/crypto_util.py
+++ b/letsencrypt/crypto_util.py
@@ -115,7 +115,7 @@ def make_csr(key_str, domains):
         OpenSSL.crypto.X509Extension(
             "subjectAltName",
             critical=False,
-            value=", ".join("DNS:%s" % d for d in domains)
+            value=str(", ".join("DNS:%s" % d for d in domains))
         ),
     ])
     req.set_pubkey(pkey)


### PR DESCRIPTION
I was running into [this](https://github.com/letsencrypt/letsencrypt/pull/2309#issuecomment-177172587) issue, so I converted it to a string as the issue suggested and it renewed successfully. I think i tested everything sufficiently, but not 100% sure?