### PR TITLE
Revise the concatenation order for fullchain.pem

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -313,7 +313,7 @@ The following files are available:
 
 ``fullchain.pem``
   All certificates, **including** server certificate. This is
-  concatenation of ``chain.pem`` and ``cert.pem``.
+  concatenation of ``cert.pem`` and ``chain.pem``.
 
   This is what Apache >= 2.4.8 needs for `SSLCertificateFile
   <https://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslcertificatefile>`_,


### PR DESCRIPTION
Let's encrypt does a [correct](http://blog.edgecloud.com/post/19519955133/ssl-certificate-chain-order-matters) concatenation of `certs.pem` and `chain.pem` for `fullchain.pem`. But in the docs, the order is interchanged.