### PR TITLE
Require setuptools>=1.0 in all our packages.

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -18,7 +18,9 @@ install_requires = [
     'pyrfc3339',
     'pytz',
     'requests',
-    'setuptools',  # pkg_resources
+    # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
+    # will tolerate; see #2599:
+    'setuptools>=1.0',
     'six',
 ]
 

--- a/letsencrypt-apache/setup.py
+++ b/letsencrypt-apache/setup.py
@@ -11,7 +11,9 @@ install_requires = [
     'acme=={0}'.format(version),
     'letsencrypt=={0}'.format(version),
     'python-augeas',
-    'setuptools',  # pkg_resources
+    # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
+    # will tolerate; see #2599:
+    'setuptools>=1.0',
     'zope.component',
     'zope.interface',
 ]

--- a/letsencrypt-nginx/setup.py
+++ b/letsencrypt-nginx/setup.py
@@ -12,7 +12,9 @@ install_requires = [
     'letsencrypt=={0}'.format(version),
     'PyOpenSSL',
     'pyparsing>=1.5.5',  # Python3 support; perhaps unnecessary?
-    'setuptools',  # pkg_resources
+    # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
+    # will tolerate; see #2599:
+    'setuptools>=1.0',
     'zope.interface',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,9 @@ install_requires = [
     'pyrfc3339',
     'python2-pythondialog>=3.2.2rc1',  # Debian squeeze support, cf. #280
     'pytz',
-    'setuptools',  # pkg_resources
+    # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
+    # will tolerate; see #2599:
+    'setuptools>=1.0',
     'six',
     'zope.component',
     'zope.interface',


### PR DESCRIPTION
When pip-installing any of our packages, pip hits our permissive, any-version "setuptools" dependency first and then ignores all subsequent, more constrained ones, like cryptography's "setuptools>=1.0". See https://github.com/pypa/pip/issues/988. It thus, on a box with setuptools 0.9.8, sticks with that version. Then, at runtime, letsencrypt crashes because pkg_resources can't satisfy cryptography's setuptools>=1.0 requirement.

This change lets us pip-install our packages and have it work. We'll need to make sure our direct requirements (all of them) satisfy the more constrained requirements of our dependencies. Yes, it is disgusting.