### PR TITLE
fix spelling mistake in CLI help text

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -721,7 +721,7 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):
         help="Command to be run in a shell once for each successfully renewed certificate."
         "For this command, the shell variable $RENEWED_LINEAGE will point to the"
         "config live subdirectory containing the new certs and keys; the shell variable "
-        "$RENEWED_DOMAINS will conatain a space-delimited list of renewed cert domains")
+        "$RENEWED_DOMAINS will contain a space-delimited list of renewed cert domains")
 
     helpful.add_deprecated_argument("--agree-dev-preview", 0)
 


### PR DESCRIPTION
well, not much to say as it is so trivial (mistake added in commit 3265660478e15c11b8eb3e82000707907d2a13db)