### PR TITLE
handle permission denied during cleanup

### DIFF
--- a/letsencrypt/plugins/webroot.py
+++ b/letsencrypt/plugins/webroot.py
@@ -152,5 +152,8 @@ to serve all files under specified web root ({0})."""
                     if exc.errno == errno.ENOTEMPTY:
                         logger.debug("Challenges cleaned up but %s not empty",
                                      root_path)
+                    elif exc.errno == errno.EACCES:
+                        logger.debug("Challenges cleaned up but no permissions for %s",
+                                     root_path)
                     else:
                         raise

--- a/letsencrypt/plugins/webroot_test.py
+++ b/letsencrypt/plugins/webroot_test.py
@@ -158,7 +158,7 @@ class AuthenticatorTest(unittest.TestCase):
         os.rmdir(leftover_path)
 
     @mock.patch('os.rmdir')
-    def test_cleanup_oserror(self, mock_rmdir):
+    def test_cleanup_permission_denied(self, mock_rmdir):
         self.auth.prepare()
         self.auth.perform([self.achall])
 
@@ -166,10 +166,22 @@ class AuthenticatorTest(unittest.TestCase):
         os_error.errno = errno.EACCES
         mock_rmdir.side_effect = os_error
 
-        self.assertRaises(OSError, self.auth.cleanup, [self.achall])
+        self.auth.cleanup([self.achall])
         self.assertFalse(os.path.exists(self.validation_path))
         self.assertTrue(os.path.exists(self.root_challenge_path))
 
+    @mock.patch('os.rmdir')
+    def test_cleanup_oserror(self, mock_rmdir):
+        self.auth.prepare()
+        self.auth.perform([self.achall])
+
+        os_error = OSError()
+        os_error.errno = errno.ENOENT
+        mock_rmdir.side_effect = os_error
+
+        self.assertRaises(OSError, self.auth.cleanup, [self.achall])
+        self.assertFalse(os.path.exists(self.validation_path))
+        self.assertTrue(os.path.exists(self.root_challenge_path))
 
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover


### PR DESCRIPTION
if the .well-known/acme-challenge was created before and the user has no
permissions to delete it, it failed at cleanup.