### PR TITLE
Py3k minor fixes

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -19,6 +19,7 @@ import traceback
 
 import configargparse
 import OpenSSL
+import six
 import zope.component
 import zope.interface.exceptions
 import zope.interface.verify
@@ -1159,7 +1160,7 @@ class HelpfulArgumentParser(object):
 
     # List of topics for which additional help can be provided
     HELP_TOPICS = ["all", "security",
-                   "paths", "automation", "testing"] + VERBS.keys()
+                   "paths", "automation", "testing"] + list(six.iterkeys(VERBS))
 
     def __init__(self, args, plugins, detect_defaults=False):
         plugin_names = [name for name, _p in plugins.iteritems()]

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -843,7 +843,7 @@ def _restore_plugin_configs(config, renewalparams):
     if renewalparams.get("installer", None) is not None:
         plugin_prefixes.append(renewalparams["installer"])
     for plugin_prefix in set(plugin_prefixes):
-        for config_item, config_value in renewalparams.iteritems():
+        for config_item, config_value in six.iteritems(renewalparams):
             if config_item.startswith(plugin_prefix + "_") and not _set_by_cli(config_item):
                 # Values None, True, and False need to be treated specially,
                 # As they don't get parsed correctly based on type
@@ -1163,7 +1163,7 @@ class HelpfulArgumentParser(object):
                    "paths", "automation", "testing"] + list(six.iterkeys(VERBS))
 
     def __init__(self, args, plugins, detect_defaults=False):
