### PR TITLE
Remove error type for nonexistant revoker

### DIFF
--- a/letsencrypt/errors.py
+++ b/letsencrypt/errors.py
@@ -86,10 +86,6 @@ class NotSupportedError(PluginError):
     """Let's Encrypt Plugin function not supported error."""
 
 
-class RevokerError(Error):
-    """Let's Encrypt Revoker error."""
-
-
 class StandaloneBindError(Error):
     """Standalone plugin bind error."""
 


### PR DESCRIPTION
While working on #1304 I found `RevokerError`. `revoker.py` is long gone so this can be deleted.