### PR TITLE
apacheconf: sane sudo letsencrypt (fixes #2800)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,6 @@ addons:
     # For Boulder integration testing
     - rsyslog
     # for apacheconftest
-    #- realpath
     #- apache2
     #- libapache2-mod-wsgi
     #- libapache2-mod-macro

--- a/letsencrypt-apache/letsencrypt_apache/tests/apache-conf-files/apache-conf-test
+++ b/letsencrypt-apache/letsencrypt_apache/tests/apache-conf-files/apache-conf-test
@@ -19,13 +19,13 @@ function Setup() {
     if [ "$APPEND_APACHECONF" = "" ] ; then
         sudo cp "$f" "$EA"/sites-available/
         sudo ln -sf "$EA/sites-available/$f" "$EA/sites-enabled/$f"
-        sudo echo """
+        echo "
 <VirtualHost *:80>
     ServerName example.com
     DocumentRoot /tmp/
     ErrorLog /tmp/error.log
     CustomLog /tmp/requests.log combined
-</VirtualHost>""" >> $EA/sites-available/throwaway-example.conf
+</VirtualHost>" | sudo tee $EA/sites-available/throwaway-example.conf >/dev/null
     else
         TMP="/tmp/`basename \"$APPEND_APACHECONF\"`.$$"
         sudo cp -a "$APPEND_APACHECONF" "$TMP"

--- a/letsencrypt-apache/letsencrypt_apache/tests/apache-conf-files/apache-conf-test
+++ b/letsencrypt-apache/letsencrypt_apache/tests/apache-conf-files/apache-conf-test
@@ -5,9 +5,7 @@
 
 export EA=/etc/apache2/ 
 TESTDIR="`dirname $0`"
-LEROOT="`realpath \"$TESTDIR/../../../../\"`"
 cd $TESTDIR/passing
-LETSENCRYPT="${LETSENCRYPT:-$LEROOT/venv/bin/letsencrypt}"
 
 function CleanupExit() {
     echo control c, exiting tests...
@@ -61,7 +59,7 @@ trap CleanupExit INT
 for f in *.conf ; do 
     echo -n  testing "$f"...
     Setup
-    RESULT=`echo c | sudo "$LETSENCRYPT" -vvvv --debug --staging --apache --register-unsafely-without-email --agree-tos certonly -t 2>&1`
+    RESULT=`echo c | sudo env "PATH=$PATH" letsencrypt -vvvv --debug --staging --apache --register-unsafely-without-email --agree-tos certonly -t 2>&1`
     if echo $RESULT | grep -Eq \("Which names would you like"\|"mod_macro is not yet"\) ; then
         echo passed
     else

--- a/tox.ini
+++ b/tox.ini
@@ -77,11 +77,9 @@ commands =
 
 [testenv:apacheconftest]
 #basepython = python2.7
-setenv =
-    LETSENCRYPT=/home/travis/build/letsencrypt/letsencrypt/.tox/apacheconftest/bin/letsencrypt
 commands =
     pip install -e acme -e .[dev] -e letsencrypt-apache -e letsencrypt-nginx -e letsencrypt-compatibility-test -e letshelp-letsencrypt
-    sudo ./letsencrypt-apache/letsencrypt_apache/tests/apache-conf-files/apache-conf-test --debian-modules
+    ./letsencrypt-apache/letsencrypt_apache/tests/apache-conf-files/apache-conf-test --debian-modules
 
 [testenv:le_auto]
 # At the moment, this tests under Python 2.7 only, as only that version is

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,8 @@ commands =
 #basepython = python2.7
 commands =
     pip install -e acme -e .[dev] -e letsencrypt-apache -e letsencrypt-nginx -e letsencrypt-compatibility-test -e letshelp-letsencrypt
-    ./letsencrypt-apache/letsencrypt_apache/tests/apache-conf-files/apache-conf-test --debian-modules
+    {toxinidir}/letsencrypt-apache/letsencrypt_apache/tests/apache-conf-files/apache-conf-test --debian-modules
+
 
 [testenv:le_auto]
 # At the moment, this tests under Python 2.7 only, as only that version is


### PR DESCRIPTION
- hardcoded
  `LETSENCRYPT=/home/travis/build/letsencrypt/letsencrypt/.tox/apacheconftest/bin/letsencrypt`
  causes Travis tests to fail if running under any other Travis user
  (from e.g. a fork)

- `sudo env "PATH=$PATH" letsencrypt` should make sure that sudo can
  find letsencrypt binary from virtualenv; realpath is not necessary

- sudo is called already from within the test script, no need to sudo
  the entire script