### PR TITLE
renew_coverage++

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -856,10 +856,10 @@ def _reconstitute(config, full_path):
     try:
         domains = [le_util.enforce_domain_sanity(x) for x in
                    renewal_candidate.names()]
-    except (UnicodeError, ValueError):
+    except errors.ConfigurationError as error:
         logger.warning("Renewal configuration file %s references a cert "
-                       "that mentions a domain name that we regarded as "
-                       "invalid. Skipping.", full_path)
+                       "that contains an invalid domain name. The problem "
+                       "was: %s. Skipping.", full_path, error)
         return None
 
     setattr(config.namespace, "domains", domains)

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -602,18 +602,25 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
             print "Logs:"
             print lf.read()
 
-
-    def test_renewal_verb(self):
+    def test_renew_verb(self):
         with open(test_util.vector_path('sample-renewal.conf')) as src:
             # put the correct path for cert.pem, chain.pem etc in the renewal conf
             renewal_conf = src.read().replace("MAGICDIR", test_util.vector_path())
         rd = os.path.join(self.config_dir, "renewal")
-        os.makedirs(rd)
+        if not os.path.exists(rd):
+            os.makedirs(rd)
         rc = os.path.join(rd, "sample-renewal.conf")
         with open(rc, "w") as dest:
             dest.write(renewal_conf)
         args = ["renew", "--dry-run", "-tvv"]
         self._test_renewal_common(True, [], args=args, renew=True)
+
+    def test_renew_verb_empty_config(self):
+        renewer_configs_dir = os.path.join(self.config_dir, 'renewal')
+        os.makedirs(renewer_configs_dir)
+        with open(os.path.join(renewer_configs_dir, 'empty.conf'), 'w'):
+            pass  # leave the file empty
+        self.test_renew_verb()
 
     @mock.patch('letsencrypt.cli.zope.component.getUtility')
     @mock.patch('letsencrypt.cli._treat_as_renewal')

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -641,6 +641,22 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
                                           args=['renew'], renew=False)
             self.assertFalse(mock_obtain_cert.called)
 
+    def test_renew_with_bad_int(self):
+        renewer_configs_dir = os.path.join(self.config_dir, 'renewal')
+        os.makedirs(renewer_configs_dir)
+        with open(os.path.join(renewer_configs_dir, 'test.conf'), 'w') as f:
+            f.write("My contents don't matter")
+        with mock.patch('letsencrypt.storage.RenewableCert') as mock_rc:
+            mock_lineage = mock.MagicMock()
+            mock_rc.return_value = mock_lineage
+            mock_lineage.configuration = {
+                'renewalparams': {'authenticator': None,
+                                  'rsa_key_size': 'over 9000'}}
+            with mock.patch('letsencrypt.cli.obtain_cert') as mock_obtain_cert:
+                self._test_renewal_common(True, None,
+                                          args=['renew'], renew=False)
+            self.assertFalse(mock_obtain_cert.called)
+
     @mock.patch('letsencrypt.cli.zope.component.getUtility')
     @mock.patch('letsencrypt.cli._treat_as_renewal')
     @mock.patch('letsencrypt.cli._init_le_client')

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -673,6 +673,24 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
                                           args=['renew'], renew=False)
             self.assertFalse(mock_obtain_cert.called)
 
+    def test_renew_plugin_config_restoration(self):
+        renewer_configs_dir = os.path.join(self.config_dir, 'renewal')
+        os.makedirs(renewer_configs_dir)
+        with open(os.path.join(renewer_configs_dir, 'test.conf'), 'w') as f:
+            f.write("My contents don't matter")
+        with mock.patch('letsencrypt.storage.RenewableCert') as mock_rc:
+            mock_lineage = mock.MagicMock()
+            mock_rc.return_value = mock_lineage
+            mock_lineage.configuration = {
+                'renewalparams':
+                    {'authenticator': 'webroot',
+                     'webroot_path': 'None',
+                     'webroot_imaginary_flag': '42'}}
+            with mock.patch('letsencrypt.cli.obtain_cert') as mock_obtain_cert:
+                self._test_renewal_common(True, None,
+                                          args=['renew'], renew=False)
+            self.assertEqual(mock_obtain_cert.call_count, 1)
+
     @mock.patch('letsencrypt.cli.zope.component.getUtility')
     @mock.patch('letsencrypt.cli._treat_as_renewal')
     @mock.patch('letsencrypt.cli._init_le_client')

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -630,7 +630,12 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
         with mock.patch('letsencrypt.storage.RenewableCert') as mock_rc:
             mock_lineage = mock.MagicMock()
             mock_rc.return_value = mock_lineage
