### PR TITLE
Fixes unicode errors

### DIFF
--- a/letsencrypt/le_util.py
+++ b/letsencrypt/le_util.py
@@ -312,12 +312,12 @@ def enforce_domain_sanity(domain):
     try:
         domain = domain.encode('ascii').lower()
     except UnicodeError:
-        error_fmt = ("Internationalized domain names "
-                     "are not presently supported: {0}")
+        error_fmt = (u"Internationalized domain names "
+                      "are not presently supported: {0}")
         if isinstance(domain, six.text_type):
-            raise errors.ConfigurationError(unicode(error_fmt).format(domain))
-        else:
             raise errors.ConfigurationError(error_fmt.format(domain))
+        else:
+            raise errors.ConfigurationError(str(error_fmt).format(domain))
 
     # Remove trailing dot
     domain = domain[:-1] if domain.endswith('.') else domain

--- a/letsencrypt/le_util.py
+++ b/letsencrypt/le_util.py
@@ -6,6 +6,7 @@ import logging
 import os
 import platform
 import re
+import six
 import socket
 import stat
 import subprocess
@@ -310,10 +311,13 @@ def enforce_domain_sanity(domain):
     # Unicode
     try:
         domain = domain.encode('ascii').lower()
-    except UnicodeDecodeError:
-        raise errors.ConfigurationError(
-            "Internationalized domain names are not presently supported: {0}"
-            .format(domain))
+    except UnicodeError:
+        error_fmt = ("Internationalized domain names "
+                     "are not presently supported: {0}")
+        if isinstance(domain, six.text_type):
+            raise errors.ConfigurationError(unicode(error_fmt).format(domain))
+        else:
+            raise errors.ConfigurationError(error_fmt.format(domain))
 
     # Remove trailing dot
     domain = domain[:-1] if domain.endswith('.') else domain

--- a/letsencrypt/tests/le_util_test.py
+++ b/letsencrypt/tests/le_util_test.py
@@ -323,5 +323,21 @@ class AddDeprecatedArgumentTest(unittest.TestCase):
         self.assertTrue("--old-option" not in stdout.getvalue())
 
 
+class EnforceDomainSanityTest(unittest.TestCase):
+    """Test enforce_domain_sanity."""
+
+    def _call(self, domain):
+        from letsencrypt.le_util import enforce_domain_sanity
+        return enforce_domain_sanity(domain)
+
+    def test_nonascii_str(self):
+        self.assertRaises(errors.ConfigurationError, self._call,
+                          u"eichh\u00f6rnchen.example.com".encode("utf-8"))
+
+    def test_nonascii_unicode(self):
+        self.assertRaises(errors.ConfigurationError, self._call,
+                          u"eichh\u00f6rnchen.example.com")
+
+
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover


### PR DESCRIPTION
Fixes #2661. Both `UnicodeEncodeError` and `UnicodeDecodeError` inherit from `UnicodeError` so both exceptions are caught.

As for the error handling, the problem occurs when using `format` with objects of different types. My proposed solution uses `six.text_type` which is `unicode` in Python 2 and `str` in Python 3 ([source](https://pythonhosted.org/six/#constants)).

In Python 2, this solves the problem and correctly prints the characters, whether `str` or `unicode` is passed to `enforce_domain_sanity`.

Looking forward to Python 3 support, this is a little more interesting. When running the client, `domain` will always be a unicode `str`. This means the first case is always hit which creates a nicely formatted string.

The tests I wrote hit both cases (even while using Python 3), but the error message isn't as nice in the second case. Using the example from my tests, the error message becomes:
```
"Internationalized domain names are not presently supported: b'eichh\\xc3\\xb6rnchen.example.com'"
```
However, this ugliness only appears during testing on Python 3 and will not occur for any users so I think this "problem" can be ignored.