### PR TITLE
Fix apache 2.2 redirect problems (Issue 2455) [needs minor revision]

### DIFF
--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -1074,6 +1074,9 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
             if not self._is_rewrite_engine_on(general_vh):
                 self.parser.add_dir(general_vh.path, "RewriteEngine", "on")
 
+            for name in ssl_vhost.get_names():
+                self.parser.add_dir(general_vh.path, "RewriteCond",
+                                    ["%{SERVER_NAME}", "={0}".format(name), "[OR]"]
             if self.get_version() >= (2, 3, 9):
                 self.parser.add_dir(general_vh.path, "RewriteRule",
                                     constants.REWRITE_HTTPS_ARGS_WITH_END)
@@ -1242,6 +1245,10 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         # Second filter - check addresses
         for http_vh in candidate_http_vhs:
             if http_vh.same_server(ssl_vhost):
+                return http_vh
+        # Third filter - if none with same names, return generic
+        for http_vh in candidate_http_vhs:
+            if http_vh.same_server(ssl_vhost, generic=True):
                 return http_vh
 
         return None

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -1073,13 +1073,12 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
             #     even with save() and load()
             if not self._is_rewrite_engine_on(general_vh):
                 self.parser.add_dir(general_vh.path, "RewriteEngine", "on")
-            cond = "[OR]"
             names = ssl_vhost.get_names()
             for idx, name in enumerate(names):
+                args = ["%{SERVER_NAME}", "={0}".format(name), "[OR]"]
                 if idx == len(names) - 1:
-                    cond = ""
-                self.parser.add_dir(general_vh.path, "RewriteCond",
-                                    ["%{SERVER_NAME}", "={0}".format(name), cond])
+                    args.pop()
+                self.parser.add_dir(general_vh.path, "RewriteCond", args)
             if self.get_version() >= (2, 3, 9):
                 self.parser.add_dir(general_vh.path, "RewriteRule",
                                     constants.REWRITE_HTTPS_ARGS_WITH_END)

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -1073,10 +1073,13 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
             #     even with save() and load()
             if not self._is_rewrite_engine_on(general_vh):
                 self.parser.add_dir(general_vh.path, "RewriteEngine", "on")
-
-            for name in ssl_vhost.get_names():
+            cond = "[OR]"
+            names = ssl_vhost.get_names()
+            for idx, name in enumerate(names):
+                if idx == len(names) - 1:
+                    cond = ""
                 self.parser.add_dir(general_vh.path, "RewriteCond",
-                                    ["%{SERVER_NAME}", "={0}".format(name), "[OR]"]
+                                    ["%{SERVER_NAME}", "={0}".format(name), cond])
             if self.get_version() >= (2, 3, 9):
                 self.parser.add_dir(general_vh.path, "RewriteRule",
                                     constants.REWRITE_HTTPS_ARGS_WITH_END)

--- a/letsencrypt-apache/letsencrypt_apache/obj.py
+++ b/letsencrypt-apache/letsencrypt_apache/obj.py
@@ -194,6 +194,8 @@ class VirtualHost(object):  # pylint: disable=too-few-public-methods
 
         Used in redirection - indicates whether or not the two virtual hosts
         serve on the exact same IP combinations, but different ports.
+        The generic flag indicates that that we're trying to match to a
+        default or generic vhost
 
         .. todo:: Handle _default_
 
@@ -207,8 +209,7 @@ class VirtualHost(object):  # pylint: disable=too-few-public-methods
             if self.name is not None or self.aliases:
                 return True
         # If we're looking for a generic vhost, don't return one with a ServerName
-        else:
-            if self.name:
+        elif self.name:
                 return False
 
         # Both sets of names are empty.

--- a/letsencrypt-apache/letsencrypt_apache/obj.py
+++ b/letsencrypt-apache/letsencrypt_apache/obj.py
@@ -189,7 +189,7 @@ class VirtualHost(object):  # pylint: disable=too-few-public-methods
                     return True
         return False
 
-    def same_server(self, vhost):
+    def same_server(self, vhost, generic=False):
         """Determines if the vhost is the same 'server'.
 
         Used in redirection - indicates whether or not the two virtual hosts
@@ -199,12 +199,17 @@ class VirtualHost(object):  # pylint: disable=too-few-public-methods
 
         """
 
-        if vhost.get_names() != self.get_names():
-            return False
+        if not generic:
+            if vhost.get_names() != self.get_names():
+                return False
 
-        # If equal and set is not empty... assume same server
-        if self.name is not None or self.aliases:
-            return True
+            # If equal and set is not empty... assume same server
+            if self.name is not None or self.aliases:
+                return True
+        # If we're looking for a generic vhost, don't return one with a ServerName
+        else:
+            if self.name:
+                return False
 
         # Both sets of names are empty.
 

--- a/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
+++ b/letsencrypt-apache/letsencrypt_apache/tests/configurator_test.py
@@ -746,9 +746,9 @@ class TwoVhost80Test(util.ApacheTest):
         self.config.parser.modules.add("rewrite_module")
         mock_exe.return_value = True
         ssl_vh = obj.VirtualHost(
-            "fp", "ap", set([obj.Addr(("*", "443")),
-                             obj.Addr(("satoshi.com",))]),
+            "fp", "ap", set([obj.Addr(("*", "443"))]),
             True, False)
+        ssl_vh.name = "satoshi.com"
         self.config.vhosts.append(ssl_vh)
         self.assertRaises(
             errors.PluginError,


### PR DESCRIPTION
an attempt to fix #2455 
pull in either a vhost with the same names or a generic one (one with no names) on the same addr/port and add a conditional redirect to it using all of the server names in the newly created ssl vhost

more info on the apache syntax here: https://httpd.apache.org/docs/2.2/mod/mod_rewrite.html#rewritecond