### PR TITLE
Fix apache conf test

### DIFF
--- a/certbot-apache/certbot_apache/tests/apache-conf-files/apache-conf-test
+++ b/certbot-apache/certbot_apache/tests/apache-conf-files/apache-conf-test
@@ -59,7 +59,7 @@ trap CleanupExit INT
 for f in *.conf ; do 
     echo -n  testing "$f"...
     Setup
-    RESULT=`echo c | sudo env "PATH=$PATH" certbot -vvvv --debug --staging --apache --register-unsafely-without-email --agree-tos certonly -t 2>&1`
+    RESULT=`echo c | sudo $(command -v certbot) -vvvv --debug --staging --apache --register-unsafely-without-email --agree-tos certonly -t 2>&1`
     if echo $RESULT | grep -Eq \("Which names would you like"\|"mod_macro is not yet"\) ; then
         echo passed
     else


### PR DESCRIPTION
Fixes #2837 and builds on #2841 (this is PR is a one line change).

EDIT: Figured I'd explain what I was doing.

The cause of test failures is Debian puts `apache2ctl` in `/usr/sbin` which is not in non-root user's path by default. This means the Apache plugin cannot find this executable and errors saying it is not installed. Using the `command` approach, we use the current `PATH` to find the `certbot` executable and then run it with `sudo`. `PATH` will be modified to include `/usr/sbin` and all is well.