### PR TITLE
Fix minor bootstrap problems

### DIFF
--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -328,19 +328,19 @@ BootstrapGentooCommon() {
 
   case "$PACKAGE_MANAGER" in
     (paludis)
-      "$SUDO" cave resolve --preserve-world --keep-targets if-possible $PACKAGES -x
+      $SUDO cave resolve --preserve-world --keep-targets if-possible $PACKAGES -x
       ;;
     (pkgcore)
-      "$SUDO" pmerge --noreplace --oneshot $PACKAGES
+      $SUDO pmerge --noreplace --oneshot $PACKAGES
       ;;
     (portage|*)
-      "$SUDO" emerge --noreplace --oneshot $PACKAGES
+      $SUDO emerge --noreplace --oneshot $PACKAGES
       ;;
   esac
 }
 
 BootstrapFreeBsd() {
-  "$SUDO" pkg install -Ay \
+  $SUDO pkg install -Ay \
     python \
     py27-virtualenv \
     augeas \

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -307,7 +307,8 @@ BootstrapArchCommon() {
     pkg-config
   "
 
-  missing=$($SUDO pacman -T $deps)
+  # pacman -T exits with 127 if there are missing dependencies
+  missing=$($SUDO pacman -T $deps) || true
 
   if [ "$missing" ]; then
     $SUDO pacman -S --needed $missing

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -307,10 +307,10 @@ BootstrapArchCommon() {
     pkg-config
   "
 
-  missing=$("$SUDO" pacman -T $deps)
+  missing=$($SUDO pacman -T $deps)
 
   if [ "$missing" ]; then
-    "$SUDO" pacman -S --needed $missing
+    $SUDO pacman -S --needed $missing
   fi
 }
 

--- a/letsencrypt-auto-source/pieces/bootstrappers/arch_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/arch_common.sh
@@ -18,9 +18,9 @@ BootstrapArchCommon() {
     pkg-config
   "
 
-  missing=$("$SUDO" pacman -T $deps)
+  missing=$($SUDO pacman -T $deps)
 
   if [ "$missing" ]; then
-    "$SUDO" pacman -S --needed $missing
+    $SUDO pacman -S --needed $missing
   fi
 }

--- a/letsencrypt-auto-source/pieces/bootstrappers/arch_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/arch_common.sh
@@ -18,7 +18,8 @@ BootstrapArchCommon() {
     pkg-config
   "
 
-  missing=$($SUDO pacman -T $deps)
+  # pacman -T exits with 127 if there are missing dependencies
+  missing=$($SUDO pacman -T $deps) || true
 
   if [ "$missing" ]; then
     $SUDO pacman -S --needed $missing

--- a/letsencrypt-auto-source/pieces/bootstrappers/free_bsd.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/free_bsd.sh
@@ -1,5 +1,5 @@
 BootstrapFreeBsd() {
-  "$SUDO" pkg install -Ay \
+  $SUDO pkg install -Ay \
     python \
     py27-virtualenv \
     augeas \

--- a/letsencrypt-auto-source/pieces/bootstrappers/gentoo_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/gentoo_common.sh
@@ -11,13 +11,13 @@ BootstrapGentooCommon() {
 
   case "$PACKAGE_MANAGER" in
     (paludis)
-      "$SUDO" cave resolve --preserve-world --keep-targets if-possible $PACKAGES -x
+      $SUDO cave resolve --preserve-world --keep-targets if-possible $PACKAGES -x
       ;;
     (pkgcore)
-      "$SUDO" pmerge --noreplace --oneshot $PACKAGES
+      $SUDO pmerge --noreplace --oneshot $PACKAGES
       ;;
     (portage|*)
-      "$SUDO" emerge --noreplace --oneshot $PACKAGES
+      $SUDO emerge --noreplace --oneshot $PACKAGES
       ;;
   esac
 }


### PR DESCRIPTION
I was trying to run `letsencrypt-auto --os-packages-only --debug` on an Arch system and had the following problems.

1) When running `letsencrypt-auto` as root, `"$SUDO"` becomes an empty string leading to:
```
++ '' pacman -T python2 python-virtualenv gcc dialog augeas openssl libffi ca-certificates pkg-config
./letsencrypt-auto: line 310: : command not found
```

To fix this, I removed quotes around `$SUDO` from `arch_common.sh` and the other bootstrap scripts that had them.

2) `pacman -T example` exits with code 127 if the `example` package is not installed. Because `set -e` is at the top of `letsencrypt-auto`, this means that the script will exit if it needs to install any OS packages.

I fixed this by appending `|| true` to the end of the line containing `pacman -T`.