### PR TITLE
Blot out Travis addons on le_auto job.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ matrix:
       env: TOXENV=le_auto
       services: docker
       before_install:
+      addons:
     - python: "2.7"
       env: TOXENV=cover
     - python: "3.3"


### PR DESCRIPTION
MariaDB addon is broken on Google Compute Engine jobs at the moment: see https://github.com/travis-ci/travis-ci/issues/5759.