### PR TITLE
Use a new file for the updated le-auto script. Fix #2456.

### DIFF
--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -1818,12 +1818,21 @@ UNLIKELY_EOF
     # future Windows compatibility.
     "$LE_PYTHON" "$TEMP_DIR/fetch.py" --le-auto-script "v$REMOTE_VERSION"
 
-    # Install new copy of letsencrypt-auto. This preserves permissions and
-    # ownership from the old copy.
+    # Install new copy of letsencrypt-auto.
     # TODO: Deal with quotes in pathnames.
     echo "Replacing letsencrypt-auto..."
-    echo "  " $SUDO cp "$TEMP_DIR/letsencrypt-auto" "$0"
-    $SUDO cp "$TEMP_DIR/letsencrypt-auto" "$0"
+    # Clone permissions with cp. chmod and chown don't have a --reference
+    # option on OS X or BSD, and stat -c on Linux is stat -f on OS X and BSD:
+    echo "  " $SUDO cp -p "$0" "$TEMP_DIR/letsencrypt-auto.permission-clone"
+    $SUDO cp -p "$0" "$TEMP_DIR/letsencrypt-auto.permission-clone"
+    echo "  " $SUDO cp "$TEMP_DIR/letsencrypt-auto" "$TEMP_DIR/letsencrypt-auto.permission-clone"
+    $SUDO cp "$TEMP_DIR/letsencrypt-auto" "$TEMP_DIR/letsencrypt-auto.permission-clone"
+    # Using mv rather than cp leaves the old file descriptor pointing to the
+    # original copy so the shell can continue to read it unmolested. mv across
+    # filesystems is non-atomic, doing `rm dest, cp src dest, rm src`, but the
+    # cp is unlikely to fail (esp. under sudo) if the rm doesn't.
+    echo "  " $SUDO mv -f "$TEMP_DIR/letsencrypt-auto.permission-clone" "$0"
+    $SUDO mv -f "$TEMP_DIR/letsencrypt-auto.permission-clone" "$0"
     # TODO: Clean up temp dir safely, even if it has quotes in its path.
     rm -rf "$TEMP_DIR"
   fi  # should upgrade

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -252,12 +252,21 @@ UNLIKELY_EOF
     # future Windows compatibility.
     "$LE_PYTHON" "$TEMP_DIR/fetch.py" --le-auto-script "v$REMOTE_VERSION"
 
-    # Install new copy of letsencrypt-auto. This preserves permissions and
-    # ownership from the old copy.
+    # Install new copy of letsencrypt-auto.
     # TODO: Deal with quotes in pathnames.
     echo "Replacing letsencrypt-auto..."
-    echo "  " $SUDO cp "$TEMP_DIR/letsencrypt-auto" "$0"
-    $SUDO cp "$TEMP_DIR/letsencrypt-auto" "$0"
+    # Clone permissions with cp. chmod and chown don't have a --reference
+    # option on OS X or BSD, and stat -c on Linux is stat -f on OS X and BSD:
+    echo "  " $SUDO cp -p "$0" "$TEMP_DIR/letsencrypt-auto.permission-clone"
+    $SUDO cp -p "$0" "$TEMP_DIR/letsencrypt-auto.permission-clone"
+    echo "  " $SUDO cp "$TEMP_DIR/letsencrypt-auto" "$TEMP_DIR/letsencrypt-auto.permission-clone"
+    $SUDO cp "$TEMP_DIR/letsencrypt-auto" "$TEMP_DIR/letsencrypt-auto.permission-clone"
+    # Using mv rather than cp leaves the old file descriptor pointing to the
+    # original copy so the shell can continue to read it unmolested. mv across
+    # filesystems is non-atomic, doing `rm dest, cp src dest, rm src`, but the
+    # cp is unlikely to fail (esp. under sudo) if the rm doesn't.
+    echo "  " $SUDO mv -f "$TEMP_DIR/letsencrypt-auto.permission-clone" "$0"
+    $SUDO mv -f "$TEMP_DIR/letsencrypt-auto.permission-clone" "$0"
     # TODO: Clean up temp dir safely, even if it has quotes in its path.
     rm -rf "$TEMP_DIR"
   fi  # should upgrade


### PR DESCRIPTION
@bmw I took a look at the various approaches and decided to err on the side of simplicity. Yes, there's an assumption necessary for this to work--that the shell doesn't do multiple open() calls to the script path throughout the life of the interpreter--but I think it's reasonable. The alternative of exec-ing out to a dedicated update script which then execs back to le-auto has more moving parts (like extra files that we have to clean up and a way of passing Phase 2 of the script the temp folder so it can clean it up) and is longer.

I don't have a good test for this yet; the repro in the ticket works for the wgetted version but not for my locally built one at safer-shell-script-updates^. See if it looks sane to you in the meantime.