### PR TITLE
Always install the homebrew version of Python. Fix #1437.

### DIFF
--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -359,8 +359,8 @@ BootstrapMac() {
       brew install dialog
   fi
 
-  if ! hash pip 2>/dev/null; then
-      echo "pip not installed.\nInstalling python from Homebrew..."
+  if [ -z "$(brew list --versions python)" ]; then
+      echo "python not installed.\nInstalling python from Homebrew..."
       brew install python
   fi
 

--- a/letsencrypt-auto-source/pieces/bootstrappers/mac.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/mac.sh
@@ -14,8 +14,8 @@ BootstrapMac() {
       brew install dialog
   fi
 
-  if ! hash pip 2>/dev/null; then
-      echo "pip not installed.\nInstalling python from Homebrew..."
+  if [ -z "$(brew list --versions python)" ]; then
+      echo "python not installed.\nInstalling python from Homebrew..."
       brew install python
   fi
 


### PR DESCRIPTION
Otherwise, we sometimes end up using the system Python, for which we'd need to use sudo to install virtualenv. Brew complicates this by yelling at you if you do use sudo. So let's simplify things by always using the homebrew python, which is more up to date anyway.