### PR TITLE
Adding required /etc/hosts entries to .travis.yml and docs/contributing.rst

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,9 +65,14 @@ branches:
 sudo: false
 
 addons:
-  # make sure simplehttp simple verification works (custom /etc/hosts)
+  # Custom /etc/hosts required for SimpleHTTP simple verification,
+  # simple_verify for http01 and tls-sni-01, and letsencrypt_test_nginx
   hosts:
     - le.wtf
+    - le1.wtf
+    - le2.wtf
+    - le3.wtf
+    - nginx.wtf
   mariadb: "10.0"
   apt:
     sources:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -127,9 +127,9 @@ Afterwards, you'd be able to start Boulder_ using the following command::
 
 The script will download, compile and run the executable; please be
 patient - it will take some time... Once its ready, you will see
-``Server running, listening on 127.0.0.1:4000...``. Add an
-``/etc/hosts`` entry pointing ``le.wtf`` to 127.0.0.1.  You may now
-run (in a separate terminal)::
+``Server running, listening on 127.0.0.1:4000...``. Add ``/etc/hosts``
+entries pointing ``le.wtf``, ``le1.wtf``, ``le2.wtf``, ``le3.wtf``
+and ``nginx.wtf`` to 127.0.0.1.  You may now run (in a separate terminal)::
 
   ./tests/boulder-integration.sh && echo OK || echo FAIL
 


### PR DESCRIPTION
This is a trivial change created by @TheNavigat during his work on https://github.com/letsencrypt/letsencrypt/pull/1876 I discussed with him before sending this PR

(these are used in tests/boulder-integration.sh)