### PR TITLE
Match globs properly

### DIFF
--- a/letsencrypt-apache/letsencrypt_apache/parser.py
+++ b/letsencrypt-apache/letsencrypt_apache/parser.py
@@ -477,7 +477,7 @@ class ApacheParser(object):
         # Note: This works for augeas globs, ie. *.conf
         if use_new:
             inc_test = self.aug.match(
-                "/augeas/load/Httpd/incl [. ='%s']" % filepath)
+                "/augeas/load/Httpd['%s' =~ glob(incl)]" % filepath)
             if not inc_test:
                 # Load up files
                 # This doesn't seem to work on TravisCI


### PR DESCRIPTION
The comment in `_parse_file` is correct that we can use globs to include files to be parsed by the httpd lens, but we weren't using globs when matching.

As an example, suppose we had already included `/etc/apache2/mods-enabled/*.load` and `_parse_file` is called again to see if the lens is parsing `/etc/apache2/mods-enabled/ssl.load`. In this case, `_parse_file` would determine we weren't parsing `ssl.load` and include it again, breaking things.

This code fixes that by matching against a glob. See augeas documentation [here](https://github.com/hercules-team/augeas/wiki/Path-expressions#Builtin_Functions) for more information on `glob()`.

After this lands, #2105 can be merged and we can use those files to ensure this isn't broken again.