### PR TITLE
print only challenge changes to configs

### DIFF
--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -1429,7 +1429,6 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
 
         """
         self.config_test()
-        logger.debug(self.reverter.view_config_changes(for_logging=True))
         self._reload()
 
     def _reload(self):

--- a/letsencrypt-apache/letsencrypt_apache/tls_sni_01.py
+++ b/letsencrypt-apache/letsencrypt_apache/tls_sni_01.py
@@ -144,8 +144,8 @@ class ApacheTlsSni01(common.TLSSNI01):
         if len(self.configurator.parser.find_dir(
                 parser.case_i("Include"), self.challenge_conf)) == 0:
             # print "Including challenge virtual host(s)"
-            logger.debug("Adding Include {0} to {1}".format(
-                            self.challenge_conf, parser.get_aug_path(main_config)))
+            logger.debug("Adding Include %s to %s",
+                          self.challenge_conf, parser.get_aug_path(main_config))
             self.configurator.parser.add_dir(
                 parser.get_aug_path(main_config),
                 "Include", self.challenge_conf)

--- a/letsencrypt-apache/letsencrypt_apache/tls_sni_01.py
+++ b/letsencrypt-apache/letsencrypt_apache/tls_sni_01.py
@@ -108,7 +108,7 @@ class ApacheTlsSni01(common.TLSSNI01):
         self.configurator.reverter.register_file_creation(
             True, self.challenge_conf)
 
-        logger.debug("writing a config file with text: %s", config_text)
+        logger.debug("writing a config file with text:\n %s", config_text)
         with open(self.challenge_conf, "w") as new_conf:
             new_conf.write(config_text)
 
@@ -144,6 +144,8 @@ class ApacheTlsSni01(common.TLSSNI01):
         if len(self.configurator.parser.find_dir(
                 parser.case_i("Include"), self.challenge_conf)) == 0:
             # print "Including challenge virtual host(s)"
+            logger.debug("Adding Include {0} to {1}".format(
+                            self.challenge_conf, parser.get_aug_path(main_config)))
             self.configurator.parser.add_dir(
                 parser.get_aug_path(main_config),
                 "Include", self.challenge_conf)


### PR DESCRIPTION
meant to solve #2410 
by removing the logging of `reverter.view_config_changes` we won't print the whole history of the cert
instead we're doing explicit logging of each change before the reload
here's an excerpt from my server with a breakpoint at the `self._reload()` line in configurator.py

```
2016-02-17 19:01:06,147:DEBUG:letsencrypt_apache.tls_sni_01:Adding Include /etc/apache2/le_tls_sni_01_cert_challenge.conf to /files/etc/apache2/apache2.conf
2016-02-17 19:01:06,149:DEBUG:letsencrypt_apache.tls_sni_01:writing a config file with text:
 <IfModule mod_ssl.c>
<VirtualHost *:443>
    ServerName 2c64574da165a264b88b23074201fcef.e3eb4501eaeae66c2be2660007877514.acme.invalid
    UseCanonicalName on
    SSLStrictSNIVHostCheck on

    LimitRequestBody 1048576

    Include /etc/letsencrypt/options-ssl-apache.conf
    SSLCertificateFile /var/lib/letsencrypt/k_Zt9CfG6ETWu8jV6_CKSmJvOOggdVYfeLcK_Rbrt6w.crt
    SSLCertificateKeyFile /var/lib/letsencrypt/k_Zt9CfG6ETWu8jV6_CKSmJvOOggdVYfeLcK_Rbrt6w.pem

    DocumentRoot /var/lib/letsencrypt/tls_sni_01_page/
</VirtualHost>

</IfModule>

2016-02-17 19:01:06,190:DEBUG:letsencrypt.reverter:Creating backup of /etc/apache2/apache2.conf
> /root/letsencrypt/letsencrypt-apache/letsencrypt_apache/configurator.py(1434)restart()
   1432         self.config_test()
   1433         ipdb.set_trace()
-> 1434         self._reload()
   1435 
   1436     def _reload(self):
```