-            mock_lineage.configuration = ["not renewalparams"]
+            mock_lineage.configuration = ['not renewalparams']
+            with mock.patch('letsencrypt.cli.obtain_cert') as mock_obtain_cert:
+                self._test_renewal_common(True, None,
+                                          args=['renew'], renew=False)
+            self.assertFalse(mock_obtain_cert.called)
+            mock_lineage.configuration = {'renewalparams': ['no auth']}
             with mock.patch('letsencrypt.cli.obtain_cert') as mock_obtain_cert:
                 self._test_renewal_common(True, None,
                                           args=['renew'], renew=False)

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -698,11 +698,26 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
             f.write("My contents don't matter")
         # pylint: disable=protected-access
         with mock.patch('letsencrypt.cli._reconstitute') as mock_reconstitute:
-            mock_reconstitute.side_effect = [Exception]
+            mock_reconstitute.side_effect = Exception
             with mock.patch('letsencrypt.cli.obtain_cert') as mock_obtain_cert:
                 self._test_renewal_common(True, None,
                                           args=['renew'], renew=False)
             self.assertFalse(mock_obtain_cert.called)
+
+    def test_renew_obtain_cert_error(self):
+        renewer_configs_dir = os.path.join(self.config_dir, 'renewal')
+        os.makedirs(renewer_configs_dir)
+        with open(os.path.join(renewer_configs_dir, 'test.conf'), 'w') as f:
+            f.write("My contents don't matter")
+        with mock.patch('letsencrypt.storage.RenewableCert') as mock_rc:
+            mock_lineage = mock.MagicMock()
+            mock_rc.return_value = mock_lineage
+            mock_lineage.configuration = {
+                'renewalparams': {'authenticator': 'webroot'}}
+            with mock.patch('letsencrypt.cli.obtain_cert') as mock_obtain_cert:
+                mock_obtain_cert.side_effect = Exception
+                self._test_renewal_common(True, None,
+                                          args=['renew'], renew=False)
 
     def test_renew_with_bad_cli_args(self):
         self.assertRaises(errors.Error, self._test_renewal_common, True, None,

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -691,6 +691,13 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
                                           args=['renew'], renew=False)
             self.assertEqual(mock_obtain_cert.call_count, 1)
 
+    def test_renew_with_bad_cli_args(self):
+        self.assertRaises(errors.Error, self._test_renewal_common, True, None,
+                          args='renew -d example.com'.split(), renew=False)
+        self.assertRaises(errors.Error, self._test_renewal_common, True, None,
+                          args='renew --csr {0}'.format(CSR).split(),
+                          renew=False)
+
     @mock.patch('letsencrypt.cli.zope.component.getUtility')
     @mock.patch('letsencrypt.cli._treat_as_renewal')
     @mock.patch('letsencrypt.cli._init_le_client')

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -622,6 +622,20 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
             pass  # leave the file empty
         self.test_renew_verb()
 
