### PR TITLE
Class advice impossible

### DIFF
--- a/examples/plugins/letsencrypt_example_plugins.py
+++ b/examples/plugins/letsencrypt_example_plugins.py
@@ -9,9 +9,9 @@ from letsencrypt import interfaces
 from letsencrypt.plugins import common
 
 
+@zope.interface.implementer(interfaces.IAuthenticator)
 class Authenticator(common.Plugin):
     """Example Authenticator."""
-    zope.interface.implements(interfaces.IAuthenticator)
     zope.interface.classProvides(interfaces.IPluginFactory)
 
     description = "Example Authenticator plugin"
@@ -20,9 +20,9 @@ class Authenticator(common.Plugin):
     # "self" as first argument, e.g. def prepare(self)...
 
 
+@zope.interface.implementer(interfaces.IInstaller)
 class Installer(common.Plugin):
     """Example Installer."""
-    zope.interface.implements(interfaces.IInstaller)
     zope.interface.classProvides(interfaces.IPluginFactory)
 
     description = "Example Installer plugin"

--- a/examples/plugins/letsencrypt_example_plugins.py
+++ b/examples/plugins/letsencrypt_example_plugins.py
@@ -10,9 +10,9 @@ from letsencrypt.plugins import common
 
 
 @zope.interface.implementer(interfaces.IAuthenticator)
+@zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(common.Plugin):
     """Example Authenticator."""
-    zope.interface.classProvides(interfaces.IPluginFactory)
 
     description = "Example Authenticator plugin"
 
@@ -21,9 +21,9 @@ class Authenticator(common.Plugin):
 
 
 @zope.interface.implementer(interfaces.IInstaller)
+@zope.interface.provider(interfaces.IPluginFactory)
 class Installer(common.Plugin):
     """Example Installer."""
-    zope.interface.classProvides(interfaces.IPluginFactory)
 
     description = "Example Installer plugin"
 

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -61,6 +61,7 @@ logger = logging.getLogger(__name__)
 #     and load()
 
 @zope.interface.implementer(interfaces.IAuthenticator, interfaces.IInstaller)
+@zope.interface.provider(interfaces.IPluginFactory)
 class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
     # pylint: disable=too-many-instance-attributes,too-many-public-methods
     """Apache configurator.
@@ -81,7 +82,6 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
     :ivar dict assoc: Mapping between domains and vhosts
 
     """
-    zope.interface.classProvides(interfaces.IPluginFactory)
 
     description = "Apache Web Server - Alpha"
 

--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -60,6 +60,7 @@ logger = logging.getLogger(__name__)
 #     sites-available doesn't allow immediate find_dir search even with save()
 #     and load()
 
+@zope.interface.implementer(interfaces.IAuthenticator, interfaces.IInstaller)
 class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
     # pylint: disable=too-many-instance-attributes,too-many-public-methods
     """Apache configurator.
@@ -80,7 +81,6 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
     :ivar dict assoc: Mapping between domains and vhosts
 
     """
-    zope.interface.implements(interfaces.IAuthenticator, interfaces.IInstaller)
     zope.interface.classProvides(interfaces.IPluginFactory)
 
     description = "Apache Web Server - Alpha"

--- a/letsencrypt-compatibility-test/letsencrypt_compatibility_test/configurators/apache/apache24.py
+++ b/letsencrypt-compatibility-test/letsencrypt_compatibility_test/configurators/apache/apache24.py
@@ -34,10 +34,9 @@ SHARED_MODULES = {
     "vhost_alias"}
 
 
+@zope.interface.implementer(interfaces.IConfiguratorProxy)
 class Proxy(apache_common.Proxy):
     """Wraps the ApacheConfigurator for Apache 2.4 tests"""
-
-    zope.interface.implements(interfaces.IConfiguratorProxy)
 
     def __init__(self, args):
         """Initializes the plugin with the given command line args"""

--- a/letsencrypt-compatibility-test/letsencrypt_compatibility_test/configurators/apache/common.py
+++ b/letsencrypt-compatibility-test/letsencrypt_compatibility_test/configurators/apache/common.py
@@ -19,11 +19,10 @@ APACHE_VERSION_REGEX = re.compile(r"Apache/([0-9\.]*)", re.IGNORECASE)
 APACHE_COMMANDS = ["apachectl", "a2enmod", "a2dismod"]
 
 
