### PR TITLE
Merge Augeas lens fix for backslashes in section headings

### DIFF
--- a/letsencrypt-apache/letsencrypt_apache/augeas_lens/httpd.aug
+++ b/letsencrypt-apache/letsencrypt_apache/augeas_lens/httpd.aug
@@ -59,7 +59,7 @@ let indent              = Util.indent
 
 (* borrowed from shellvars.aug *)
 let char_arg_dir  = /([^\\ '"{\t\r\n]|[^ '"{\t\r\n]+[^\\ \t\r\n])|\\\\"|\\\\'/
-let char_arg_sec  = /[^\\ '"\t\r\n>]|\\\\"|\\\\'/
+let char_arg_sec  = /([^\\ '"\t\r\n>]|[^ '"\t\r\n>]+[^\\ \t\r\n>])|\\\\"|\\\\'/
 let char_arg_wl   = /([^\\ '"},\t\r\n]|[^ '"},\t\r\n]+[^\\ '"},\t\r\n])/
 
 let cdot = /\\\\./


### PR DESCRIPTION
From https://github.com/hercules-team/augeas/commit/1cd33e52110e7c85befc00d93c867ec89cc12628

This adds to PR #2538.