### PR TITLE
Pass a single argument to append()

### DIFF
--- a/certbot/renewal.py
+++ b/certbot/renewal.py
@@ -287,7 +287,7 @@ def _renew_describe_results(config, renew_successes, renew_failures,
     if parse_failures:
         notify("\nAdditionally, the following renewal configuration files "
                "were invalid: ")
-        notify(parse_failures, "parsefail")
+        notify(report(parse_failures, "parsefail"))
 
     if config.dry_run:
         notify("** DRY RUN: simulating 'certbot renew' close to cert expiry")


### PR DESCRIPTION
The other notify() calls in this block all pass the output of report(), but
this one attempts to pass two arguments, which results in the stack trace
described in #2822.