### PR TITLE
Revert "Pin parsedatetime version < 2.0"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ install_requires = [
     'ConfigArgParse>=0.9.3',
     'configobj',
     'cryptography>=0.7',  # load_pem_x509_certificate
-    'parsedatetime<2.0',  # parsedatetime 2.0 doesn't work on py26
+    'parsedatetime',
     'psutil>=2.1.0',  # net_connections introduced in 2.1.0
     'PyOpenSSL',
     'pyrfc3339',


### PR DESCRIPTION
Reverts letsencrypt/letsencrypt#2568

`parsedatetime` already pushed fixes for us to PyPI so we can remove this pin.