### PR TITLE
Temporary saves only

### DIFF
--- a/letsencrypt-apache/letsencrypt_apache/tls_sni_01.py
+++ b/letsencrypt-apache/letsencrypt_apache/tls_sni_01.py
@@ -62,7 +62,7 @@ class ApacheTlsSni01(common.TLSSNI01):
             return []
         # Save any changes to the configuration as a precaution
         # About to make temporary changes to the config
-        self.configurator.save()
+        self.configurator.save("Changes before challenge setup", True)
 
         # Prepare the server for HTTPS
         self.configurator.prepare_server_https(


### PR DESCRIPTION
This is related to the problem with `certonly` and the Nginx plugin I mentioned in #1977. This will be a long post for a simple change, but I want to explain context for the reviewer as well link to this post in #1977.

#### Reverter

##### Temporary changes

In the context of the Apache/Nginx plugins, these changes are made when passing `temporary=True` to the `save` method. These changes will be reverted next time `letsencrypt` is run or when `cleanup`/`recovery_routine` is called.

##### In Progress changes

These changes are made when calling the `save` method with `temporary=False` (which is the default) and no title. These changes will be reverted next time `letsencrypt` is run or when `recovery_routine` is called.

##### Checkpointed changes

These changes are made when calling the `save` method with `temporary=False` and a title. The changes include not only those made since the last call to `save`, but all in progress changes as well. They are reverted only when rolling back checkpoints.

#### Why shouldn't authenticators save in progress changes?

An authenticator should only be making temporary changes to the user's configuration. It is not expected that an authenticator should be making permanent changes to the user's configuration in any way.

Per `interfaces.py`, the only reversion function that an authenticator has is `cleanup`. This should revert all changes the plugin has made. Currently, `cleanup` only reverts temporary changes for both the Apache and Nginx plugins, however, the line of code I changed here previously saved in progress changes.

There are a number of fixes to this problem:

1. Have `cleanup` also revert in progress changes. While this works, I think it makes the most sense for all authenticator functions to only make temporary changes since its changes should only exist while performing the challenge.
2. Delete the save if possible. I believe this is possible for the Apache plugin. I am pretty confident Apache never makes any changes before this save (not 100% confident because Augeas continues to surprise me). Nginx, however, does make changes before this save causing the problem I described [here](https://github.com/letsencrypt/letsencrypt/issues/1977#issuecomment-185493304).
3. Make this save temporary so it is reverted properly. This is the approach taken by this PR.