-        plugin_names = [name for name, _p in plugins.iteritems()]
+        plugin_names = list(six.iterkeys(plugins))
         self.help_topics = self.HELP_TOPICS + plugin_names + [None]
         usage, short_usage = usage_strings(plugins)
         self.parser = configargparse.ArgParser(
@@ -1433,7 +1433,7 @@ class HelpfulArgumentParser(object):
         may or may not be displayed as help topics.
 
         """
-        for name, plugin_ep in plugins.iteritems():
+        for name, plugin_ep in six.iteritems(plugins):
             parser_or_group = self.add_group(name, description=plugin_ep.description)
             #print(parser_or_group)
             plugin_ep.plugin_cls.inject_parser_options(parser_or_group, name)
@@ -1828,7 +1828,7 @@ def _process_domain(args_or_config, domain_arg, webroot_path=None):
 class WebrootMapProcessor(argparse.Action):  # pylint: disable=missing-docstring
     def __call__(self, parser, args, webroot_map_arg, option_string=None):
         webroot_map = json.loads(webroot_map_arg)
-        for domains, webroot_path in webroot_map.iteritems():
+        for domains, webroot_path in six.iteritems(webroot_map):
             _process_domain(args, domains, [webroot_path])
 
 

--- a/letsencrypt/plugins/webroot_test.py
+++ b/letsencrypt/plugins/webroot_test.py
@@ -1,4 +1,7 @@
 """Tests for letsencrypt.plugins.webroot."""
+
+from __future__ import print_function
+
 import errno
 import os
 import shutil
@@ -74,7 +77,7 @@ class AuthenticatorTest(unittest.TestCase):
         os.chmod(self.path, 0o000)
         try:
             open(permission_canary, "r")
-            print "Warning, running tests as root skips permissions tests..."
+            print("Warning, running tests as root skips permissions tests...")
         except IOError:
             # ok, permissions work, test away...
             self.assertRaises(errors.PluginError, self.auth.prepare)

--- a/letsencrypt/reporter.py
+++ b/letsencrypt/reporter.py
@@ -4,10 +4,10 @@ from __future__ import print_function
 import collections
 import logging
 import os
-import Queue
 import sys
 import textwrap
 
+from six.moves import queue  # pylint: disable=import-error
 import zope.interface
 
 from letsencrypt import interfaces
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 class Reporter(object):
     """Collects and displays information to the user.
 
-    :ivar `Queue.PriorityQueue` messages: Messages to be displayed to
+    :ivar `queue.PriorityQueue` messages: Messages to be displayed to
         the user.
 
     """
@@ -36,7 +36,7 @@ class Reporter(object):
     _msg_type = collections.namedtuple('ReporterMsg', 'priority text on_crash')
 
     def __init__(self):
-        self.messages = Queue.PriorityQueue()
+        self.messages = queue.PriorityQueue()
 
     def add_message(self, msg, priority, on_crash=True):
         """Adds msg to the list of messages to be printed.

--- a/letsencrypt/storage.py
+++ b/letsencrypt/storage.py
@@ -694,7 +694,7 @@ class RenewableCert(object):  # pylint: disable=too-many-instance-attributes
         for i in (cli_config.renewal_configs_dir, cli_config.archive_dir,
                   cli_config.live_dir):
             if not os.path.exists(i):
-                os.makedirs(i, 0700)
+                os.makedirs(i, 0o700)
                 logger.debug("Creating directory %s.", i)
         config_file, config_filename = le_util.unique_lineage_name(
             cli_config.renewal_configs_dir, lineagename)

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -7,12 +7,12 @@ import functools
 import itertools
 import os
 import shutil
-import StringIO
 import traceback
 import tempfile
 import unittest
 
 import mock
+import six
 
 from acme import jose
 
@@ -84,7 +84,7 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
 
     def _help_output(self, args):
         "Run a command, and return the ouput string for scrutiny"
-        output = StringIO.StringIO()
+        output = six.StringIO()
         with mock.patch('letsencrypt.cli.sys.stdout', new=output):
             self.assertRaises(SystemExit, self._call_stdout, args)
             out = output.getvalue()

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -1,4 +1,7 @@
 """Tests for letsencrypt.cli."""
+
+from __future__ import print_function
+
 import argparse
 import functools
 import itertools
@@ -580,7 +583,7 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
                                 try:
                                     ret, _, _, _ = self._call(args)
                                     if ret:
-                                        print "Returned", ret
+                                        print("Returned", ret)
                                         raise AssertionError(ret)
                                     assert not error_expected, "renewal should have errored"
                                 except: # pylint: disable=bare-except
@@ -628,8 +631,8 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
 
     def _dump_log(self):
         with open(os.path.join(self.logs_dir, "letsencrypt.log")) as lf:
-            print "Logs:"
-            print lf.read()
+            print("Logs:")
+            print(lf.read())
 
 
     def _make_test_renewal_conf(self, testfile):

--- a/letsencrypt/tests/colored_logging_test.py
+++ b/letsencrypt/tests/colored_logging_test.py
@@ -1,7 +1,8 @@
 """Tests for letsencrypt.colored_logging."""
 import logging
-import StringIO
 import unittest
+
+import six
 
 from letsencrypt import le_util
 
@@ -12,7 +13,7 @@ class StreamHandlerTest(unittest.TestCase):
     def setUp(self):
         from letsencrypt import colored_logging
 
-        self.stream = StringIO.StringIO()
+        self.stream = six.StringIO()
         self.stream.isatty = lambda: True
         self.handler = colored_logging.StreamHandler(self.stream)
 

--- a/letsencrypt/tests/le_util_test.py
+++ b/letsencrypt/tests/le_util_test.py
@@ -4,11 +4,11 @@ import errno
 import os
 import shutil
 import stat
-import StringIO
 import tempfile
 import unittest
 
 import mock
+import six
 
 from letsencrypt import errors
 
@@ -307,14 +307,14 @@ class AddDeprecatedArgumentTest(unittest.TestCase):
         self.assertTrue("--old-option is deprecated" in stderr)
 
     def _get_argparse_warnings(self, args):
-        stderr = StringIO.StringIO()
+        stderr = six.StringIO()
         with mock.patch("letsencrypt.le_util.sys.stderr", new=stderr):
             self.parser.parse_args(args)
         return stderr.getvalue()
 
     def test_help(self):
         self._call("--old-option", 2)
-        stdout = StringIO.StringIO()
+        stdout = six.StringIO()
         with mock.patch("letsencrypt.le_util.sys.stdout", new=stdout):
             try:
                 self.parser.parse_args(["-h"])

--- a/letsencrypt/tests/reporter_test.py
+++ b/letsencrypt/tests/reporter_test.py
@@ -1,7 +1,8 @@
 """Tests for letsencrypt.reporter."""
-import StringIO
 import sys
 import unittest
+
+import six
 
 
 class ReporterTest(unittest.TestCase):
@@ -12,7 +13,7 @@ class ReporterTest(unittest.TestCase):
         self.reporter = reporter.Reporter()
 
         self.old_stdout = sys.stdout
-        sys.stdout = StringIO.StringIO()
+        sys.stdout = six.StringIO()
 
     def tearDown(self):
         sys.stdout = self.old_stdout

--- a/letshelp-letsencrypt/letshelp_letsencrypt/apache.py
+++ b/letshelp-letsencrypt/letshelp_letsencrypt/apache.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 """Let's Encrypt Apache configuration submission script"""
+
+from __future__ import print_function
+
 import argparse
 import atexit
 import contextlib
@@ -48,20 +51,20 @@ def make_and_verify_selection(server_root, temp_dir):
     """
     copied_files, copied_dirs = copy_config(server_root, temp_dir)
 
-    print textwrap.fill("A secure copy of the files that have been selected "
+    print(textwrap.fill("A secure copy of the files that have been selected "
                         "for submission has been created under {0}. All "
                         "comments have been removed and the files are only "
                         "accessible by the current user. A list of the files "
                         "that have been included is shown below. Please make "
                         "sure that this selection does not contain private "
                         "keys, passwords, or any other sensitive "
-                        "information.".format(temp_dir))
-    print "\nFiles:"
+                        "information.".format(temp_dir)))
+    print("\nFiles:")
     for copied_file in copied_files:
-        print copied_file
-    print "Directories (including all contained files):"
+        print(copied_file)
+    print("Directories (including all contained files):")
     for copied_dir in copied_dirs:
-        print copied_dir
+        print(copied_dir)
 
     sys.stdout.write("\nIs it safe to submit these files? ")
     while True:


### PR DESCRIPTION
A small bundle of Python 3 compatibility fixes.

This represents all the small and simple Python 3 touchups required to get `letsencrypt --help` up and running. There's some slightly larger changes, but they will be in a separate PR.