### PR TITLE
don't include files that have multiple vhosts

### DIFF
--- a/letsencrypt-apache/letsencrypt_apache/configurator.py
+++ b/letsencrypt-apache/letsencrypt_apache/configurator.py
@@ -545,6 +545,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
             paths = self.aug.match(
                 ("/files%s//*[label()=~regexp('%s')]" %
                     (vhost_path, parser.case_i("VirtualHost"))))
+            paths = [path for path in paths if os.path.basename(path) == "VirtualHost"]
             for path in paths:
                 new_vhost = self._create_vhost(path)
                 realpath = os.path.realpath(new_vhost.filep)

--- a/letsencrypt-apache/letsencrypt_apache/display_ops.py
+++ b/letsencrypt-apache/letsencrypt_apache/display_ops.py
@@ -83,7 +83,8 @@ def _vhost_menu(domain, vhosts):
         code, tag = zope.component.getUtility(interfaces.IDisplay).menu(
             "We were unable to find a vhost with a ServerName "
             "or Address of {0}.{1}Which virtual host would you "
-            "like to choose?".format(domain, os.linesep),
+            "like to choose?\n(note: conf files with multiple "
+            "vhosts are not currently supported)".format(domain, os.linesep),
             choices, help_label="More Info", ok_label="Select")
     except errors.MissingCommandlineFlag as e:
         msg = ("Failed to run Apache plugin non-interactively{1}{0}{1}"

--- a/letsencrypt-apache/letsencrypt_apache/display_ops.py
+++ b/letsencrypt-apache/letsencrypt_apache/display_ops.py
@@ -84,7 +84,7 @@ def _vhost_menu(domain, vhosts):
             "We were unable to find a vhost with a ServerName "
             "or Address of {0}.{1}Which virtual host would you "
             "like to choose?\n(note: conf files with multiple "
-            "vhosts are not currently supported)".format(domain, os.linesep),
+            "vhosts are not yet supported)".format(domain, os.linesep),
             choices, help_label="More Info", ok_label="Select")
     except errors.MissingCommandlineFlag as e:
         msg = ("Failed to run Apache plugin non-interactively{1}{0}{1}"


### PR DESCRIPTION
should prevent files with multiple vhosts from getting parsed and offered as options for ssl enabled vhosts
this is because if augeas notices more than one vhost in a file it will list them as VirtualHost[1], VirtualHost[2], and so on:
realted to #2320 and #2600 