### PR TITLE
dns-01 challenge and response

### DIFF
--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -641,3 +641,32 @@ class DNSResponse(ChallengeResponse):
 
         """
         return chall.check_validation(self.validation, account_public_key)
+
+
+@ChallengeResponse.register
+class DNS01Response(KeyAuthorizationChallengeResponse):
+    """ACME dns-01 challenge response."""
+    typ = "dns-01"
+
+
+@Challenge.register  # pylint: disable=too-many-ancestors
+class DNS01(KeyAuthorizationChallenge):
+    """ACME dns-01 challenge."""
+    response_cls = DNS01Response
+    typ = response_cls.typ
+
+    RR_SUBDOMAIN = "_acme-challenge"
+    RR_TTL = 300
+    RR_CLS = "IN"
+    RR_TYP = "TXT"
+
+    def validation(self, account_key, **unused_kwargs):
+        """Generate validation.
+
+        :param JWK account_key:
+        :rtype: list of fields describing the DNS resource record
+
+        """
+        sha256hash = hashlib.sha256(self.key_authorization(account_key))
+        value = jose.encode_b64jose(sha256hash.digest()).encode('ascii')
+        return [self.RR_SUBDOMAIN, self.RR_TTL, self.RR_CLS, self.RR_TYP, value]


### PR DESCRIPTION
I am creating a dns-01 Authenticator plugin, and these DNS01+DNS01Response classes are needed for that. (With this patch my current plugin prototype works.)

So far I have omitted tests, DNS01Response.simple_verify() and the removal of DNS (old code).

Some questions:
 - Why do HTTP01 and TLSSNI01 have the .simple_verify() method? I see what they do, but only the manual HTTP01 authenticator uses it, and then only to possibly generate a warning. Creating this method for DNS01 would introduce a new dependency (dnspython seems best suited here), so I omited the method entirely.
 - Am I correct in assuming the DNS and DNSResponse classes are dead code? As best as I can tell, the type "dns" is removed from the spec and the way it worked is no longer used anyway.
 - I know unit tests are desired, but since I'm mostly focusing on the plugin itself, I would like a reaction before writing tests that have to be reworked later. I'll update the PR when I add tests.
 - My plugin uses DNS UPDATE, just like the ddns_auth branch by @ThomasWaldmann, but implemented using the dnspython library. Would there be any interest in having it in the main branch? As there is currently no officially supported DNS Authenticator, including it in this repository might make sense.

I would gladly hear comments on the code and these questions.