### PR TITLE
letsencrypt-auto: don't use --oneshot when emerging dependencies on Gentoo

### DIFF
--- a/letsencrypt-auto
+++ b/letsencrypt-auto
@@ -328,13 +328,13 @@ BootstrapGentooCommon() {
 
   case "$PACKAGE_MANAGER" in
     (paludis)
-      $SUDO cave resolve --preserve-world --keep-targets if-possible $PACKAGES -x
+      $SUDO cave resolve --keep-targets if-possible $PACKAGES -x
       ;;
     (pkgcore)
-      $SUDO pmerge --noreplace --oneshot $PACKAGES
+      $SUDO pmerge --noreplace $PACKAGES
       ;;
     (portage|*)
-      $SUDO emerge --noreplace --oneshot $PACKAGES
+      $SUDO emerge --noreplace $PACKAGES
       ;;
   esac
 }

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -328,13 +328,13 @@ BootstrapGentooCommon() {
 
   case "$PACKAGE_MANAGER" in
     (paludis)
-      $SUDO cave resolve --preserve-world --keep-targets if-possible $PACKAGES -x
+      $SUDO cave resolve --keep-targets if-possible $PACKAGES -x
       ;;
     (pkgcore)
-      $SUDO pmerge --noreplace --oneshot $PACKAGES
+      $SUDO pmerge --noreplace $PACKAGES
       ;;
     (portage|*)
-      $SUDO emerge --noreplace --oneshot $PACKAGES
+      $SUDO emerge --noreplace $PACKAGES
       ;;
   esac
 }

--- a/letsencrypt-auto-source/pieces/bootstrappers/gentoo_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/gentoo_common.sh
@@ -11,13 +11,13 @@ BootstrapGentooCommon() {
 
   case "$PACKAGE_MANAGER" in
     (paludis)
-      $SUDO cave resolve --preserve-world --keep-targets if-possible $PACKAGES -x
+      $SUDO cave resolve --keep-targets if-possible $PACKAGES -x
       ;;
     (pkgcore)
-      $SUDO pmerge --noreplace --oneshot $PACKAGES
+      $SUDO pmerge --noreplace $PACKAGES
       ;;
     (portage|*)
-      $SUDO emerge --noreplace --oneshot $PACKAGES
+      $SUDO emerge --noreplace $PACKAGES
       ;;
   esac
 }


### PR DESCRIPTION
Installed dependencies won't be _suddenly_ removed by `emerge --depclean`. This behaviour is also on par with what's being done on other Linux distros (`pkg install`, `yum install`, `brew install`, `port install`, etc.).

`man portage`:
> WARNING: This option should only be used for packages that are reachable from the `@world` package set (those that would not be removed by `--depclean`)...