+@zope.interface.implementer(interfaces.IConfiguratorProxy)
 class Proxy(configurators_common.Proxy):
     # pylint: disable=too-many-instance-attributes
     """A common base for Apache test configurators"""
-
-    zope.interface.implements(interfaces.IConfiguratorProxy)
 
     def __init__(self, args):
         """Initializes the plugin with the given command line args"""

--- a/letsencrypt-compatibility-test/letsencrypt_compatibility_test/validator.py
+++ b/letsencrypt-compatibility-test/letsencrypt_compatibility_test/validator.py
@@ -12,10 +12,10 @@ from letsencrypt import interfaces
 logger = logging.getLogger(__name__)
 
 
+@zope.interface.implementer(interfaces.IValidator)
 class Validator(object):
     # pylint: disable=no-self-use
     """Collection of functions to test a live webserver's configuration"""
-    zope.interface.implements(interfaces.IValidator)
 
     def certificate(self, cert, name, alt_host=None, port=443):
         """Verifies the certificate presented at name is cert"""

--- a/letsencrypt-nginx/letsencrypt_nginx/configurator.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/configurator.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 @zope.interface.implementer(interfaces.IAuthenticator, interfaces.IInstaller)
+@zope.interface.provider(interfaces.IPluginFactory)
 class NginxConfigurator(common.Plugin):
     # pylint: disable=too-many-instance-attributes,too-many-public-methods
     """Nginx configurator.
@@ -53,7 +54,6 @@ class NginxConfigurator(common.Plugin):
     :ivar tup version: version of Nginx
 
     """
-    zope.interface.classProvides(interfaces.IPluginFactory)
 
     description = "Nginx Web Server - currently doesn't work"
 

--- a/letsencrypt-nginx/letsencrypt_nginx/configurator.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/configurator.py
@@ -31,6 +31,7 @@ from letsencrypt_nginx import parser
 logger = logging.getLogger(__name__)
 
 
+@zope.interface.implementer(interfaces.IAuthenticator, interfaces.IInstaller)
 class NginxConfigurator(common.Plugin):
     # pylint: disable=too-many-instance-attributes,too-many-public-methods
     """Nginx configurator.
@@ -52,7 +53,6 @@ class NginxConfigurator(common.Plugin):
     :ivar tup version: version of Nginx
 
     """
-    zope.interface.implements(interfaces.IAuthenticator, interfaces.IInstaller)
     zope.interface.classProvides(interfaces.IPluginFactory)
 
     description = "Nginx Web Server - currently doesn't work"

--- a/letsencrypt/configuration.py
+++ b/letsencrypt/configuration.py
@@ -11,6 +11,7 @@ from letsencrypt import interfaces
 from letsencrypt import le_util
 
 
+@zope.interface.implementer(interfaces.IConfig)
 class NamespaceConfig(object):
     """Configuration wrapper around :class:`argparse.Namespace`.
 
@@ -32,7 +33,6 @@ class NamespaceConfig(object):
     :type namespace: :class:`argparse.Namespace`
 
     """
-    zope.interface.implements(interfaces.IConfig)
 
     def __init__(self, namespace):
         self.namespace = namespace

--- a/letsencrypt/continuity_auth.py
+++ b/letsencrypt/continuity_auth.py
@@ -9,6 +9,7 @@ from letsencrypt import interfaces
 from letsencrypt import proof_of_possession
 
 
+@zope.interface.implementer(interfaces.IAuthenticator)
 class ContinuityAuthenticator(object):
     """IAuthenticator for
     :const:`~acme.challenges.ContinuityChallenge` class challenges.
@@ -18,7 +19,6 @@ class ContinuityAuthenticator(object):
         :class:`letsencrypt.proof_of_possession.Proof_of_Possession`
 
     """
-    zope.interface.implements(interfaces.IAuthenticator)
 
     # This will have an installer soon for get_key/cert purposes
     def __init__(self, config, installer):  # pylint: disable=unused-argument

