### PR TITLE
Moved VERBS back to cli.py

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -629,9 +629,13 @@ class HelpfulArgumentParser(object):
     """
 
     def __init__(self, args, plugins, detect_defaults=False):
-
         from letsencrypt import main
-        self.VERBS = main.VERBS
+        self.VERBS = {"auth": main.obtain_cert, "certonly": main.obtain_cert,
+                      "config_changes": main.config_changes, "run": main.run,
+                      "install": main.install, "plugins": main.plugins_cmd,
+                      "renew": renew, "revoke": main.revoke,
+                      "rollback": main.rollback, "everything": main.run}
+
         # List of topics for which additional help can be provided
         HELP_TOPICS = ["all", "security", "paths", "automation", "testing"] + list(self.VERBS)
 

--- a/letsencrypt/main.py
+++ b/letsencrypt/main.py
@@ -701,15 +701,6 @@ def main(cli_args=sys.argv[1:]):
     return config.func(config, plugins)
 
 
-# Maps verbs/subcommands to the functions that implement them
-# In principle this should live in cli.HelpfulArgumentParser, but
-# due to issues with import cycles and testing, it lives here
-VERBS = {"auth": obtain_cert, "certonly": obtain_cert,
-         "config_changes": config_changes, "everything": run,
-         "install": install, "plugins": plugins_cmd, "renew": cli.renew,
-         "revoke": revoke, "rollback": rollback, "run": run}
-
-
 if __name__ == "__main__":
     err_string = main()
     if err_string:


### PR DESCRIPTION
After looking at this more closely, I agree with @pde that `VERBS` is much nicer in `cli.py` than `main.py`. This PR moves it back to `cli.py` and incorporates the testing fixes to make that work. By moving `VERBS` creation into `__init__`, `MockedVerb` isn't necessary at all.