### PR TITLE
Explicit error message for #2206

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -649,11 +649,6 @@ def record_chosen_plugins(config, plugins, auth, inst):
 # Possible difficulties: config.csr was hacked into auth
 def run(config, plugins):  # pylint: disable=too-many-branches,too-many-locals
     """Obtain a certificate and install."""
-    if config.csr is not None:
-        raise errors.Error("Currently, the default 'run' verb cannot be used "
-                           "when specifying a CSR file. Please try the "
-                           "certonly command instead.")
-
     try:
         installer, authenticator = choose_configurator_plugins(config, plugins, "run")
     except errors.PluginSelectionError as e:
@@ -988,10 +983,6 @@ def renew(config, unused_plugins):
                            "renew specific certificates, use the certonly "
                            "command. The renew verb may provide other options "
                            "for selecting certificates to renew in the future.")
-    if config.csr is not None:
-        raise errors.Error("Currently, the renew verb cannot be used when "
-                           "specifying a CSR file. Please try the certonly "
-                           "command instead.")
     renewer_config = configuration.RenewerConfiguration(config)
     renew_successes = []
     renew_failures = []
@@ -1249,6 +1240,12 @@ class HelpfulArgumentParser(object):
         Process a --csr flag. This needs to happen early enough that the
         webroot plugin can know about the calls to _process_domain
         """
+        if parsed_args.verb != "certonly":
+            raise errors.Error("Currently, a CSR file may only be specified "
+                               "when obtaining a new or replacement "
+                               "via the certonly command. Please try the "
+                               "certonly command instead.")
+
         try:
             csr = le_util.CSR(file=parsed_args.csr[0], data=parsed_args.csr[1], form="der")
             typ = OpenSSL.crypto.FILETYPE_ASN1

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -649,6 +649,11 @@ def record_chosen_plugins(config, plugins, auth, inst):
 # Possible difficulties: config.csr was hacked into auth
 def run(config, plugins):  # pylint: disable=too-many-branches,too-many-locals
     """Obtain a certificate and install."""
+    if config.csr is not None:
+        raise errors.Error("Currently, the default 'run' verb cannot be used "
+                           "when specifying a CSR file. Please try the "
+                           "certonly command instead.")
+
     try:
         installer, authenticator = choose_configurator_plugins(config, plugins, "run")
     except errors.PluginSelectionError as e:

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -356,6 +356,15 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
                           self._call,
                           ['-d', '204.11.231.35'])
 
+    def test_run_with_csr(self):
+        # This is an error because you can only use --csr with certonly
+        try:
+            self._call(['--csr', CSR])
+        except errors.Error as e:
+            assert "Please try the certonly" in e.message
+            return
+        assert False, "Expected supplying --csr to fail with default verb"
+
     def _get_argument_parser(self):
         plugins = disco.PluginsRegistry.find_all()
         return functools.partial(cli.prepare_and_parse_args, plugins)

--- a/letsencrypt/tests/client_test.py
+++ b/letsencrypt/tests/client_test.py
@@ -125,6 +125,9 @@ class ClientTest(unittest.TestCase):
         from letsencrypt import cli
         test_csr = le_util.CSR(form="der", file=None, data=CSR_SAN)
         mock_parsed_args = mock.MagicMock()
+        # The CLI should believe that this is a certonly request, because
+        # a CSR would not be allowed with other kinds of requests!
+        mock_parsed_args.verb = "certonly"
         with mock.patch("letsencrypt.client.le_util.CSR") as mock_CSR:
             mock_CSR.return_value = test_csr
             mock_parsed_args.domains = self.eg_domains[:]


### PR DESCRIPTION
This does not solve #2206 but does cause a clear error message to be generated when supplying `--csr` with `run` (previously, it would just be ignored, which would confuse users who expected to be able to do `letsencrypt --csr foo.pem`, such as the user who filed #2206). Now, it will be an error that stops the execution of the client and directs users to use `certonly` instead.