### PR TITLE
Discover all plugins

### DIFF
--- a/certbot/constants.py
+++ b/certbot/constants.py
@@ -8,6 +8,9 @@ from acme import challenges
 SETUPTOOLS_PLUGINS_ENTRY_POINT = "certbot.plugins"
 """Setuptools entry point group name for plugins."""
 
+OLD_SETUPTOOLS_PLUGINS_ENTRY_POINT = "letsencrypt.plugins"
+"""Plugins Setuptools entry point before rename."""
+
 CLI_DEFAULTS = dict(
     config_files=[
         "/etc/letsencrypt/cli.ini",

--- a/certbot/plugins/disco.py
+++ b/certbot/plugins/disco.py
@@ -1,5 +1,6 @@
 """Utilities for plugins discovery and selection."""
 import collections
+import itertools
 import logging
 import pkg_resources
 
@@ -164,8 +165,12 @@ class PluginsRegistry(collections.Mapping):
     def find_all(cls):
         """Find plugins using setuptools entry points."""
         plugins = {}
-        for entry_point in pkg_resources.iter_entry_points(
-                constants.SETUPTOOLS_PLUGINS_ENTRY_POINT):
+        entry_points = itertools.chain(
+            pkg_resources.iter_entry_points(
+                constants.SETUPTOOLS_PLUGINS_ENTRY_POINT),
+            pkg_resources.iter_entry_points(
+                constants.OLD_SETUPTOOLS_PLUGINS_ENTRY_POINT),)
+        for entry_point in entry_points:
             plugin_ep = PluginEntryPoint(entry_point)
             assert plugin_ep.name not in plugins, (
                 "PREFIX_FREE_DISTRIBUTIONS messed up")

--- a/certbot/plugins/disco_test.py
+++ b/certbot/plugins/disco_test.py
@@ -9,9 +9,14 @@ from certbot import errors
 from certbot import interfaces
 
 from certbot.plugins import standalone
+from certbot.plugins import webroot
 
 EP_SA = pkg_resources.EntryPoint(
     "sa", "certbot.plugins.standalone",
+    attrs=("Authenticator",),
+    dist=mock.MagicMock(key="certbot"))
+EP_WR = pkg_resources.EntryPoint(
+    "wr", "certbot.plugins.webroot",
     attrs=("Authenticator",),
     dist=mock.MagicMock(key="certbot"))
 
@@ -176,10 +181,13 @@ class PluginsRegistryTest(unittest.TestCase):
     def test_find_all(self):
         from certbot.plugins.disco import PluginsRegistry
         with mock.patch("certbot.plugins.disco.pkg_resources") as mock_pkg:
-            mock_pkg.iter_entry_points.return_value = iter([EP_SA])
+            mock_pkg.iter_entry_points.side_effect = [iter([EP_SA]),
+                                                      iter([EP_WR])]
             plugins = PluginsRegistry.find_all()
         self.assertTrue(plugins["sa"].plugin_cls is standalone.Authenticator)
         self.assertTrue(plugins["sa"].entry_point is EP_SA)
+        self.assertTrue(plugins["wr"].plugin_cls is webroot.Authenticator)
+        self.assertTrue(plugins["wr"].entry_point is EP_WR)
 
     def test_getitem(self):
         self.assertEqual(self.plugin_ep, self.reg["mock"])


### PR DESCRIPTION
Fixes #2646.

With the rename, we changed the group id where plugins are registered ([source](https://github.com/letsencrypt/letsencrypt/blob/master/setup.py#L132)).

We could arguably not do this. `letsencrypt.plugins` is an arbitrary string. It's not actually loading the module `letsencrypt.plugins` so there is no requirement we actually make this change. With that said, I suspect given a long enough time frame, having new plugins continue to use the `letsencrypt` name is a bit awkward.

This PR causes our plugin discovery code to search both `letsencrypt.plugins` and `certbot.plugins`. I tested this code with #2849 and `letsencrypt-plesk` everything worked.