### PR TITLE
PyOpenSSL 0.13 can not be compiled with OpenSSL 1.0.2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ deps =
     py{26,27}-oldest: cryptography==0.8
     py{26,27}-oldest: configargparse==0.10.0
     py{26,27}-oldest: psutil==2.1.0
-    py{26,27}-oldest: PyOpenSSL==0.13
+    py{26,27}-oldest: PyOpenSSL==0.14
     py{26,27}-oldest: python2-pythondialog==3.2.2rc1
 
 [testenv:py33]


### PR DESCRIPTION
This sets the PyOpenSSL version for py26-oldest and py27-oldest to 0.14. Increasing it further or not capping it at all result in a coverage failure within the acme package regarding the standalone_test and crypto_util.

Running `tox` with OpenSSL >=1.0.2a resulted in the following build error which is known in pyca/pyopenssl#276:
```
OpenSSL/crypto/crl.c:6:23: error: static declaration of ‘X509_REVOKED_dup’ follows non-static declaration
   static X509_REVOKED * X509_REVOKED_dup(X509_REVOKED *orig) {
                         ^
  In file included from /usr/include/openssl/ssl.h:156:0,
                   from OpenSSL/crypto/x509.h:17,
                   from OpenSSL/crypto/crypto.h:30,
                   from OpenSSL/crypto/crl.c:3:
  /usr/include/openssl/x509.h:751:15: note: previous declaration of ‘X509_REVOKED_dup’ was here
   X509_REVOKED *X509_REVOKED_dup(X509_REVOKED *rev);
                 ^
  error: command 'gcc' failed with exit status 1
```
