### PR TITLE
wrap csr in ComparableX509

### DIFF
--- a/acme/examples/example_client.py
+++ b/acme/examples/example_client.py
@@ -42,7 +42,7 @@ csr = OpenSSL.crypto.load_certificate_request(
     OpenSSL.crypto.FILETYPE_ASN1, pkg_resources.resource_string(
         'acme', os.path.join('testdata', 'csr.der')))
 try:
-    acme.request_issuance(csr, (authzr,))
+    acme.request_issuance(jose.util.ComparableX509(csr), (authzr,))
 except messages.Error as error:
     print ("This script is doomed to fail as no authorization "
            "challenges are ever solved. Error from server: {0}".format(error))


### PR DESCRIPTION
This causes the example client to fail for the correct reason instead of

    AttributeError: 'X509Req' object has no attribute 'wrapped'