### PR TITLE
Choose Python for better integration with boulder

### DIFF
--- a/tools/venv.sh
+++ b/tools/venv.sh
@@ -1,7 +1,14 @@
 #!/bin/sh -xe
 # Developer virtualenv setup for Certbot client
 
-export VENV_ARGS="--python python2"
+if command -v python2; then
+    export VENV_ARGS="--python python2"
+elif command -v python2.7; then
+    export VENV_ARGS="--python python2.7"
+else
+    echo "Couldn't find python2 or python2.7 in $PATH"
+    exit 1
+fi
 
 ./tools/_venv_common.sh \
   -e acme[dev] \


### PR DESCRIPTION
This allows `boulder` to use `tools/venv.sh` in integration tests.