+    def test_renew_sparse_config(self):
+        renewer_configs_dir = os.path.join(self.config_dir, 'renewal')
+        os.makedirs(renewer_configs_dir)
+        with open(os.path.join(renewer_configs_dir, 'test.conf'), 'w') as f:
+            f.write("My contents don't matter")
+        with mock.patch('letsencrypt.storage.RenewableCert') as mock_rc:
+            mock_lineage = mock.MagicMock()
+            mock_rc.return_value = mock_lineage
+            mock_lineage.configuration = ["not renewalparams"]
+            with mock.patch('letsencrypt.cli.obtain_cert') as mock_obtain_cert:
+                self._test_renewal_common(True, None,
+                                          args=['renew'], renew=False)
+            self.assertFalse(mock_obtain_cert.called)
+
     @mock.patch('letsencrypt.cli.zope.component.getUtility')
     @mock.patch('letsencrypt.cli._treat_as_renewal')
     @mock.patch('letsencrypt.cli._init_le_client')

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -650,7 +650,7 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
             mock_lineage = mock.MagicMock()
             mock_rc.return_value = mock_lineage
             mock_lineage.configuration = {
-                'renewalparams': {'authenticator': None,
+                'renewalparams': {'authenticator': 'webroot',
                                   'rsa_key_size': 'over 9000'}}
             with mock.patch('letsencrypt.cli.obtain_cert') as mock_obtain_cert:
                 self._test_renewal_common(True, None,
@@ -665,9 +665,9 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
         with mock.patch('letsencrypt.storage.RenewableCert') as mock_rc:
             mock_lineage = mock.MagicMock()
             mock_rc.return_value = mock_lineage
-            mock_rc.names.return_value = ['*.example.com']
             mock_lineage.configuration = {
-                'renewalparams': {'authenticator': None}}
+                'renewalparams': {'authenticator': 'webroot'}}
+            mock_lineage.names.return_value = ['*.example.com']
             with mock.patch('letsencrypt.cli.obtain_cert') as mock_obtain_cert:
                 self._test_renewal_common(True, None,
                                           args=['renew'], renew=False)

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -657,6 +657,22 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
                                           args=['renew'], renew=False)
             self.assertFalse(mock_obtain_cert.called)
 
+    def test_renew_with_bad_domain(self):
+        renewer_configs_dir = os.path.join(self.config_dir, 'renewal')
+        os.makedirs(renewer_configs_dir)
+        with open(os.path.join(renewer_configs_dir, 'test.conf'), 'w') as f:
+            f.write("My contents don't matter")
+        with mock.patch('letsencrypt.storage.RenewableCert') as mock_rc:
+            mock_lineage = mock.MagicMock()
+            mock_rc.return_value = mock_lineage
+            mock_rc.names.return_value = ['*.example.com']
+            mock_lineage.configuration = {
+                'renewalparams': {'authenticator': None}}
+            with mock.patch('letsencrypt.cli.obtain_cert') as mock_obtain_cert:
+                self._test_renewal_common(True, None,
+                                          args=['renew'], renew=False)
+            self.assertFalse(mock_obtain_cert.called)
+
     @mock.patch('letsencrypt.cli.zope.component.getUtility')
     @mock.patch('letsencrypt.cli._treat_as_renewal')
     @mock.patch('letsencrypt.cli._init_le_client')

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -691,6 +691,19 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
                                           args=['renew'], renew=False)
             self.assertEqual(mock_obtain_cert.call_count, 1)
 
+    def test_renew_reconstitute_error(self):
+        renewer_configs_dir = os.path.join(self.config_dir, 'renewal')
+        os.makedirs(renewer_configs_dir)
+        with open(os.path.join(renewer_configs_dir, 'test.conf'), 'w') as f:
+            f.write("My contents don't matter")
+        # pylint: disable=protected-access
+        with mock.patch('letsencrypt.cli._reconstitute') as mock_reconstitute:
+            mock_reconstitute.side_effect = [Exception]
+            with mock.patch('letsencrypt.cli.obtain_cert') as mock_obtain_cert:
+                self._test_renewal_common(True, None,
+                                          args=['renew'], renew=False)
+            self.assertFalse(mock_obtain_cert.called)
+
     def test_renew_with_bad_cli_args(self):
         self.assertRaises(errors.Error, self._test_renewal_common, True, None,
                           args='renew -d example.com'.split(), renew=False)


### PR DESCRIPTION
Increases coverage on the `renew` verb and fixes problem with error handling around `enforce_domain_sanity`.