### PR TITLE
Remove beta software disclaimer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,16 +1,5 @@
 .. notice for github users
 
-Disclaimer
-==========
-
-The Let's Encrypt Client is **BETA SOFTWARE**. It contains plenty of bugs and
-rough edges, and should be tested thoroughly in staging environments before use
-on production systems.
-
-For more information regarding the status of the project, please see
-https://letsencrypt.org. Be sure to checkout the
-`Frequently Asked Questions (FAQ) <https://community.letsencrypt.org/t/frequently-asked-questions-faq/26#topic-title>`_.
-
 About the Let's Encrypt Client
 ==============================
 


### PR DESCRIPTION
*Let's Encrypt*'s blog [explains](https://letsencrypt.org/2016/04/12/leaving-beta-new-sponsors.html) that it is no longer Beta software, therefore that [disclaimer](https://github.com/letsencrypt/letsencrypt#disclaimer) is no longer necessary.

The FAQ link has value and should come back somewhere in the *[About the Let's Encrypt Client](https://github.com/letsencrypt/letsencrypt#about-the-lets-encrypt-client)* section, I think.