--- a/letsencrypt/display/util.py
+++ b/letsencrypt/display/util.py
@@ -36,10 +36,9 @@ def _wrap_lines(msg):
         fixed_l.append(textwrap.fill(line, 80))
     return os.linesep.join(fixed_l)
 
+@zope.interface.implementer(interfaces.IDisplay)
 class NcursesDisplay(object):
     """Ncurses-based display."""
-
-    zope.interface.implements(interfaces.IDisplay)
 
     def __init__(self, width=WIDTH, height=HEIGHT):
         super(NcursesDisplay, self).__init__()
@@ -176,10 +175,9 @@ class NcursesDisplay(object):
             message, width=self.width, height=self.height, choices=choices)
 
 
+@zope.interface.implementer(interfaces.IDisplay)
 class FileDisplay(object):
     """File-based display."""
-
-    zope.interface.implements(interfaces.IDisplay)
 
     def __init__(self, outfile):
         super(FileDisplay, self).__init__()
@@ -411,10 +409,9 @@ class FileDisplay(object):
 
         return OK, selection
 
+@zope.interface.implementer(interfaces.IDisplay)
 class NoninteractiveDisplay(object):
     """An iDisplay implementation that never asks for interactive user input"""
-
-    zope.interface.implements(interfaces.IDisplay)
 
     def __init__(self, outfile):
         super(NoninteractiveDisplay, self).__init__()

--- a/letsencrypt/plugins/common.py
+++ b/letsencrypt/plugins/common.py
@@ -31,9 +31,9 @@ hostname_regex = re.compile(
     r"^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*[a-z]+$", re.IGNORECASE)
 
 
+@zope.interface.implementer(interfaces.IPlugin)
 class Plugin(object):
     """Generic plugin."""
-    zope.interface.implements(interfaces.IPlugin)
     # classProvides is not inherited, subclasses must define it on their own
     #zope.interface.classProvides(interfaces.IPluginFactory)
 

