### PR TITLE
Support MacPorts on OS X. This fixes #2447.

### DIFF
--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -348,28 +348,45 @@ BootstrapFreeBsd() {
 }
 
 BootstrapMac() {
-  if ! hash brew 2>/dev/null; then
-      echo "Homebrew not installed.\nDownloading..."
-      ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+  if hash brew 2>/dev/null; then
+    echo "Using Homebrew to install dependencies..."
+    pkgman=brew
+    pkgcmd="brew install"
+  elif hash port 2>/dev/null; then
+    echo "Using MacPorts to install dependencies..."
+    pkgman=port
+    pkgcmd="$SUDO port install"
+  else
+    echo "No Homebrew/MacPorts; installing Homebrew..."
+    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    pkgman=brew
+    pkgcmd="brew install"
   fi
 
-  if [ -z "$(brew list --versions augeas)" ]; then
-      echo "augeas not installed.\nInstalling augeas from Homebrew..."
-      brew install augeas
+  $pkgcmd augeas
+  $pkgcmd dialog
+  if [ "$(which python)" = "/System/Library/Frameworks/Python.framework/Versions/2.7/bin/python" ]; then
+    # We want to avoid using the system Python because it requires root to use pip.
+    # python.org, MacPorts or HomeBrew Python installations should all be OK.
+    echo "Installing python..."
+    $pkgcmd python
   fi
 
-  if [ -z "$(brew list --versions dialog)" ]; then
-      echo "dialog not installed.\nInstalling dialog from Homebrew..."
-      brew install dialog
+  # Workaround for _dlopen not finding augeas on OS X
+  if [ "$pkgman" = "port" ] && ! [ -e "/usr/local/lib/libaugeas.dylib" ] && [ -e "/opt/local/lib/libaugeas.dylib" ]; then
+    echo "Applying augeas workaround"
+    $SUDO ln -s /opt/local/lib/libaugeas.dylib /usr/local/lib
   fi
 
-  if [ -z "$(brew list --versions python)" ]; then
-      echo "python not installed.\nInstalling python from Homebrew..."
-      brew install python
+  if ! hash pip 2>/dev/null; then
+      echo "pip not installed"
+      echo "Installing pip..."
+      curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python
   fi
 
   if ! hash virtualenv 2>/dev/null; then
-      echo "virtualenv not installed.\nInstalling with pip..."
+      echo "virtualenv not installed."
+      echo "Installing with pip..."
       pip install virtualenv
   fi
 }

--- a/letsencrypt-auto-source/pieces/bootstrappers/mac.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/mac.sh
@@ -1,26 +1,43 @@
 BootstrapMac() {
-  if ! hash brew 2>/dev/null; then
-      echo "Homebrew not installed.\nDownloading..."
-      ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+  if hash brew 2>/dev/null; then
+    echo "Using Homebrew to install dependencies..."
+    pkgman=brew
+    pkgcmd="brew install"
+  elif hash port 2>/dev/null; then
+    echo "Using MacPorts to install dependencies..."
+    pkgman=port
+    pkgcmd="$SUDO port install"
+  else
+    echo "No Homebrew/MacPorts; installing Homebrew..."
+    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    pkgman=brew
+    pkgcmd="brew install"
   fi
 
-  if [ -z "$(brew list --versions augeas)" ]; then
-      echo "augeas not installed.\nInstalling augeas from Homebrew..."
-      brew install augeas
+  $pkgcmd augeas
+  $pkgcmd dialog
+  if [ "$(which python)" = "/System/Library/Frameworks/Python.framework/Versions/2.7/bin/python" ]; then
+    # We want to avoid using the system Python because it requires root to use pip.
+    # python.org, MacPorts or HomeBrew Python installations should all be OK.
+    echo "Installing python..."
+    $pkgcmd python
   fi
 
-  if [ -z "$(brew list --versions dialog)" ]; then
-      echo "dialog not installed.\nInstalling dialog from Homebrew..."
-      brew install dialog
+  # Workaround for _dlopen not finding augeas on OS X
+  if [ "$pkgman" = "port" ] && ! [ -e "/usr/local/lib/libaugeas.dylib" ] && [ -e "/opt/local/lib/libaugeas.dylib" ]; then
+    echo "Applying augeas workaround"
+    $SUDO ln -s /opt/local/lib/libaugeas.dylib /usr/local/lib
   fi
 
-  if [ -z "$(brew list --versions python)" ]; then
-      echo "python not installed.\nInstalling python from Homebrew..."
-      brew install python
+  if ! hash pip 2>/dev/null; then
+      echo "pip not installed"
+      echo "Installing pip..."
+      curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python
   fi
 
   if ! hash virtualenv 2>/dev/null; then
-      echo "virtualenv not installed.\nInstalling with pip..."
+      echo "virtualenv not installed."
+      echo "Installing with pip..."
       pip install virtualenv
   fi
 }


### PR DESCRIPTION
Notably, this also installs pip via the recommended `get-pip` route rather than
grabbing a whole new version over Homebrew; this allows the install to work with
OS X's built-in Python or with the python.org Python.