### PR TITLE
Explain IP addresses are specifically forbidden

### DIFF
--- a/letsencrypt/le_util.py
+++ b/letsencrypt/le_util.py
@@ -319,7 +319,7 @@ def enforce_domain_sanity(domain):
     domain = domain[:-1] if domain.endswith('.') else domain
 
     # Explain separately that IP addresses aren't allowed (apart from not
-    # being FQDNs) because hope springs eternal on this point
+    # being FQDNs) because hope springs eternal concerning this point
     try:
         socket.inet_aton(domain)
         raise errors.ConfigurationError(

--- a/letsencrypt/le_util.py
+++ b/letsencrypt/le_util.py
@@ -6,6 +6,7 @@ import logging
 import os
 import platform
 import re
+import socket
 import stat
 import subprocess
 import sys
@@ -316,6 +317,15 @@ def enforce_domain_sanity(domain):
 
     # Remove trailing dot
     domain = domain[:-1] if domain.endswith('.') else domain
+
+    # Explain separately that IP addresses aren't allowed (apart from not
+    # being FQDNs) because hope springs eternal on this point
+    try:
+        socket.inet_aton(domain)
+        raise errors.ConfigurationError("Requested name {0} is an IP address. The Let's Encrypt certificate authority will not issue certificates for a bare IP address.".format(domain))
+    except socket.error:
+        # It wasn't an IP address, so that's good
+        pass
 
     # FQDN checks from
     # http://www.mkyong.com/regular-expressions/domain-name-regular-expression-example/

--- a/letsencrypt/le_util.py
+++ b/letsencrypt/le_util.py
@@ -322,7 +322,10 @@ def enforce_domain_sanity(domain):
     # being FQDNs) because hope springs eternal on this point
     try:
         socket.inet_aton(domain)
-        raise errors.ConfigurationError("Requested name {0} is an IP address. The Let's Encrypt certificate authority will not issue certificates for a bare IP address.".format(domain))
+        raise errors.ConfigurationError(
+            "Requested name {0} is an IP address. The Let's Encrypt "
+            "certificate authority will not issue certificates for a "
+            "bare IP address.".format(domain))
     except socket.error:
         # It wasn't an IP address, so that's good
         pass

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -351,6 +351,11 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
                           self._call,
                           ['-d', '*.wildcard.tld'])
 
+        # Bare IP address (this is actually a different error message now)
+        self.assertRaises(errors.ConfigurationError,
+                          self._call,
+                          ['-d', '204.11.231.35'])
+
     def _get_argument_parser(self):
         plugins = disco.PluginsRegistry.find_all()
         return functools.partial(cli.prepare_and_parse_args, plugins)


### PR DESCRIPTION
People still sometimes ask on the forums and issue tracker whether we *really* meant to forbid them to ask for bare IP addresses in certs. This PR adds a new, distinct error message in this case to make clear that yes, we really did specifically intend that.