### PR TITLE
Fixes #2712

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ COPY letsencrypt-nginx /opt/letsencrypt/src/letsencrypt-nginx/
 
 RUN virtualenv --no-site-packages -p python2 /opt/letsencrypt/venv
 
-# PATH is set now so pipstrap upgrades the correct v(env)
+# PATH is set now so pipstrap upgrades the correct (v)env
 ENV PATH /opt/letsencrypt/venv/bin:$PATH
 RUN /opt/letsencrypt/venv/bin/python /opt/letsencrypt/src/pipstrap.py && \
     /opt/letsencrypt/venv/bin/pip install \


### PR DESCRIPTION
For those unfamiliar with Docker, if you have Docker installed, from the base of our repo you can run:
```
docker build -t test .
docker run --rm -it test
```
If you do this on `master`, it should fail with #2712. If you do it on this branch, `letsencrypt` should run.

This should be merged ASAP because https://quay.io/repository/letsencrypt/letsencrypt will be updated, allowing people to use our Dockerfile per our [instructions](https://letsencrypt.readthedocs.org/en/latest/using.html#running-with-docker).