### PR TITLE
Don't suggest --duplicate; it's likely to confuse people

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -360,7 +360,7 @@ def _handle_subset_cert_request(config, domains, cert):
              br=os.linesep)
     if config.expand or config.renew_by_default or zope.component.getUtility(
             interfaces.IDisplay).yesno(question, "Expand", "Cancel",
-                                       cli_flag="--expand (or in some cases, --duplicate)"):
+                                       cli_flag="--expand"):
         return "renew", cert
     else:
         reporter_util = zope.component.getUtility(interfaces.IReporter)


### PR DESCRIPTION
Fixes #2602.

(I saw on the forum that someone was confused by the existing message into thinking that `--duplicate` was a synonym for `--expand`, when in fact they are opposites!)