### PR TITLE
Add Fedora package installation on docs

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -429,6 +429,12 @@ If you don't want to use the Apache plugin, you can omit the
 
 Packages for Debian Jessie are coming in the next few weeks.
 
+**Fedora**
+
+.. code-block:: shell
+
+    sudo dnf install letsencrypt
+
 **Gentoo**
 
 The official Let's Encrypt client is available in Gentoo Portage. If you


### PR DESCRIPTION
The client is available in Fedora's official repos. More [here](https://fedoramagazine.org/letsencrypt-now-available-fedora/).