--- a/letsencrypt/plugins/common.py
+++ b/letsencrypt/plugins/common.py
@@ -34,8 +34,8 @@ hostname_regex = re.compile(
 @zope.interface.implementer(interfaces.IPlugin)
 class Plugin(object):
     """Generic plugin."""
-    # classProvides is not inherited, subclasses must define it on their own
-    #zope.interface.classProvides(interfaces.IPluginFactory)
+    # provider is not inherited, subclasses must define it on their own
+    # @zope.interface.provider(interfaces.IPluginFactory)
 
     def __init__(self, config, name):
         self.config = config

--- a/letsencrypt/plugins/manual.py
+++ b/letsencrypt/plugins/manual.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 @zope.interface.implementer(interfaces.IAuthenticator)
+@zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(common.Plugin):
     """Manual Authenticator.
 
@@ -35,7 +36,6 @@ class Authenticator(common.Plugin):
     .. todo:: Support for `~.challenges.TLSSNI01`.
 
     """
-    zope.interface.classProvides(interfaces.IPluginFactory)
     hidden = True
 
     description = "Manually configure an HTTP server"

--- a/letsencrypt/plugins/manual.py
+++ b/letsencrypt/plugins/manual.py
@@ -23,6 +23,7 @@ from letsencrypt.plugins import common
 logger = logging.getLogger(__name__)
 
 
+@zope.interface.implementer(interfaces.IAuthenticator)
 class Authenticator(common.Plugin):
     """Manual Authenticator.
 
@@ -34,7 +35,6 @@ class Authenticator(common.Plugin):
     .. todo:: Support for `~.challenges.TLSSNI01`.
 
     """
-    zope.interface.implements(interfaces.IAuthenticator)
     zope.interface.classProvides(interfaces.IPluginFactory)
     hidden = True
 

--- a/letsencrypt/plugins/null.py
+++ b/letsencrypt/plugins/null.py
@@ -12,9 +12,9 @@ logger = logging.getLogger(__name__)
 
 
 @zope.interface.implementer(interfaces.IInstaller)
+@zope.interface.provider(interfaces.IPluginFactory)
 class Installer(common.Plugin):
     """Null installer."""
-    zope.interface.classProvides(interfaces.IPluginFactory)
 
     description = "Null Installer"
     hidden = True

--- a/letsencrypt/plugins/null.py
+++ b/letsencrypt/plugins/null.py
@@ -11,9 +11,9 @@ from letsencrypt.plugins import common
 logger = logging.getLogger(__name__)
 
 
+@zope.interface.implementer(interfaces.IInstaller)
 class Installer(common.Plugin):
     """Null installer."""
-    zope.interface.implements(interfaces.IInstaller)
     zope.interface.classProvides(interfaces.IPluginFactory)
 
     description = "Null Installer"

--- a/letsencrypt/plugins/standalone.py
+++ b/letsencrypt/plugins/standalone.py
@@ -136,6 +136,7 @@ def supported_challenges_validator(data):
 
 
 @zope.interface.implementer(interfaces.IAuthenticator)
+@zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(common.Plugin):
     """Standalone Authenticator.
 
@@ -144,7 +145,6 @@ class Authenticator(common.Plugin):
     challenges from the certificate authority. Therefore, it does not
     rely on any existing server program.
     """
-    zope.interface.classProvides(interfaces.IPluginFactory)
 
     description = "Automatically use a temporary webserver"
 

--- a/letsencrypt/plugins/standalone.py
+++ b/letsencrypt/plugins/standalone.py
@@ -135,6 +135,7 @@ def supported_challenges_validator(data):
     return data
 
 
+@zope.interface.implementer(interfaces.IAuthenticator)
 class Authenticator(common.Plugin):
     """Standalone Authenticator.
 
@@ -143,7 +144,6 @@ class Authenticator(common.Plugin):
     challenges from the certificate authority. Therefore, it does not
     rely on any existing server program.
     """
-    zope.interface.implements(interfaces.IAuthenticator)
     zope.interface.classProvides(interfaces.IPluginFactory)
 
     description = "Automatically use a temporary webserver"

--- a/letsencrypt/plugins/webroot.py
+++ b/letsencrypt/plugins/webroot.py
@@ -18,9 +18,9 @@ logger = logging.getLogger(__name__)
 
 
 @zope.interface.implementer(interfaces.IAuthenticator)
+@zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(common.Plugin):
     """Webroot Authenticator."""
-    zope.interface.classProvides(interfaces.IPluginFactory)
 
     description = "Webroot Authenticator"
 

--- a/letsencrypt/plugins/webroot.py
+++ b/letsencrypt/plugins/webroot.py
@@ -17,9 +17,9 @@ from letsencrypt.plugins import common
 logger = logging.getLogger(__name__)
 
 
+@zope.interface.implementer(interfaces.IAuthenticator)
 class Authenticator(common.Plugin):
     """Webroot Authenticator."""
-    zope.interface.implements(interfaces.IAuthenticator)
     zope.interface.classProvides(interfaces.IPluginFactory)
 
     description = "Webroot Authenticator"

--- a/letsencrypt/reporter.py
+++ b/letsencrypt/reporter.py
@@ -17,6 +17,7 @@ from letsencrypt import le_util
 logger = logging.getLogger(__name__)
 
 
+@zope.interface.implementer(interfaces.IReporter)
 class Reporter(object):
     """Collects and displays information to the user.
 
@@ -24,7 +25,6 @@ class Reporter(object):
         the user.
 
     """
-    zope.interface.implements(interfaces.IReporter)
 
     HIGH_PRIORITY = 0
     """High priority constant. See `add_message`."""


### PR DESCRIPTION
The uses of these two `zope` items causes exceptions in Python 3. The exception suggests this use instead, and exception is definitely being raised because of the former syntax being used in Python 3:

Here's an example,

```
----> 1 import letsencrypt.configuration

…/letsencrypt/configuration.py in <module>()
     12 
     13 
---> 14 class NamespaceConfig(object):
     15     """Configuration wrapper around :class:`argparse.Namespace`.
     16 

…/zope/interface/declarations.py in implements(*interfaces)
    410     # the coverage for this block there. :(
    411     if PYTHON3: #pragma NO COVER
--> 412         raise TypeError(_ADVICE_ERROR % 'implementer')
    413     _implements("implements", interfaces, classImplements)
    414 

TypeError: Class advice impossible in Python3.  Use the @implementer class decorator instead.
```

Attempting to follow the advice given by the exception.